### PR TITLE
2024 01 22 cli refactor writetransaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,7 +67,7 @@ checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
 [[package]]
 name = "alloy-ethers-typecast"
 version = "0.2.0"
-source = "git+https://github.com/rainlanguage/alloy-ethers-typecast?rev=20c7d3a5e8c5f1f4a88c3ff4395d003ce71b708b#20c7d3a5e8c5f1f4a88c3ff4395d003ce71b708b"
+source = "git+https://github.com/rainlanguage/alloy-ethers-typecast?rev=1f76426cfb228b3d3a65e1358b798c0cf413876b#1f76426cfb228b3d3a65e1358b798c0cf413876b"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,7 +67,7 @@ checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
 [[package]]
 name = "alloy-ethers-typecast"
 version = "0.2.0"
-source = "git+https://github.com/rainlanguage/alloy-ethers-typecast?rev=125dd778d5ec5edafa512d69935db050e70bbdff#125dd778d5ec5edafa512d69935db050e70bbdff"
+source = "git+https://github.com/rainlanguage/alloy-ethers-typecast?rev=20c7d3a5e8c5f1f4a88c3ff4395d003ce71b708b#20c7d3a5e8c5f1f4a88c3ff4395d003ce71b708b"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3188,6 +3188,7 @@ dependencies = [
  "rain_orderbook_subgraph_queries",
  "serde",
  "thiserror",
+ "tracing",
  "url",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "CAL-1.0"
 homepage = "https://github.com/rainprotocol/rain.orderbook"
 
 [workspace.dependencies]
-alloy-ethers-typecast = { git = "https://github.com/rainlanguage/alloy-ethers-typecast", rev = "20c7d3a5e8c5f1f4a88c3ff4395d003ce71b708b" }
+alloy-ethers-typecast = { git = "https://github.com/rainlanguage/alloy-ethers-typecast", rev = "1f76426cfb228b3d3a65e1358b798c0cf413876b" }
 alloy-sol-types = { version = "0.5.4" }
 alloy-primitives = "0.5.4"
 anyhow = "1.0.70"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "CAL-1.0"
 homepage = "https://github.com/rainprotocol/rain.orderbook"
 
 [workspace.dependencies]
-alloy-ethers-typecast = { git = "https://github.com/rainlanguage/alloy-ethers-typecast", rev = "125dd778d5ec5edafa512d69935db050e70bbdff" }
+alloy-ethers-typecast = { git = "https://github.com/rainlanguage/alloy-ethers-typecast", rev = "20c7d3a5e8c5f1f4a88c3ff4395d003ce71b708b" }
 alloy-sol-types = { version = "0.5.4" }
 alloy-primitives = "0.5.4"
 anyhow = "1.0.70"

--- a/crates/cli/src/commands/vault/deposit.rs
+++ b/crates/cli/src/commands/vault/deposit.rs
@@ -2,34 +2,49 @@ use crate::{
     execute::Execute,
     transaction::{CliTransactionCommandArgs, ExecuteTransaction},
 };
-use alloy_ethers_typecast::ethers_address_to_alloy;
+use alloy_ethers_typecast::{ethers_address_to_alloy, transaction::WriteTransaction};
 use alloy_primitives::U256;
 use anyhow::Result;
 use clap::Args;
-use rain_orderbook_bindings::{IOrderBookV3::depositCall, IERC20::approveCall};
-use rain_orderbook_common::deposit::DepositArgs;
+use rain_orderbook_bindings::IOrderBookV3::depositCall;
+use rain_orderbook_common::{deposit::DepositArgs, transaction::TransactionArgs};
 use tracing::info;
 
 pub type Deposit = CliTransactionCommandArgs<CliDepositArgs>;
 
 impl Execute for Deposit {
     async fn execute(&self) -> Result<()> {
-        // Prepare deposit call
+        let tx_args: TransactionArgs = self.transaction_args.clone().into();
         let deposit_args: DepositArgs = self.cmd_args.clone().into();
-        let deposit_call: depositCall = deposit_args.clone().try_into()?;
 
-        // Prepare approve call
-        let mut execute_tx: ExecuteTransaction = self.clone().into();
-        let ledger_client = execute_tx.connect_ledger().await?;
-        let ledger_address = ethers_address_to_alloy(ledger_client.client.address());
-        let approve_call: approveCall = deposit_args.clone().into_approve_call(ledger_address);
-
+        // ERC20 approve call
         info!("Step 1/2: Approve token transfer");
-        execute_tx.send(ledger_client, approve_call).await?;
+        let ledger_client = tx_args.clone().try_into_ledger_client().await?;
+        let ledger_address = ethers_address_to_alloy(ledger_client.client.address());
+        let approve_call = deposit_args.clone().into_approve_call(ledger_address);
+        let params = tx_args
+            .try_into_write_contract_parameters(approve_call)
+            .await?;
+        WriteTransaction::new(ledger_client.client, params, 4, |status| {
+            info!("Transaction status updated: {:?}", status);
+        })
+        .execute()
+        .await?;
 
+        // Orderbook deposit call
         info!("Step 2/2: Deposit tokens into vault");
-        let ledger_client = execute_tx.connect_ledger().await?;
-        execute_tx.send(ledger_client, deposit_call).await
+        let ledger_client = tx_args.clone().try_into_ledger_client().await?;
+        let deposit_call: depositCall = deposit_args.clone().try_into()?;
+        let params = tx_args
+            .try_into_write_contract_parameters(deposit_call)
+            .await?;
+        WriteTransaction::new(ledger_client.client, params, 4, |status| {
+            info!("Transaction status updated: {:?}", status);
+        })
+        .execute()
+        .await?;
+
+        Ok(())
     }
 }
 

--- a/crates/cli/src/commands/vault/deposit.rs
+++ b/crates/cli/src/commands/vault/deposit.rs
@@ -1,14 +1,11 @@
 use crate::{
-    execute::Execute,
-    transaction::{CliTransactionCommandArgs, ExecuteTransaction},
+    execute::Execute, status::display_write_transaction_status,
+    transaction::CliTransactionCommandArgs,
 };
-use alloy_ethers_typecast::{ethers_address_to_alloy, transaction::WriteTransaction};
 use alloy_primitives::U256;
 use anyhow::Result;
 use clap::Args;
-use rain_orderbook_bindings::IOrderBookV3::depositCall;
 use rain_orderbook_common::{deposit::DepositArgs, transaction::TransactionArgs};
-use tracing::info;
 
 pub type Deposit = CliTransactionCommandArgs<CliDepositArgs>;
 
@@ -17,33 +14,21 @@ impl Execute for Deposit {
         let tx_args: TransactionArgs = self.transaction_args.clone().into();
         let deposit_args: DepositArgs = self.cmd_args.clone().into();
 
-        // ERC20 approve call
-        info!("Step 1/2: Approve token transfer");
-        let ledger_client = tx_args.clone().try_into_ledger_client().await?;
-        let ledger_address = ethers_address_to_alloy(ledger_client.client.address());
-        let approve_call = deposit_args.clone().into_approve_call(ledger_address);
-        let params = tx_args
-            .try_into_write_contract_parameters(approve_call)
+        println!("----- Transaction (1/2): Approve ERC20 token spend -----");
+        deposit_args
+            .execute(
+                tx_args,
+                |status| {
+                    display_write_transaction_status(status);
+                },
+                |status| {
+                    display_write_transaction_status(status);
+                },
+                || {
+                    println!("----- Transaction (2/2): Deposit tokens into Orderbook -----");
+                },
+            )
             .await?;
-        WriteTransaction::new(ledger_client.client, params, 4, |status| {
-            info!("Transaction status updated: {:?}", status);
-        })
-        .execute()
-        .await?;
-
-        // Orderbook deposit call
-        info!("Step 2/2: Deposit tokens into vault");
-        let ledger_client = tx_args.clone().try_into_ledger_client().await?;
-        let deposit_call: depositCall = deposit_args.clone().try_into()?;
-        let params = tx_args
-            .try_into_write_contract_parameters(deposit_call)
-            .await?;
-        WriteTransaction::new(ledger_client.client, params, 4, |status| {
-            info!("Transaction status updated: {:?}", status);
-        })
-        .execute()
-        .await?;
-
         Ok(())
     }
 }

--- a/crates/cli/src/commands/vault/withdraw.rs
+++ b/crates/cli/src/commands/vault/withdraw.rs
@@ -1,23 +1,25 @@
-use crate::{
-    execute::Execute,
-    transaction::{CliTransactionCommandArgs, ExecuteTransaction},
-};
+use crate::status::display_write_transaction_status;
+use crate::{execute::Execute, transaction::CliTransactionCommandArgs};
 use alloy_primitives::U256;
 use anyhow::Result;
 use clap::Args;
-use rain_orderbook_bindings::IOrderBookV3::withdrawCall;
+use rain_orderbook_common::transaction::TransactionArgs;
 use rain_orderbook_common::withdraw::WithdrawArgs;
 
 pub type Withdraw = CliTransactionCommandArgs<CliWithdrawArgs>;
 
 impl Execute for Withdraw {
     async fn execute(&self) -> Result<()> {
-        let mut execute_tx: ExecuteTransaction = self.clone().into();
+        let tx_args: TransactionArgs = self.transaction_args.clone().into();
         let withdraw_args: WithdrawArgs = self.cmd_args.clone().into();
-        let withdraw_call: withdrawCall = withdraw_args.try_into()?;
 
-        let ledger_client = execute_tx.connect_ledger().await?;
-        execute_tx.send(ledger_client, withdraw_call).await
+        println!("----- Transaction (1/2): Withdraw tokens from Vault -----");
+        withdraw_args
+            .execute(tx_args, |status| {
+                display_write_transaction_status(status);
+            })
+            .await?;
+        Ok(())
     }
 }
 

--- a/crates/cli/src/commands/vault/withdraw.rs
+++ b/crates/cli/src/commands/vault/withdraw.rs
@@ -13,7 +13,7 @@ impl Execute for Withdraw {
         let tx_args: TransactionArgs = self.transaction_args.clone().into();
         let withdraw_args: WithdrawArgs = self.cmd_args.clone().into();
 
-        println!("----- Transaction (1/2): Withdraw tokens from Vault -----");
+        println!("----- Withdraw tokens from Vault -----");
         withdraw_args
             .execute(tx_args, |status| {
                 display_write_transaction_status(status);

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -5,6 +5,7 @@ use clap::Subcommand;
 
 mod commands;
 mod execute;
+mod status;
 mod subgraph;
 mod transaction;
 

--- a/crates/cli/src/status.rs
+++ b/crates/cli/src/status.rs
@@ -1,0 +1,20 @@
+use alloy_ethers_typecast::transaction::WriteTransactionStatus;
+use alloy_sol_types::SolCall;
+use std::fmt::Debug;
+
+pub fn display_write_transaction_status<T: SolCall + Debug>(status: WriteTransactionStatus<T>) {
+    match status {
+        WriteTransactionStatus::PendingPrepare(_) => {
+            println!("⏳  Preparing transaction. Please wait.");
+        }
+        WriteTransactionStatus::PendingSign(_) => {
+            println!("🖋   Please sign the transaction on your Ledger device.");
+        }
+        WriteTransactionStatus::PendingSend(_) => {
+            println!("⏳  Awaiting transaction confirmation. Please wait.");
+        }
+        WriteTransactionStatus::Confirmed(receipt) => {
+            println!("✅  Transaction confirmed: {:?}", receipt.transaction_hash);
+        }
+    }
+}

--- a/crates/cli/src/transaction.rs
+++ b/crates/cli/src/transaction.rs
@@ -79,7 +79,7 @@ impl ExecuteTransaction {
     ) -> Result<()> {
         let params = self
             .transaction_args
-            .to_write_contract_parameters(call)
+            .try_into_write_contract_parameters(call)
             .await?;
 
         let writable_client = WritableClient::new(ledger_client.client);
@@ -94,6 +94,6 @@ impl ExecuteTransaction {
 
     pub async fn connect_ledger(&mut self) -> Result<LedgerClient, LedgerClientError> {
         debug!("Connecting to Ledger device");
-        self.transaction_args.clone().to_ledger_client().await
+        self.transaction_args.clone().try_into_ledger_client().await
     }
 }

--- a/crates/cli/src/transaction.rs
+++ b/crates/cli/src/transaction.rs
@@ -1,15 +1,8 @@
-use alloy_ethers_typecast::client::LedgerClient;
-use alloy_ethers_typecast::client::LedgerClientError;
-use alloy_ethers_typecast::transaction::WritableClient;
 use alloy_primitives::U256;
-use alloy_sol_types::SolCall;
-use anyhow::anyhow;
-use anyhow::Result;
 use clap::Args;
 use clap::FromArgMatches;
 use clap::Parser;
 use rain_orderbook_common::transaction::TransactionArgs;
-use tracing::{debug, info};
 
 #[derive(Args, Clone)]
 pub struct CliTransactionArgs {
@@ -57,43 +50,4 @@ pub struct CliTransactionCommandArgs<T: FromArgMatches + Args> {
 
     #[clap(flatten)]
     pub transaction_args: CliTransactionArgs,
-}
-
-pub struct ExecuteTransaction {
-    pub transaction_args: TransactionArgs,
-}
-
-impl<T: FromArgMatches + Args> From<CliTransactionCommandArgs<T>> for ExecuteTransaction {
-    fn from(value: CliTransactionCommandArgs<T>) -> Self {
-        Self {
-            transaction_args: value.transaction_args.into(),
-        }
-    }
-}
-
-impl ExecuteTransaction {
-    pub async fn send(
-        &self,
-        ledger_client: LedgerClient,
-        call: impl SolCall + Clone,
-    ) -> Result<()> {
-        let params = self
-            .transaction_args
-            .try_into_write_contract_parameters(call)
-            .await?;
-
-        let writable_client = WritableClient::new(ledger_client.client);
-        writable_client
-            .write(params)
-            .await
-            .map_err(|e| anyhow!(e))?;
-        info!("Awaiting signature from Ledger device");
-
-        Ok(())
-    }
-
-    pub async fn connect_ledger(&mut self) -> Result<LedgerClient, LedgerClientError> {
-        debug!("Connecting to Ledger device");
-        self.transaction_args.clone().try_into_ledger_client().await
-    }
 }

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -17,3 +17,4 @@ alloy-sol-types = { workspace = true }
 url = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
+tracing = { workspace = true }

--- a/crates/common/src/deposit.rs
+++ b/crates/common/src/deposit.rs
@@ -63,19 +63,19 @@ impl DepositArgs {
             .clone()
             .try_into_ledger_client()
             .await
-            .map_err(|e| WritableTransactionExecuteError::LedgerClient(e))?;
+            .map_err(WritableTransactionExecuteError::LedgerClient)?;
 
         let ledger_address = ethers_address_to_alloy(ledger_client.client.address());
         let approve_call = self.clone().into_approve_call(ledger_address);
         let params = transaction_args
             .try_into_write_contract_parameters(approve_call)
             .await
-            .map_err(|e| WritableTransactionExecuteError::TransactionArgs(e))?;
+            .map_err(WritableTransactionExecuteError::TransactionArgs)?;
 
         WriteTransaction::new(ledger_client.client, params, 4, transaction_status_changed)
             .execute()
             .await
-            .map_err(|e| WritableTransactionExecuteError::WritableClient(e))?;
+            .map_err(WritableTransactionExecuteError::WritableClient)?;
 
         Ok(())
     }
@@ -90,7 +90,7 @@ impl DepositArgs {
             .clone()
             .try_into_ledger_client()
             .await
-            .map_err(|e| WritableTransactionExecuteError::LedgerClient(e))?;
+            .map_err(WritableTransactionExecuteError::LedgerClient)?;
 
         let deposit_call: depositCall = self.clone().try_into().map_err(|_| {
             WritableTransactionExecuteError::InvalidArgs(
@@ -100,12 +100,12 @@ impl DepositArgs {
         let params = transaction_args
             .try_into_write_contract_parameters(deposit_call)
             .await
-            .map_err(|e| WritableTransactionExecuteError::TransactionArgs(e))?;
+            .map_err(WritableTransactionExecuteError::TransactionArgs)?;
 
         WriteTransaction::new(ledger_client.client, params, 4, transaction_status_changed)
             .execute()
             .await
-            .map_err(|e| WritableTransactionExecuteError::WritableClient(e))?;
+            .map_err(WritableTransactionExecuteError::WritableClient)?;
 
         Ok(())
     }

--- a/crates/common/src/deposit.rs
+++ b/crates/common/src/deposit.rs
@@ -1,23 +1,10 @@
-use crate::transaction::{TransactionArgs, TransactionArgsError};
-use alloy_ethers_typecast::client::LedgerClientError;
-use alloy_ethers_typecast::transaction::{WritableClientError, WriteTransaction};
+use crate::error::WritableTransactionExecuteError;
+use crate::transaction::TransactionArgs;
+use alloy_ethers_typecast::transaction::WriteTransaction;
 use alloy_ethers_typecast::{ethers_address_to_alloy, transaction::WriteTransactionStatus};
 use alloy_primitives::{hex::FromHexError, Address, U256};
 use rain_orderbook_bindings::{IOrderBookV3::depositCall, IERC20::approveCall};
 use std::convert::TryInto;
-use thiserror::Error;
-
-#[derive(Error, Debug)]
-pub enum DepositExecuteError {
-    #[error("WritableClient error: {0}")]
-    WritableClient(#[from] WritableClientError),
-    #[error("TransactionArgs error: {0}")]
-    TransactionArgs(#[from] TransactionArgsError),
-    #[error("LedgerClient error: {0}")]
-    LedgerClient(#[from] LedgerClientError),
-    #[error("Invalid DepositArgs: {0}")]
-    InvalidArgs(String),
-}
 
 #[derive(Clone)]
 pub struct DepositArgs {
@@ -56,7 +43,7 @@ impl DepositArgs {
         approve_transaction_status_changed: A,
         deposit_transaction_status_changed: D,
         approve_transaction_success: S,
-    ) -> Result<(), DepositExecuteError> {
+    ) -> Result<(), WritableTransactionExecuteError> {
         self.execute_approve(transaction_args.clone(), approve_transaction_status_changed)
             .await?;
         (approve_transaction_success)();
@@ -71,24 +58,24 @@ impl DepositArgs {
         &self,
         transaction_args: TransactionArgs,
         transaction_status_changed: S,
-    ) -> Result<(), DepositExecuteError> {
+    ) -> Result<(), WritableTransactionExecuteError> {
         let ledger_client = transaction_args
             .clone()
             .try_into_ledger_client()
             .await
-            .map_err(|e| DepositExecuteError::LedgerClient(e))?;
+            .map_err(|e| WritableTransactionExecuteError::LedgerClient(e))?;
 
         let ledger_address = ethers_address_to_alloy(ledger_client.client.address());
         let approve_call = self.clone().into_approve_call(ledger_address);
         let params = transaction_args
             .try_into_write_contract_parameters(approve_call)
             .await
-            .map_err(|e| DepositExecuteError::TransactionArgs(e))?;
+            .map_err(|e| WritableTransactionExecuteError::TransactionArgs(e))?;
 
         WriteTransaction::new(ledger_client.client, params, 4, transaction_status_changed)
             .execute()
             .await
-            .map_err(|e| DepositExecuteError::WritableClient(e))?;
+            .map_err(|e| WritableTransactionExecuteError::WritableClient(e))?;
 
         Ok(())
     }
@@ -98,25 +85,27 @@ impl DepositArgs {
         &self,
         transaction_args: TransactionArgs,
         transaction_status_changed: S,
-    ) -> Result<(), DepositExecuteError> {
+    ) -> Result<(), WritableTransactionExecuteError> {
         let ledger_client = transaction_args
             .clone()
             .try_into_ledger_client()
             .await
-            .map_err(|e| DepositExecuteError::LedgerClient(e))?;
+            .map_err(|e| WritableTransactionExecuteError::LedgerClient(e))?;
 
         let deposit_call: depositCall = self.clone().try_into().map_err(|_| {
-            DepositExecuteError::InvalidArgs("Failed to parse address String into Address".into())
+            WritableTransactionExecuteError::InvalidArgs(
+                "Failed to parse address String into Address".into(),
+            )
         })?;
         let params = transaction_args
             .try_into_write_contract_parameters(deposit_call)
             .await
-            .map_err(|e| DepositExecuteError::TransactionArgs(e))?;
+            .map_err(|e| WritableTransactionExecuteError::TransactionArgs(e))?;
 
         WriteTransaction::new(ledger_client.client, params, 4, transaction_status_changed)
             .execute()
             .await
-            .map_err(|e| DepositExecuteError::WritableClient(e))?;
+            .map_err(|e| WritableTransactionExecuteError::WritableClient(e))?;
 
         Ok(())
     }

--- a/crates/common/src/deposit.rs
+++ b/crates/common/src/deposit.rs
@@ -1,6 +1,23 @@
+use crate::transaction::{TransactionArgs, TransactionArgsError};
+use alloy_ethers_typecast::client::LedgerClientError;
+use alloy_ethers_typecast::transaction::{WritableClientError, WriteTransaction};
+use alloy_ethers_typecast::{ethers_address_to_alloy, transaction::WriteTransactionStatus};
 use alloy_primitives::{hex::FromHexError, Address, U256};
 use rain_orderbook_bindings::{IOrderBookV3::depositCall, IERC20::approveCall};
 use std::convert::TryInto;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum DepositExecuteError {
+    #[error("WritableClient error: {0}")]
+    WritableClient(#[from] WritableClientError),
+    #[error("TransactionArgs error: {0}")]
+    TransactionArgs(#[from] TransactionArgsError),
+    #[error("LedgerClient error: {0}")]
+    LedgerClient(#[from] LedgerClientError),
+    #[error("Invalid DepositArgs: {0}")]
+    InvalidArgs(String),
+}
 
 #[derive(Clone)]
 pub struct DepositArgs {
@@ -27,6 +44,81 @@ impl DepositArgs {
             spender,
             amount: self.amount,
         }
+    }
+
+    pub async fn execute<
+        A: Fn(WriteTransactionStatus<approveCall>),
+        D: Fn(WriteTransactionStatus<depositCall>),
+        S: Fn(),
+    >(
+        &self,
+        transaction_args: TransactionArgs,
+        approve_transaction_status_changed: A,
+        deposit_transaction_status_changed: D,
+        approve_transaction_success: S,
+    ) -> Result<(), DepositExecuteError> {
+        self.execute_approve(transaction_args.clone(), approve_transaction_status_changed)
+            .await?;
+        (approve_transaction_success)();
+        self.execute_deposit(transaction_args, deposit_transaction_status_changed)
+            .await?;
+
+        Ok(())
+    }
+
+    /// Execute ERC20 approve call
+    async fn execute_approve<S: Fn(WriteTransactionStatus<approveCall>)>(
+        &self,
+        transaction_args: TransactionArgs,
+        transaction_status_changed: S,
+    ) -> Result<(), DepositExecuteError> {
+        let ledger_client = transaction_args
+            .clone()
+            .try_into_ledger_client()
+            .await
+            .map_err(|e| DepositExecuteError::LedgerClient(e))?;
+
+        let ledger_address = ethers_address_to_alloy(ledger_client.client.address());
+        let approve_call = self.clone().into_approve_call(ledger_address);
+        let params = transaction_args
+            .try_into_write_contract_parameters(approve_call)
+            .await
+            .map_err(|e| DepositExecuteError::TransactionArgs(e))?;
+
+        WriteTransaction::new(ledger_client.client, params, 4, transaction_status_changed)
+            .execute()
+            .await
+            .map_err(|e| DepositExecuteError::WritableClient(e))?;
+
+        Ok(())
+    }
+
+    /// Execute OrderbookV3 deposit call
+    async fn execute_deposit<S: Fn(WriteTransactionStatus<depositCall>)>(
+        &self,
+        transaction_args: TransactionArgs,
+        transaction_status_changed: S,
+    ) -> Result<(), DepositExecuteError> {
+        let ledger_client = transaction_args
+            .clone()
+            .try_into_ledger_client()
+            .await
+            .map_err(|e| DepositExecuteError::LedgerClient(e))?;
+
+        let deposit_call: depositCall = self.clone().try_into().map_err(|_| {
+            DepositExecuteError::InvalidArgs("Failed to parse address String into Address".into())
+        })?;
+        let params = transaction_args
+            .try_into_write_contract_parameters(deposit_call)
+            .await
+            .map_err(|e| DepositExecuteError::TransactionArgs(e))?;
+
+        WriteTransaction::new(ledger_client.client, params, 4, transaction_status_changed)
+            .execute()
+            .await
+            .map_err(|e| DepositExecuteError::WritableClient(e))?;
+
+        Ok(())
     }
 }
 

--- a/crates/common/src/error.rs
+++ b/crates/common/src/error.rs
@@ -1,0 +1,16 @@
+use alloy_ethers_typecast::{client::LedgerClientError, transaction::WritableClientError};
+use thiserror::Error;
+
+use crate::transaction::TransactionArgsError;
+
+#[derive(Error, Debug)]
+pub enum WritableTransactionExecuteError {
+    #[error("WritableClient error: {0}")]
+    WritableClient(#[from] WritableClientError),
+    #[error("TransactionArgs error: {0}")]
+    TransactionArgs(#[from] TransactionArgsError),
+    #[error("LedgerClient error: {0}")]
+    LedgerClient(#[from] LedgerClientError),
+    #[error("Invalid input args: {0}")]
+    InvalidArgs(String),
+}

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod deposit;
+pub mod error;
 pub mod subgraph;
 pub mod transaction;
 pub mod withdraw;

--- a/crates/common/src/transaction.rs
+++ b/crates/common/src/transaction.rs
@@ -28,7 +28,7 @@ pub struct TransactionArgs {
 }
 
 impl TransactionArgs {
-    pub async fn to_write_contract_parameters<T: SolCall + Clone>(
+    pub async fn try_into_write_contract_parameters<T: SolCall + Clone>(
         &self,
         call: T,
     ) -> Result<WriteContractParameters<T>, TransactionArgsError> {
@@ -46,7 +46,7 @@ impl TransactionArgs {
             .map_err(TransactionArgsError::BuildParameters)
     }
 
-    pub async fn to_ledger_client(self) -> Result<LedgerClient, LedgerClientError> {
+    pub async fn try_into_ledger_client(self) -> Result<LedgerClient, LedgerClientError> {
         LedgerClient::new(self.derivation_index, self.chain_id, self.rpc_url.clone()).await
     }
 }

--- a/crates/common/src/withdraw.rs
+++ b/crates/common/src/withdraw.rs
@@ -35,7 +35,7 @@ impl WithdrawArgs {
             .clone()
             .try_into_ledger_client()
             .await
-            .map_err(|e| WritableTransactionExecuteError::LedgerClient(e))?;
+            .map_err(WritableTransactionExecuteError::LedgerClient)?;
 
         let withdraw_call: withdrawCall = self.clone().try_into().map_err(|_| {
             WritableTransactionExecuteError::InvalidArgs(
@@ -45,12 +45,12 @@ impl WithdrawArgs {
         let params = transaction_args
             .try_into_write_contract_parameters(withdraw_call)
             .await
-            .map_err(|e| WritableTransactionExecuteError::TransactionArgs(e))?;
+            .map_err(WritableTransactionExecuteError::TransactionArgs)?;
 
         WriteTransaction::new(ledger_client.client, params, 4, transaction_status_changed)
             .execute()
             .await
-            .map_err(|e| WritableTransactionExecuteError::WritableClient(e))?;
+            .map_err(WritableTransactionExecuteError::WritableClient)?;
 
         Ok(())
     }

--- a/crates/common/src/withdraw.rs
+++ b/crates/common/src/withdraw.rs
@@ -1,7 +1,11 @@
+use alloy_ethers_typecast::transaction::{WriteTransaction, WriteTransactionStatus};
 use alloy_primitives::{hex::FromHexError, Address, U256};
 use rain_orderbook_bindings::IOrderBookV3::withdrawCall;
 use std::convert::TryInto;
 
+use crate::{error::WritableTransactionExecuteError, transaction::TransactionArgs};
+
+#[derive(Clone)]
 pub struct WithdrawArgs {
     pub token: String,
     pub vault_id: U256,
@@ -17,6 +21,38 @@ impl TryInto<withdrawCall> for WithdrawArgs {
             vaultId: self.vault_id,
             targetAmount: self.target_amount,
         })
+    }
+}
+
+impl WithdrawArgs {
+    /// Execute OrderbookV3 withdraw call
+    pub async fn execute<S: Fn(WriteTransactionStatus<withdrawCall>)>(
+        &self,
+        transaction_args: TransactionArgs,
+        transaction_status_changed: S,
+    ) -> Result<(), WritableTransactionExecuteError> {
+        let ledger_client = transaction_args
+            .clone()
+            .try_into_ledger_client()
+            .await
+            .map_err(|e| WritableTransactionExecuteError::LedgerClient(e))?;
+
+        let withdraw_call: withdrawCall = self.clone().try_into().map_err(|_| {
+            WritableTransactionExecuteError::InvalidArgs(
+                "Failed to parse address String into Address".into(),
+            )
+        })?;
+        let params = transaction_args
+            .try_into_write_contract_parameters(withdraw_call)
+            .await
+            .map_err(|e| WritableTransactionExecuteError::TransactionArgs(e))?;
+
+        WriteTransaction::new(ledger_client.client, params, 4, transaction_status_changed)
+            .execute()
+            .await
+            .map_err(|e| WritableTransactionExecuteError::WritableClient(e))?;
+
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Waiting on https://github.com/rainlanguage/alloy-ethers-typecast/pull/13 and https://github.com/rainlanguage/alloy-ethers-typecast/pull/14 before merging

Refactors cli deposit & withdraw functions to use `WriteTransaction`, pushes logic down into `common` crate, while cli crate just handles printing updates.