### PR TITLE
2024 01 13 set dependency versions in workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,13 +50,13 @@ dependencies = [
 [[package]]
 name = "alloy-ethers-typecast"
 version = "0.2.0"
-source = "git+https://github.com/rainlanguage/alloy-ethers-typecast?rev=d35a8e08ef240c4a66177f6de4e1de6fcb165b5f#d35a8e08ef240c4a66177f6de4e1de6fcb165b5f"
+source = "git+https://github.com/rainlanguage/alloy-ethers-typecast?rev=5ee1b7c9f8fac9145062ca40ac5c31d7eab66dd6#5ee1b7c9f8fac9145062ca40ac5c31d7eab66dd6"
 dependencies = [
  "alloy-primitives",
  "anyhow",
  "ethers",
  "ethers-signers",
- "log",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license = "CAL-1.0"
 homepage = "https://github.com/rainprotocol/rain.orderbook"
 
 [workspace.dependencies]
+alloy-ethers-typecast = { git = "https://github.com/rainlanguage/alloy-ethers-typecast", rev = "5ee1b7c9f8fac9145062ca40ac5c31d7eab66dd6" }
 alloy-sol-types = { version = "0.5.4", features = ["json"] }
 alloy-primitives = "0.5.4"
 anyhow = "1.0.70"
@@ -23,3 +24,15 @@ tokio = { version = "1.28.0", features = ["full"] }
 tracing = "0.1.37"
 tracing-subscriber = "0.3.17"
 url = "2.5.0"
+
+[workspace.dependencies.rain_orderbook_bindings]
+path = "crates/bindings"
+
+[workspace.dependencies.rain_orderbook_common]
+path = "crates/common"
+
+[workspace.dependencies.rain_orderbook_cli]
+path = "crates/cli"
+
+[workspace.dependencies.rain_orderbook_subgraph_queries]
+path = "crates/subgraph"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "CAL-1.0"
 homepage = "https://github.com/rainprotocol/rain.orderbook"
 
 [workspace.dependencies]
-alloy-ethers-typecast = { git = "https://github.com/rainlanguage/alloy-ethers-typecast", rev = "5ee1b7c9f8fac9145062ca40ac5c31d7eab66dd6" }
+alloy-ethers-typecast = { git = "https://github.com/rainlanguage/alloy-ethers-typecast", rev = "d35a8e08ef240c4a66177f6de4e1de6fcb165b5f" }
 alloy-sol-types = { version = "0.5.4", features = ["json"] }
 alloy-primitives = "0.5.4"
 anyhow = "1.0.70"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/rainprotocol/rain.orderbook"
 
 [workspace.dependencies]
 alloy-ethers-typecast = { git = "https://github.com/rainlanguage/alloy-ethers-typecast", rev = "d35a8e08ef240c4a66177f6de4e1de6fcb165b5f" }
-alloy-sol-types = { version = "0.5.4", features = ["json"] }
+alloy-sol-types = { version = "0.5.4" }
 alloy-primitives = "0.5.4"
 anyhow = "1.0.70"
 clap = { version = "4.2.5", features = ["cargo", "derive"] }

--- a/crates/bindings/Cargo.toml
+++ b/crates/bindings/Cargo.toml
@@ -8,5 +8,5 @@ homepage.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-alloy-sol-types = { version = "0.5.4", features = ["json"] }
-alloy-primitives = "0.5.4"
+alloy-sol-types = { workspace = true, features = ["json"] }
+alloy-primitives = { workspace = true }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -9,21 +9,20 @@ homepage = "https://github.com/rainprotocol/rain.orderbook"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-alloy-ethers-typecast = { git = "https://github.com/rainlanguage/alloy-ethers-typecast", rev = "d35a8e08ef240c4a66177f6de4e1de6fcb165b5f" }
-rain_orderbook_subgraph_queries = { path = "../subgraph" }
-rain_orderbook_bindings = { path = "../bindings" }
-rain_orderbook_common =  { path = "../common" }
-anyhow = "1.0.70"
-clap = { version = "4.2.5", features = ["cargo", "derive"] }
-graphql_client = "0.12.0"
-once_cell = "1.17.1"
-reqwest = { version = "0.11.17", features = ["json"] }
-rust-bigint = "1.2.0"
-serde = "1.0.160"
-serde_bytes = "0.11.9"
-tokio = { version = "1.28.0", features = ["full"] }
-tracing = "0.1.37"
-tracing-subscriber = "0.3.17"
-alloy-primitives = "0.5.4"
-alloy-sol-types = { version = "0.5.4" }
-
+alloy-ethers-typecast = { workspace = true }
+rain_orderbook_subgraph_queries = { workspace = true }
+rain_orderbook_bindings = { workspace = true }
+rain_orderbook_common = { workspace = true }
+anyhow = { workspace = true }
+clap = { workspace = true, features = ["cargo", "derive"] }
+graphql_client = { workspace = true }
+once_cell = { workspace = true }
+reqwest = { workspace = true, features = ["json"] }
+rust-bigint = { workspace = true }
+serde = { workspace = true }
+serde_bytes = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+alloy-primitives = { workspace = true }
+alloy-sol-types = { workspace = true }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -14,14 +14,14 @@ rain_orderbook_subgraph_queries = { workspace = true }
 rain_orderbook_bindings = { workspace = true }
 rain_orderbook_common = { workspace = true }
 anyhow = { workspace = true }
-clap = { workspace = true, features = ["cargo", "derive"] }
+clap = { workspace = true }
 graphql_client = { workspace = true }
 once_cell = { workspace = true }
-reqwest = { workspace = true, features = ["json"] }
+reqwest = { workspace = true }
 rust-bigint = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 alloy-primitives = { workspace = true }

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -9,8 +9,8 @@ homepage = "https://github.com/rainprotocol/rain.orderbook"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rain_orderbook_bindings = { path = "../bindings" }
-alloy-primitives = "0.5.4"
-alloy-ethers-typecast = { git = "https://github.com/rainlanguage/alloy-ethers-typecast", rev = "d35a8e08ef240c4a66177f6de4e1de6fcb165b5f" }
-anyhow = "1.0.70"
-alloy-sol-types = { version = "0.5.4" }
+rain_orderbook_bindings = { workspace = true }
+alloy-primitives = { workspace = true }
+alloy-ethers-typecast = { workspace = true }
+anyhow = { workspace = true }
+alloy-sol-types = { workspace = true }

--- a/crates/subgraph/Cargo.toml
+++ b/crates/subgraph/Cargo.toml
@@ -9,13 +9,13 @@ homepage = "https://github.com/rainprotocol/rain.orderbook"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.70"
-graphql_client = "0.12.0"
-once_cell = "1.17.1"
-reqwest = { version = "0.11.17", features = ["json"] }
-rust-bigint = "1.2.0"
-serde = "1.0.160"
-serde_bytes = "0.11.9"
-tokio = { version = "1.28.0", features = ["full"] }
-tracing = "0.1.37"
-tracing-subscriber = "0.3.17"
+anyhow = { workspace = true }
+graphql_client = { workspace = true }
+once_cell = { workspace = true }
+reqwest = { workspace = true, features = ["json"] }
+rust-bigint = { workspace = true }
+serde = { workspace = true }
+serde_bytes = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/crates/subgraph/Cargo.toml
+++ b/crates/subgraph/Cargo.toml
@@ -12,10 +12,10 @@ homepage = "https://github.com/rainprotocol/rain.orderbook"
 anyhow = { workspace = true }
 graphql_client = { workspace = true }
 once_cell = { workspace = true }
-reqwest = { workspace = true, features = ["json"] }
+reqwest = { workspace = true }
 rust-bigint = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }


### PR DESCRIPTION
We already had most dependencies included in the workspace, but were not using them in crates.

This PR adds the remaining dependencies to the workspace, and modifies the crates to use those workspace-defined dependencies.