### PR TITLE
chore(cli): rename derivation-path -> derivation-index

### DIFF
--- a/crates/cli/src/transaction.rs
+++ b/crates/cli/src/transaction.rs
@@ -6,8 +6,12 @@ pub struct CliTransactionArgs {
     #[arg(short, long, help = "Orderbook contract address")]
     pub orderbook_address: String,
 
-    #[arg(short, long, help = "Derivation path of the Ledger wallet")]
-    pub derivation_path: Option<usize>,
+    #[arg(
+        short,
+        long,
+        help = "Derivation index of the Ledger wallet address to use"
+    )]
+    pub derivation_index: Option<usize>,
 
     #[arg(short, long, help = "Chain ID of the network")]
     pub chain_id: u64,
@@ -20,7 +24,7 @@ impl From<CliTransactionArgs> for TransactionArgs {
     fn from(val: CliTransactionArgs) -> Self {
         TransactionArgs {
             orderbook_address: val.orderbook_address,
-            derivation_path: val.derivation_path,
+            derivation_index: val.derivation_index,
             chain_id: val.chain_id,
             rpc_url: val.rpc_url,
         }

--- a/crates/common/src/transaction.rs
+++ b/crates/common/src/transaction.rs
@@ -4,7 +4,7 @@ use alloy_sol_types::SolCall;
 
 pub struct TransactionArgs {
     pub orderbook_address: String,
-    pub derivation_path: Option<usize>,
+    pub derivation_index: Option<usize>,
     pub chain_id: u64,
     pub rpc_url: String,
 }
@@ -23,6 +23,6 @@ impl TransactionArgs {
     }
 
     pub async fn to_ledger_client(self) -> anyhow::Result<LedgerClient> {
-        LedgerClient::new(self.derivation_path, self.chain_id, self.rpc_url.clone()).await
+        LedgerClient::new(self.derivation_index, self.chain_id, self.rpc_url.clone()).await
     }
 }


### PR DESCRIPTION
Rename CLI arg `--derivation-path` to `--derivation-index` for clarity (Ledger client only takes the index, not the full derivation path)