### PR TITLE
feat(cli): default arg --derivation-index to '0'

### DIFF
--- a/crates/cli/src/transaction.rs
+++ b/crates/cli/src/transaction.rs
@@ -17,7 +17,8 @@ pub struct CliTransactionArgs {
     #[arg(
         short,
         long,
-        help = "Derivation index of the Ledger wallet address to use"
+        help = "Derivation index of the Ledger wallet address to use",
+        default_value = "0"
     )]
     pub derivation_index: Option<usize>,
 


### PR DESCRIPTION
Set default value of `--derivation-index` to '0'

Resolves #82 