### PR TITLE
2024 01 23 gui chainid

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,7 +67,7 @@ checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
 [[package]]
 name = "alloy-ethers-typecast"
 version = "0.2.0"
-source = "git+https://github.com/rainlanguage/alloy-ethers-typecast?rev=1f76426cfb228b3d3a65e1358b798c0cf413876b#1f76426cfb228b3d3a65e1358b798c0cf413876b"
+source = "git+https://github.com/rainlanguage/alloy-ethers-typecast?rev=eb0e02ee40699808fb984461a920286c19a6c754#eb0e02ee40699808fb984461a920286c19a6c754"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "CAL-1.0"
 homepage = "https://github.com/rainprotocol/rain.orderbook"
 
 [workspace.dependencies]
-alloy-ethers-typecast = { git = "https://github.com/rainlanguage/alloy-ethers-typecast", rev = "1f76426cfb228b3d3a65e1358b798c0cf413876b" }
+alloy-ethers-typecast = { git = "https://github.com/rainlanguage/alloy-ethers-typecast", rev = "eb0e02ee40699808fb984461a920286c19a6c754" }
 alloy-sol-types = { version = "0.5.4" }
 alloy-primitives = "0.5.4"
 anyhow = "1.0.70"

--- a/crates/cli/src/commands/vault/deposit.rs
+++ b/crates/cli/src/commands/vault/deposit.rs
@@ -11,7 +11,8 @@ pub type Deposit = CliTransactionCommandArgs<CliDepositArgs>;
 
 impl Execute for Deposit {
     async fn execute(&self) -> Result<()> {
-        let tx_args: TransactionArgs = self.transaction_args.clone().into();
+        let mut tx_args: TransactionArgs = self.transaction_args.clone().into();
+        tx_args.try_fill_chain_id().await?;
         let deposit_args: DepositArgs = self.cmd_args.clone().into();
 
         println!("----- Transaction (1/2): Approve ERC20 token spend -----");

--- a/crates/cli/src/commands/vault/withdraw.rs
+++ b/crates/cli/src/commands/vault/withdraw.rs
@@ -10,7 +10,8 @@ pub type Withdraw = CliTransactionCommandArgs<CliWithdrawArgs>;
 
 impl Execute for Withdraw {
     async fn execute(&self) -> Result<()> {
-        let tx_args: TransactionArgs = self.transaction_args.clone().into();
+        let mut tx_args: TransactionArgs = self.transaction_args.clone().into();
+        tx_args.try_fill_chain_id().await?;
         let withdraw_args: WithdrawArgs = self.cmd_args.clone().into();
 
         println!("----- Withdraw tokens from Vault -----");

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -15,14 +15,14 @@ pub enum Orderbook {
     Order(Order),
 
     #[command(subcommand)]
-    Vault(Vault),
+    Vault(Box<Vault>),
 }
 
 impl Orderbook {
     pub async fn execute(self) -> Result<()> {
         match self {
             Orderbook::Order(order) => order.execute().await,
-            Orderbook::Vault(vault) => vault.execute().await,
+            Orderbook::Vault(vault) => (*vault).execute().await,
         }
     }
 }

--- a/crates/cli/src/transaction.rs
+++ b/crates/cli/src/transaction.rs
@@ -18,7 +18,7 @@ pub struct CliTransactionArgs {
     pub derivation_index: Option<usize>,
 
     #[arg(short, long, help = "Chain ID of the network")]
-    pub chain_id: u64,
+    pub chain_id: Option<u64>,
 
     #[arg(short, long, help = "RPC URL")]
     pub rpc_url: String,

--- a/crates/common/src/deposit.rs
+++ b/crates/common/src/deposit.rs
@@ -63,7 +63,7 @@ impl DepositArgs {
             .clone()
             .try_into_ledger_client()
             .await
-            .map_err(WritableTransactionExecuteError::LedgerClient)?;
+            .map_err(WritableTransactionExecuteError::TransactionArgs)?;
 
         let ledger_address = ethers_address_to_alloy(ledger_client.client.address());
         let approve_call = self.clone().into_approve_call(ledger_address);
@@ -90,7 +90,7 @@ impl DepositArgs {
             .clone()
             .try_into_ledger_client()
             .await
-            .map_err(WritableTransactionExecuteError::LedgerClient)?;
+            .map_err(WritableTransactionExecuteError::TransactionArgs)?;
 
         let deposit_call: depositCall = self.clone().try_into().map_err(|_| {
             WritableTransactionExecuteError::InvalidArgs(

--- a/crates/common/src/transaction.rs
+++ b/crates/common/src/transaction.rs
@@ -1,8 +1,8 @@
 use alloy_ethers_typecast::{
     client::{LedgerClient, LedgerClientError},
     transaction::{
-        WriteContractParameters, WriteContractParametersBuilder,
-        WriteContractParametersBuilderError,
+        ReadableClientError, ReadableClientHttp, WriteContractParameters,
+        WriteContractParametersBuilder, WriteContractParametersBuilderError,
     },
 };
 use alloy_primitives::{hex::FromHexError, Address, U256};
@@ -15,13 +15,21 @@ pub enum TransactionArgsError {
     ParseOrderbookAddress(#[from] FromHexError),
     #[error("Build parameters error: {0}")]
     BuildParameters(#[from] WriteContractParametersBuilderError),
+    #[error("Parse Chain ID U256 to u64 error")]
+    ChainIdParse,
+    #[error("Chain ID is required, but set to None")]
+    ChainIdNone,
+    #[error("Readable client error: {0}")]
+    ReadableClient(#[from] ReadableClientError),
+    #[error("Ledger Client Error {0}")]
+    LedgerClient(#[from] LedgerClientError),
 }
 
 #[derive(Clone)]
 pub struct TransactionArgs {
     pub orderbook_address: String,
     pub derivation_index: Option<usize>,
-    pub chain_id: u64,
+    pub chain_id: Option<u64>,
     pub rpc_url: String,
     pub max_priority_fee_per_gas: Option<U256>,
     pub max_fee_per_gas: Option<U256>,
@@ -46,7 +54,31 @@ impl TransactionArgs {
             .map_err(TransactionArgsError::BuildParameters)
     }
 
-    pub async fn try_into_ledger_client(self) -> Result<LedgerClient, LedgerClientError> {
-        LedgerClient::new(self.derivation_index, self.chain_id, self.rpc_url.clone()).await
+    pub async fn try_fill_chain_id(&mut self) -> Result<(), TransactionArgsError> {
+        if self.chain_id.is_none() {
+            let chain_id = ReadableClientHttp::new_from_url(self.rpc_url.clone())
+                .map_err(TransactionArgsError::ReadableClient)?
+                .get_chainid()
+                .await
+                .map_err(TransactionArgsError::ReadableClient)?;
+            let chain_id_u64: u64 = chain_id
+                .try_into()
+                .map_err(|_| TransactionArgsError::ChainIdParse)?;
+
+            self.chain_id = Some(chain_id_u64);
+        }
+
+        Ok(())
+    }
+
+    pub async fn try_into_ledger_client(self) -> Result<LedgerClient, TransactionArgsError> {
+        match self.chain_id {
+            Some(chain_id) => {
+                LedgerClient::new(self.derivation_index, chain_id, self.rpc_url.clone())
+                    .await
+                    .map_err(TransactionArgsError::LedgerClient)
+            }
+            None => Err(TransactionArgsError::ChainIdNone),
+        }
     }
 }

--- a/crates/common/src/withdraw.rs
+++ b/crates/common/src/withdraw.rs
@@ -35,7 +35,7 @@ impl WithdrawArgs {
             .clone()
             .try_into_ledger_client()
             .await
-            .map_err(WritableTransactionExecuteError::LedgerClient)?;
+            .map_err(WritableTransactionExecuteError::TransactionArgs)?;
 
         let withdraw_call: withdrawCall = self.clone().try_into().map_err(|_| {
             WritableTransactionExecuteError::InvalidArgs(

--- a/tauri-app/src-tauri/Cargo.lock
+++ b/tauri-app/src-tauri/Cargo.lock
@@ -126,7 +126,7 @@ dependencies = [
 [[package]]
 name = "alloy-ethers-typecast"
 version = "0.2.0"
-source = "git+https://github.com/rainlanguage/alloy-ethers-typecast?rev=1f76426cfb228b3d3a65e1358b798c0cf413876b#1f76426cfb228b3d3a65e1358b798c0cf413876b"
+source = "git+https://github.com/rainlanguage/alloy-ethers-typecast?rev=eb0e02ee40699808fb984461a920286c19a6c754#eb0e02ee40699808fb984461a920286c19a6c754"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/tauri-app/src-tauri/Cargo.toml
+++ b/tauri-app/src-tauri/Cargo.toml
@@ -16,7 +16,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 rain_orderbook_common = { path = "../../crates/common" }
 rain_orderbook_subgraph_queries = { path = "../../crates/subgraph" }
-alloy-ethers-typecast = { git = "https://github.com/rainlanguage/alloy-ethers-typecast", rev = "1f76426cfb228b3d3a65e1358b798c0cf413876b" }
+alloy-ethers-typecast = { git = "https://github.com/rainlanguage/alloy-ethers-typecast", rev = "eb0e02ee40699808fb984461a920286c19a6c754" }
 alloy-primitives = "0.5.4"
 typeshare = "1.0.1"
 

--- a/tauri-app/src-tauri/src/commands/chain.rs
+++ b/tauri-app/src-tauri/src/commands/chain.rs
@@ -1,0 +1,16 @@
+use alloy_ethers_typecast::transaction::ReadableClientHttp;
+
+#[tauri::command]
+pub async fn get_chainid(rpc_url: String) -> Result<u64, String> {
+    let chain_id = ReadableClientHttp::new_from_url(rpc_url)
+        .map_err(|_| String::from("Failed to connect to RPC URL"))?
+        .get_chainid()
+        .await
+        .map_err(|_| String::from("Failed to get Chain ID"))?;
+
+    let chain_id_u64: u64 = chain_id
+        .try_into()
+        .map_err(|_| String::from("Failed to convert Chain ID to u64"))?;
+
+    Ok(chain_id_u64)
+}

--- a/tauri-app/src-tauri/src/commands/mod.rs
+++ b/tauri-app/src-tauri/src/commands/mod.rs
@@ -1,2 +1,3 @@
+pub mod chain;
 pub mod vault;
 pub mod wallet;

--- a/tauri-app/src-tauri/src/main.rs
+++ b/tauri-app/src-tauri/src/main.rs
@@ -2,6 +2,7 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 mod commands;
+use commands::chain::get_chainid;
 use commands::vault::{vault_detail, vaults_list};
 use commands::wallet::get_address_from_ledger;
 
@@ -10,7 +11,8 @@ fn main() {
         .invoke_handler(tauri::generate_handler![
             vaults_list,
             vault_detail,
-            get_address_from_ledger
+            get_address_from_ledger,
+            get_chainid
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/tauri-app/src/lib/stores/chain.ts
+++ b/tauri-app/src/lib/stores/chain.ts
@@ -1,12 +1,28 @@
 import  find from 'lodash/find';
-import { derived, writable } from 'svelte/store';
+import { derived, writable, get } from 'svelte/store';
 import * as chains from 'viem/chains'
+import { rpcUrl } from './settings';
+import { toasts } from './toasts';
+import { ToastMessageType } from '$lib/typeshare/toast';
+import { invoke } from '@tauri-apps/api';
 
 export const chainId = writable(parseInt(localStorage.getItem("settings.chainId") || '1'))
 
 chainId.subscribe(value => {
   localStorage.setItem("settings.chainId", (value || 0).toString());
 });
+
+export async function updateChainId() {
+  try {
+    const val: number = await invoke('get_chainid', {rpcUrl: get(rpcUrl)});
+    chainId.set(val);
+  } catch(e) {
+    toasts.add({
+      message_type: ToastMessageType.Error,
+      text: e as string
+    });
+  }
+}
 
 export const activeChain = derived(chainId, (val) => {  
   return find(Object.values(chains), (c) => c.id === val);

--- a/tauri-app/src/lib/stores/chain.ts
+++ b/tauri-app/src/lib/stores/chain.ts
@@ -1,0 +1,17 @@
+import  find from 'lodash/find';
+import { derived, writable } from 'svelte/store';
+import { mainnet, polygon, flare } from 'viem/chains'
+
+const SUPPORTED_CHAINS = [mainnet, polygon, flare];
+
+export const chainId = writable(parseInt(localStorage.getItem("settings.chainId") || '1'))
+
+chainId.subscribe(value => {
+  localStorage.setItem("settings.chainId", (value || 0).toString());
+});
+
+export const isChainIdSupported = derived(chainId, (val) => SUPPORTED_CHAINS.map((c) => c.id).includes(val));
+
+export const activeChain = derived(chainId, (val) => {  
+  return find(SUPPORTED_CHAINS, (c) => c.id === val);
+})

--- a/tauri-app/src/lib/stores/chain.ts
+++ b/tauri-app/src/lib/stores/chain.ts
@@ -1,8 +1,6 @@
 import  find from 'lodash/find';
 import { derived, writable } from 'svelte/store';
-import { mainnet, polygon, flare } from 'viem/chains'
-
-const SUPPORTED_CHAINS = [mainnet, polygon, flare];
+import * as chains from 'viem/chains'
 
 export const chainId = writable(parseInt(localStorage.getItem("settings.chainId") || '1'))
 
@@ -10,8 +8,6 @@ chainId.subscribe(value => {
   localStorage.setItem("settings.chainId", (value || 0).toString());
 });
 
-export const isChainIdSupported = derived(chainId, (val) => SUPPORTED_CHAINS.map((c) => c.id).includes(val));
-
 export const activeChain = derived(chainId, (val) => {  
-  return find(SUPPORTED_CHAINS, (c) => c.id === val);
+  return find(Object.values(chains), (c) => c.id === val);
 })

--- a/tauri-app/src/lib/stores/settings.ts
+++ b/tauri-app/src/lib/stores/settings.ts
@@ -3,9 +3,9 @@ import { writable, derived, get } from 'svelte/store';
 import every from 'lodash/every';
 import { isAddress } from 'viem';
 import { invoke } from '@tauri-apps/api';
+import { chainId } from '$lib/stores/chain';
 
 export const rpcUrl = writable(localStorage.getItem("settings.rpcUrl") || '');
-export const chainId = writable(parseInt(localStorage.getItem("settings.chainId") || '1'))
 export const subgraphUrl = writable(localStorage.getItem("settings.subgraphUrl") || '');
 export const orderbookAddress = writable(localStorage.getItem("settings.orderbookAddress") || '');
 export const walletAddress = writable(localStorage.getItem("settings.walletAddress") || '')
@@ -20,9 +20,7 @@ rpcUrl.subscribe(value => {
   localStorage.setItem("settings.rpcUrl", value || '');
   updateChainId();
 });
-chainId.subscribe(value => {
-  localStorage.setItem("settings.chainId", (value || 0).toString());
-});
+
 subgraphUrl.subscribe(value => {
   localStorage.setItem("settings.subgraphUrl", value || '');
 });

--- a/tauri-app/src/lib/stores/settings.ts
+++ b/tauri-app/src/lib/stores/settings.ts
@@ -1,16 +1,27 @@
 import { isUrlValid } from '$lib/utils/url';
-import { writable, derived } from 'svelte/store';
+import { writable, derived, get } from 'svelte/store';
 import every from 'lodash/every';
 import { isAddress } from 'viem';
+import { invoke } from '@tauri-apps/api';
 
 export const rpcUrl = writable(localStorage.getItem("settings.rpcUrl") || '');
+export const chainId = writable(parseInt(localStorage.getItem("settings.chainId") || '1'))
 export const subgraphUrl = writable(localStorage.getItem("settings.subgraphUrl") || '');
 export const orderbookAddress = writable(localStorage.getItem("settings.orderbookAddress") || '');
 export const walletAddress = writable(localStorage.getItem("settings.walletAddress") || '')
 export const walletDerivationIndex = writable(parseInt(localStorage.getItem("settings.walletDerivationIndex") || '0'))
 
+async function updateChainId() {
+  const val: number = await invoke('get_chainid', {rpcUrl: get(rpcUrl)});
+  chainId.set(val);
+}
+
 rpcUrl.subscribe(value => {
   localStorage.setItem("settings.rpcUrl", value || '');
+  updateChainId();
+});
+chainId.subscribe(value => {
+  localStorage.setItem("settings.chainId", (value || 0).toString());
 });
 subgraphUrl.subscribe(value => {
   localStorage.setItem("settings.subgraphUrl", value || '');

--- a/tauri-app/src/lib/stores/settings.ts
+++ b/tauri-app/src/lib/stores/settings.ts
@@ -32,7 +32,6 @@ export const isOrderbookAddressValid = derived(orderbookAddress, (val) => isAddr
 export const isWalletAddressValid = derived(walletAddress, (val) => isAddress(val));
 
 isRpcUrlValid.subscribe(value => {
-  console.log('isRpcUrlValid', value);
   if(value) {
     updateChainId();
   }

--- a/tauri-app/src/routes/settings/+page.svelte
+++ b/tauri-app/src/routes/settings/+page.svelte
@@ -7,12 +7,12 @@
     orderbookAddress,
     walletAddress,
     walletDerivationIndex,
-    chainId,
     isRpcUrlValid,
     isSubgraphUrlValid,
     isOrderbookAddressValid,
     isSettingsDefinedAndValid,
   } from '$lib/stores/settings';
+  import { activeChain } from '$lib/stores/chain';
   import InputLedgerWallet from '$lib/InputLedgerWallet.svelte';
 </script>
 
@@ -44,10 +44,10 @@
       </Helper>
     </div>
 
-    {#if $isRpcUrlValid && $chainId}
+    {#if $isRpcUrlValid && $activeChain}
       <div class="mb-8">
-        <Label class="bold mb-2 block text-xl">Chain ID</Label>
-        <Input label="RPC URL" name="chainId" required bind:value={$chainId} disabled />
+        <Label class="bold mb-2 block text-xl">Chain</Label>
+        <Input label="RPC URL" name="chainId" required bind:value={$activeChain.name} disabled />
         <Helper class="mt-2 text-sm">Automatically determined by your RPC URL.</Helper>
       </div>
     {/if}

--- a/tauri-app/src/routes/settings/+page.svelte
+++ b/tauri-app/src/routes/settings/+page.svelte
@@ -7,10 +7,10 @@
     orderbookAddress,
     walletAddress,
     walletDerivationIndex,
+    chainId,
     isRpcUrlValid,
     isSubgraphUrlValid,
     isOrderbookAddressValid,
-    isWalletAddressValid,
     isSettingsDefinedAndValid,
   } from '$lib/stores/settings';
   import InputLedgerWallet from '$lib/InputLedgerWallet.svelte';
@@ -40,9 +40,17 @@
         />
         for a reliable hosted RPC service provider. Or visit
         <BadgeExternalLink href="https://chainlist.org/" text="Chainlist" /> for find other publically
-        available RPC providerss.
+        available RPC providers.
       </Helper>
     </div>
+
+    {#if $isRpcUrlValid && $chainId}
+      <div class="mb-8">
+        <Label class="bold mb-2 block text-xl">Chain ID</Label>
+        <Input label="RPC URL" name="chainId" required bind:value={$chainId} disabled />
+        <Helper class="mt-2 text-sm">Automatically determined by your RPC URL.</Helper>
+      </div>
+    {/if}
 
     <div class="mb-8">
       <Label class="bold mb-2 block text-xl">Subgraph URL</Label>


### PR DESCRIPTION
Resolves #81 

Depends on https://github.com/rainlanguage/alloy-ethers-typecast/pull/15

- In gui, upon setting an RPC url, fetches the chain id via RPC call and displays the chain name in the settings page
- In cli, makes arg `--chain-id` optional. If not set, fetches the chain id via RPC call.

![image](https://github.com/rainlanguage/rain.orderbook/assets/159270/942fc99d-795a-4972-9d89-59022e5196a1)
