### PR TITLE
refactor(cli): take U256 values from cli input, instead of passing thru u64

### DIFF
--- a/crates/cli/src/commands/vault/deposit.rs
+++ b/crates/cli/src/commands/vault/deposit.rs
@@ -3,6 +3,7 @@ use crate::{
     transaction::{CliTransactionCommandArgs, ExecuteTransaction},
 };
 use alloy_ethers_typecast::ethers_address_to_alloy;
+use alloy_primitives::U256;
 use anyhow::Result;
 use clap::Args;
 use rain_orderbook_bindings::{IOrderBookV3::depositCall, IERC20::approveCall};
@@ -38,10 +39,10 @@ pub struct CliDepositArgs {
     token: String,
 
     #[arg(short, long, help = "The ID of the vault")]
-    vault_id: u64,
+    vault_id: U256,
 
     #[arg(short, long, help = "The amount to deposit")]
-    amount: u64,
+    amount: U256,
 }
 
 impl From<CliDepositArgs> for DepositArgs {

--- a/crates/cli/src/commands/vault/withdraw.rs
+++ b/crates/cli/src/commands/vault/withdraw.rs
@@ -2,6 +2,7 @@ use crate::{
     execute::Execute,
     transaction::{CliTransactionCommandArgs, ExecuteTransaction},
 };
+use alloy_primitives::U256;
 use anyhow::Result;
 use clap::Args;
 use rain_orderbook_bindings::IOrderBookV3::withdrawCall;
@@ -26,10 +27,10 @@ pub struct CliWithdrawArgs {
     token: String,
 
     #[arg(short, long, help = "The ID of the vault")]
-    vault_id: u64,
+    vault_id: U256,
 
     #[arg(short = 'a', long, help = "The target amount to withdraw")]
-    target_amount: u64,
+    target_amount: U256,
 }
 
 impl From<CliWithdrawArgs> for WithdrawArgs {

--- a/crates/cli/src/transaction.rs
+++ b/crates/cli/src/transaction.rs
@@ -31,10 +31,10 @@ pub struct CliTransactionArgs {
     pub rpc_url: String,
 
     #[arg(short = 'p', long, help = "Max priority fee per gas (in wei)")]
-    pub max_priority_fee_per_gas: Option<u128>,
+    pub max_priority_fee_per_gas: Option<U256>,
 
     #[arg(short, long, help = "Max fee per gas (in wei)")]
-    pub max_fee_per_gas: Option<u128>,
+    pub max_fee_per_gas: Option<U256>,
 }
 
 impl From<CliTransactionArgs> for TransactionArgs {
@@ -44,8 +44,8 @@ impl From<CliTransactionArgs> for TransactionArgs {
             derivation_index: val.derivation_index,
             chain_id: val.chain_id,
             rpc_url: val.rpc_url,
-            max_priority_fee_per_gas: val.max_priority_fee_per_gas.map(U256::from),
-            max_fee_per_gas: val.max_fee_per_gas.map(U256::from),
+            max_priority_fee_per_gas: val.max_priority_fee_per_gas,
+            max_fee_per_gas: val.max_fee_per_gas,
         }
     }
 }

--- a/crates/common/src/deposit.rs
+++ b/crates/common/src/deposit.rs
@@ -5,8 +5,8 @@ use std::convert::TryInto;
 #[derive(Clone)]
 pub struct DepositArgs {
     pub token: String,
-    pub vault_id: u64,
-    pub amount: u64,
+    pub vault_id: U256,
+    pub amount: U256,
 }
 
 impl TryInto<depositCall> for DepositArgs {
@@ -15,8 +15,8 @@ impl TryInto<depositCall> for DepositArgs {
     fn try_into(self) -> Result<depositCall, FromHexError> {
         Ok(depositCall {
             token: self.token.parse()?,
-            vaultId: U256::from(self.vault_id),
-            amount: U256::from(self.amount),
+            vaultId: self.vault_id,
+            amount: self.amount,
         })
     }
 }
@@ -25,7 +25,7 @@ impl DepositArgs {
     pub fn into_approve_call(self, spender: Address) -> approveCall {
         approveCall {
             spender,
-            amount: U256::from(self.amount),
+            amount: self.amount,
         }
     }
 }
@@ -39,8 +39,8 @@ mod tests {
     fn test_deposit_args_try_into() {
         let args = DepositArgs {
             token: "0x1234567890abcdef1234567890abcdef12345678".to_string(),
-            vault_id: 42,
-            amount: 100,
+            vault_id: U256::from(42),
+            amount: U256::from(100),
         };
 
         let result: Result<depositCall, _> = args.try_into();
@@ -67,8 +67,8 @@ mod tests {
     fn test_deposit_args_into_approve_call() {
         let args = DepositArgs {
             token: "0x1234567890abcdef1234567890abcdef12345678".to_string(),
-            vault_id: 42,
-            amount: 100,
+            vault_id: U256::from(42),
+            amount: U256::from(100),
         };
         let spender_address = Address::repeat_byte(0x11);
         let approve_call: approveCall = args.into_approve_call(spender_address);

--- a/crates/common/src/withdraw.rs
+++ b/crates/common/src/withdraw.rs
@@ -4,8 +4,8 @@ use std::convert::TryInto;
 
 pub struct WithdrawArgs {
     pub token: String,
-    pub vault_id: u64,
-    pub target_amount: u64,
+    pub vault_id: U256,
+    pub target_amount: U256,
 }
 
 impl TryInto<withdrawCall> for WithdrawArgs {
@@ -14,8 +14,8 @@ impl TryInto<withdrawCall> for WithdrawArgs {
     fn try_into(self) -> Result<withdrawCall, FromHexError> {
         Ok(withdrawCall {
             token: self.token.parse::<Address>()?,
-            vaultId: U256::from(self.vault_id),
-            targetAmount: U256::from(self.target_amount),
+            vaultId: self.vault_id,
+            targetAmount: self.target_amount,
         })
     }
 }
@@ -28,8 +28,8 @@ mod tests {
     fn test_withdraw_args_try_into() {
         let args = WithdrawArgs {
             token: "0x1234567890abcdef1234567890abcdef12345678".to_string(),
-            vault_id: 42,
-            target_amount: 100,
+            vault_id: U256::from(42),
+            target_amount: U256::from(100),
         };
 
         let result: Result<withdrawCall, _> = args.try_into();


### PR DESCRIPTION
Previously we were taking in u64 args in the cli, then converting into U256, instead we can take U256 directly. 