### PR TITLE
2024 01 24 fix approve call

### DIFF
--- a/crates/cli/src/commands/vault/deposit.rs
+++ b/crates/cli/src/commands/vault/deposit.rs
@@ -2,7 +2,7 @@ use crate::{
     execute::Execute, status::display_write_transaction_status,
     transaction::CliTransactionCommandArgs,
 };
-use alloy_primitives::U256;
+use alloy_primitives::{Address, U256};
 use anyhow::Result;
 use clap::Args;
 use rain_orderbook_common::{deposit::DepositArgs, transaction::TransactionArgs};
@@ -35,7 +35,7 @@ impl Execute for Deposit {
 #[derive(Args, Clone)]
 pub struct CliDepositArgs {
     #[arg(short, long, help = "The token address in hex format")]
-    token: String,
+    token: Address,
 
     #[arg(short, long, help = "The ID of the vault")]
     vault_id: U256,

--- a/crates/cli/src/commands/vault/withdraw.rs
+++ b/crates/cli/src/commands/vault/withdraw.rs
@@ -1,6 +1,6 @@
 use crate::status::display_write_transaction_status;
 use crate::{execute::Execute, transaction::CliTransactionCommandArgs};
-use alloy_primitives::U256;
+use alloy_primitives::{Address, U256};
 use anyhow::Result;
 use clap::Args;
 use rain_orderbook_common::transaction::TransactionArgs;
@@ -27,7 +27,7 @@ impl Execute for Withdraw {
 #[derive(Args, Clone)]
 pub struct CliWithdrawArgs {
     #[arg(short, long, help = "The token address in hex format")]
-    token: String,
+    token: Address,
 
     #[arg(short, long, help = "The ID of the vault")]
     vault_id: U256,

--- a/crates/cli/src/transaction.rs
+++ b/crates/cli/src/transaction.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::U256;
+use alloy_primitives::{Address, U256};
 use clap::Args;
 use clap::FromArgMatches;
 use clap::Parser;
@@ -7,7 +7,7 @@ use rain_orderbook_common::transaction::TransactionArgs;
 #[derive(Args, Clone)]
 pub struct CliTransactionArgs {
     #[arg(short, long, help = "Orderbook contract address")]
-    pub orderbook_address: String,
+    pub orderbook_address: Address,
 
     #[arg(
         short,

--- a/crates/common/src/transaction.rs
+++ b/crates/common/src/transaction.rs
@@ -5,15 +5,13 @@ use alloy_ethers_typecast::{
         WriteContractParametersBuilder, WriteContractParametersBuilderError,
     },
 };
-use alloy_primitives::{hex::FromHexError, Address, U256};
+use alloy_primitives::{Address, U256};
 use alloy_sol_types::SolCall;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum TransactionArgsError {
-    #[error("Parse orderbook address error: {0}")]
-    ParseOrderbookAddress(#[from] FromHexError),
     #[error("Build parameters error: {0}")]
     BuildParameters(#[from] WriteContractParametersBuilderError),
     #[error("Parse Chain ID U256 to u64 error")]
@@ -40,9 +38,10 @@ impl TransactionArgs {
     pub async fn try_into_write_contract_parameters<T: SolCall + Clone>(
         &self,
         call: T,
+        contract: Address,
     ) -> Result<WriteContractParameters<T>, TransactionArgsError> {
         WriteContractParametersBuilder::default()
-            .address(self.orderbook_address)
+            .address(contract)
             .call(call)
             .max_priority_fee_per_gas(self.max_priority_fee_per_gas)
             .max_fee_per_gas(self.max_fee_per_gas)

--- a/crates/common/src/transaction.rs
+++ b/crates/common/src/transaction.rs
@@ -28,7 +28,7 @@ pub enum TransactionArgsError {
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct TransactionArgs {
-    pub orderbook_address: String,
+    pub orderbook_address: Address,
     pub derivation_index: Option<usize>,
     pub chain_id: Option<u64>,
     pub rpc_url: String,
@@ -41,13 +41,8 @@ impl TransactionArgs {
         &self,
         call: T,
     ) -> Result<WriteContractParameters<T>, TransactionArgsError> {
-        let orderbook_address = self
-            .orderbook_address
-            .parse::<Address>()
-            .map_err(TransactionArgsError::ParseOrderbookAddress)?;
-
         WriteContractParametersBuilder::default()
-            .address(orderbook_address)
+            .address(self.orderbook_address)
             .call(call)
             .max_priority_fee_per_gas(self.max_priority_fee_per_gas)
             .max_fee_per_gas(self.max_fee_per_gas)


### PR DESCRIPTION
- modify cli arg `--token` to be an `Address` instead of `String`
- fixes embarrassing approve call bug: it was calling the wrong contract and specifying the wrong sender -- definitely need to get some tests against a deployed contract (https://github.com/rainlanguage/rain.orderbook/issues/134)