### PR TITLE
2024 01 27 gui improve vault action ux

### DIFF
--- a/.github/workflows/tauri.yaml
+++ b/.github/workflows/tauri.yaml
@@ -20,5 +20,6 @@ jobs:
       - run: nix develop .#tauri-shell --command cargo build --verbose
         working-directory: ./tauri-app
       - run: nix run .#ob-tauri-prelude
+      - run: nix run .#ob-tauri-test
       - run: nix develop .#tauri-shell --command cargo tauri build --verbose
         working-directory: ./tauri-app

--- a/flake.nix
+++ b/flake.nix
@@ -36,6 +36,14 @@
               pkgs.typeshare
             ];
           };
+          ob-tauri-test =  rainix.mkTask.${system} {
+            name = "ob-tauri-test";
+            body = ''
+              set -euxo pipefail
+
+              cd tauri-app && npm i && npm run test
+            '';
+          };
         } // rainix.packages.${system};
         devShells = rainix.devShells.${system};
       }

--- a/tauri-app/package-lock.json
+++ b/tauri-app/package-lock.json
@@ -44,7 +44,8 @@
         "tslib": "^2.4.1",
         "typescript": "^5.0.0",
         "vite": "^5.0.3",
-        "vite-plugin-checker": "^0.6.2"
+        "vite-plugin-checker": "^0.6.2",
+        "vitest": "^1.2.2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -873,6 +874,18 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
@@ -1200,6 +1213,12 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "dev": true
     },
     "node_modules/@sveltejs/adapter-auto": {
       "version": "3.1.0",
@@ -1554,6 +1573,102 @@
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
     },
+    "node_modules/@vitest/expect": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.2.2.tgz",
+      "integrity": "sha512-3jpcdPAD7LwHUUiT2pZTj2U82I2Tcgg2oVPvKxhn6mDI2On6tfvPQTjAI4628GUGDZrCm4Zna9iQHm5cEexOAg==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "1.2.2",
+        "@vitest/utils": "1.2.2",
+        "chai": "^4.3.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.2.2.tgz",
+      "integrity": "sha512-JctG7QZ4LSDXr5CsUweFgcpEvrcxOV1Gft7uHrvkQ+fsAVylmWQvnaAr/HDp3LAH1fztGMQZugIheTWjaGzYIg==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "1.2.2",
+        "p-limit": "^5.0.0",
+        "pathe": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/p-limit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+      "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/yocto-queue": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
+      "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.2.2.tgz",
+      "integrity": "sha512-SmGY4saEw1+bwE1th6S/cZmPxz/Q4JWsl7LvbQIky2tKE35US4gd0Mjzqfr84/4OD0tikGWaWdMja/nWL5NIPA==",
+      "dev": true,
+      "dependencies": {
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.2.2.tgz",
+      "integrity": "sha512-k9Gcahssw8d7X3pSLq3e3XEu/0L78mUkCjivUqCQeXJm9clfXR/Td8+AP+VC1O6fKPIDLcHDTAmBOINVuv6+7g==",
+      "dev": true,
+      "dependencies": {
+        "tinyspy": "^2.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.2.2.tgz",
+      "integrity": "sha512-WKITBHLsBHlpjnDQahr+XK6RE7MiAsgrIkr0pGhQ9ygoxBfUeG0lUG5iLlzqjmKSlBv3+j5EGsriBzh+C3Tq9g==",
+      "dev": true,
+      "dependencies": {
+        "diff-sequences": "^29.6.3",
+        "estree-walker": "^3.0.3",
+        "loupe": "^2.3.7",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@yr/monotone-cubic-spline": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@yr/monotone-cubic-spline/-/monotone-cubic-spline-1.0.3.tgz",
@@ -1598,6 +1713,15 @@
       "dev": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
+      "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/ajv": {
@@ -1730,6 +1854,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.16",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.16.tgz",
@@ -1852,6 +1985,15 @@
         "node": "*"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1890,6 +2032,24 @@
         }
       ]
     },
+    "node_modules/chai": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.4.1.tgz",
+      "integrity": "sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1904,6 +2064,18 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "dev": true,
+      "dependencies": {
+        "get-func-name": "^2.0.2"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/chokidar": {
@@ -2069,6 +2241,18 @@
         }
       }
     },
+    "node_modules/deep-eql": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
+      "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2112,6 +2296,15 @@
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
       "dev": true
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -2510,6 +2703,56 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/execa/node_modules/npm-run-path": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.2.0.tgz",
+      "integrity": "sha512-W4/tgAXFqFA0iL7fk0+uQ3g7wkL8xJmx3XdK0VGb4cHW//eZTtKGvFBBoRKVTpY7n6ze4NL9ly7rgXcHufqXKg==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/execa/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2737,6 +2980,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-func-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -2869,6 +3133,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.17.0"
       }
     },
     "node_modules/ignore": {
@@ -3022,6 +3295,18 @@
         "@types/estree": "*"
       }
     },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -3105,6 +3390,12 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
+    "node_modules/jsonc-parser": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.1.tgz",
+      "integrity": "sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==",
+      "dev": true
+    },
     "node_modules/jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -3169,6 +3460,22 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
     },
+    "node_modules/local-pkg": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.0.tgz",
+      "integrity": "sha512-ok6z3qlYyCDS4ZEU27HaU6x/xZa9Whf8jD4ptH5UZTQYZVYeb9bnZ3ojVhiJNLiXK1Hfc0GNbLXcmZ5plLDDBg==",
+      "dev": true,
+      "dependencies": {
+        "mlly": "^1.4.2",
+        "pkg-types": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
     "node_modules/locate-character": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
@@ -3212,6 +3519,15 @@
       "integrity": "sha512-hXt6Ul/5yWjfklSGvLQl8vM//l3FtyHZeuelpzK6mm99pNvN9yTDruNZPEJZD1oWrqo+izBmB7oUfWgcCX7s4Q==",
       "dev": true
     },
+    "node_modules/loupe": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+      "dev": true,
+      "dependencies": {
+        "get-func-name": "^2.0.1"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -3240,6 +3556,12 @@
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
       "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA=="
     },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -3260,6 +3582,18 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/min-indent": {
@@ -3323,6 +3657,18 @@
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.5.0.tgz",
+      "integrity": "sha512-NPVQvAY1xr1QoVeG0cy8yUYC7FQcOx6evl/RjT1wL5FvzPnzOysoqB/jmx/DhssT2dYa8nxECLAaFI/+gVLhDQ==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.11.3",
+        "pathe": "^1.1.2",
+        "pkg-types": "^1.0.3",
+        "ufo": "^1.3.2"
       }
     },
     "node_modules/mri": {
@@ -3445,6 +3791,21 @@
       "dev": true,
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/optionator": {
@@ -3573,6 +3934,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/periscopic": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/periscopic/-/periscopic-3.1.0.tgz",
@@ -3617,6 +3993,17 @@
       "dev": true,
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.0.3.tgz",
+      "integrity": "sha512-nN7pYi0AQqJnoLPC9eHFQ8AcyaixBUOwvqc5TDnIKCMEE6I0y8P7OKA7fPexsXGCGxQDl/cmrLAp26LhcwxZ4A==",
+      "dev": true,
+      "dependencies": {
+        "jsonc-parser": "^3.2.0",
+        "mlly": "^1.2.0",
+        "pathe": "^1.1.0"
       }
     },
     "node_modules/postcss": {
@@ -3901,6 +4288,32 @@
         }
       }
     },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3929,6 +4342,12 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+      "dev": true
     },
     "node_modules/read-cache": {
       "version": "1.0.0",
@@ -4140,6 +4559,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -4197,6 +4622,18 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "node_modules/std-env": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.7.0.tgz",
+      "integrity": "sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==",
+      "dev": true
     },
     "node_modules/string-width": {
       "version": "5.1.2",
@@ -4288,6 +4725,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/strip-indent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
@@ -4310,6 +4759,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-1.3.0.tgz",
+      "integrity": "sha512-PugKzOsyXpArk0yWmUwqOZecSO0GH0bPoctLcqNDH9J04pVW3lflYE0ujElBGTloevcxF5MofAOZ7C5l2b+wLg==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/sucrase": {
@@ -4764,6 +5225,30 @@
       "integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw==",
       "dev": true
     },
+    "node_modules/tinybench": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.6.0.tgz",
+      "integrity": "sha512-N8hW3PG/3aOoZAN5V/NSAEDz0ZixDSSt5b/a05iqtpgfLWMSVuCo7w0k2vVvEjdrIoeGqZzweX2WlyioNIHchA==",
+      "dev": true
+    },
+    "node_modules/tinypool": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.2.tgz",
+      "integrity": "sha512-SUszKYe5wgsxnNOVlBYO6IC+8VGWdVGZWAqUxp3UErNBtptZvWbwyUOyzNL59zigz2rCA92QiL3wvG+JDSdJdQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.0.tgz",
+      "integrity": "sha512-d2eda04AN/cPOR89F7Xv5bK/jrQEhmcLFe6HFldoeO9AJtps+fqEnh486vnT/8y4bw38pSyxDcTCAq+Ks2aJTg==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -4821,6 +5306,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/type-fest": {
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
@@ -4845,6 +5339,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/ufo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.3.2.tgz",
+      "integrity": "sha512-o+ORpgGwaYQXgqGDwd+hkS4PuZ3QnmqMMxRuajK/a38L6fTpcE5GPIfrf+L/KemFzfUpeUQc1rRS1iDBozvnFA==",
+      "dev": true
     },
     "node_modules/universalify": {
       "version": "2.0.1",
@@ -4996,6 +5496,28 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.2.2.tgz",
+      "integrity": "sha512-1as4rDTgVWJO3n1uHmUYqq7nsFgINQ9u+mRcXpjeOMJUmviqNKjcZB7UfRZrlM7MjYXMKpuWp5oGkjaFLnjawg==",
+      "dev": true,
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.4",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/vite-plugin-checker": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/vite-plugin-checker/-/vite-plugin-checker-0.6.2.tgz",
@@ -5080,6 +5602,72 @@
       },
       "peerDependenciesMeta": {
         "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.2.2.tgz",
+      "integrity": "sha512-d5Ouvrnms3GD9USIK36KG8OZ5bEvKEkITFtnGv56HFaSlbItJuYr7hv2Lkn903+AvRAgSixiamozUVfORUekjw==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/expect": "1.2.2",
+        "@vitest/runner": "1.2.2",
+        "@vitest/snapshot": "1.2.2",
+        "@vitest/spy": "1.2.2",
+        "@vitest/utils": "1.2.2",
+        "acorn-walk": "^8.3.2",
+        "cac": "^6.7.14",
+        "chai": "^4.3.10",
+        "debug": "^4.3.4",
+        "execa": "^8.0.1",
+        "local-pkg": "^0.5.0",
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.5.0",
+        "strip-literal": "^1.3.0",
+        "tinybench": "^2.5.1",
+        "tinypool": "^0.8.2",
+        "vite": "^5.0.0",
+        "vite-node": "1.2.2",
+        "why-is-node-running": "^2.2.2"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "^1.0.0",
+        "@vitest/ui": "^1.0.0",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
           "optional": true
         }
       }
@@ -5182,6 +5770,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.2.2.tgz",
+      "integrity": "sha512-6tSwToZxTOcotxHeA+qGCq1mVzKR3CwcJGmVcY+QE8SHy6TnpFnh8PAvPNHYr7EcuVeG0QSMxtYCuO1ta/G/oA==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrap-ansi": {

--- a/tauri-app/package.json
+++ b/tauri-app/package.json
@@ -8,7 +8,8 @@
     "preview": "vite preview",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
-    "lint": "eslint --fix src"
+    "lint": "eslint --fix src",
+    "test": "vitest run"
   },
   "devDependencies": {
     "@sveltejs/adapter-auto": "^3.0.0",
@@ -38,7 +39,8 @@
     "tslib": "^2.4.1",
     "typescript": "^5.0.0",
     "vite": "^5.0.3",
-    "vite-plugin-checker": "^0.6.2"
+    "vite-plugin-checker": "^0.6.2",
+    "vitest": "^1.2.2"
   },
   "type": "module",
   "dependencies": {

--- a/tauri-app/src-tauri/src/commands/vault.rs
+++ b/tauri-app/src-tauri/src/commands/vault.rs
@@ -43,16 +43,14 @@ pub async fn vault_deposit(
             total: 2,
         }),
     );
-    deposit_args
+    let _ = deposit_args
         .execute_approve(transaction_args.clone(), |status| {
             tx_status_notice.update_status_and_emit(app_handle.clone(), status);
         })
         .await
         .map_err(|e| {
-            let text = format!("{}", e);
             tx_status_notice.set_failed_status_and_emit(app_handle.clone(), text.clone());
-            text
-        })?;
+        });
 
     let tx_status_notice = TransactionStatusNoticeRwLock::new(
         "Deposit tokens into vault".into(),
@@ -61,16 +59,14 @@ pub async fn vault_deposit(
             total: 2,
         }),
     );
-    deposit_args
+    let _ = deposit_args
         .execute_deposit(transaction_args.clone(), |status| {
             tx_status_notice.update_status_and_emit(app_handle.clone(), status);
         })
         .await
         .map_err(|e| {
-            let text = format!("{}", e);
             tx_status_notice.set_failed_status_and_emit(app_handle.clone(), text.clone());
-            text
-        })?;
+        });
 
     Ok(())
 }
@@ -83,16 +79,14 @@ pub async fn vault_withdraw(
 ) -> Result<(), String> {
     let tx_status_notice =
         TransactionStatusNoticeRwLock::new("Withdraw tokens from vault".into(), None);
-    withdraw_args
+    let _ = withdraw_args
         .execute(transaction_args.clone(), |status| {
             tx_status_notice.update_status_and_emit(app_handle.clone(), status);
         })
         .await
         .map_err(|e| {
-            let text = format!("{}", e);
             tx_status_notice.set_failed_status_and_emit(app_handle.clone(), text.clone());
-            text
-        })?;
+        });
 
     Ok(())
 }

--- a/tauri-app/src-tauri/src/commands/vault.rs
+++ b/tauri-app/src-tauri/src/commands/vault.rs
@@ -49,7 +49,7 @@ pub async fn vault_deposit(
         })
         .await
         .map_err(|e| {
-            tx_status_notice.set_failed_status_and_emit(app_handle.clone(), text.clone());
+            tx_status_notice.set_failed_status_and_emit(app_handle.clone(), e.to_string());
         });
 
     let tx_status_notice = TransactionStatusNoticeRwLock::new(
@@ -65,7 +65,7 @@ pub async fn vault_deposit(
         })
         .await
         .map_err(|e| {
-            tx_status_notice.set_failed_status_and_emit(app_handle.clone(), text.clone());
+            tx_status_notice.set_failed_status_and_emit(app_handle.clone(), e.to_string());
         });
 
     Ok(())
@@ -85,7 +85,7 @@ pub async fn vault_withdraw(
         })
         .await
         .map_err(|e| {
-            tx_status_notice.set_failed_status_and_emit(app_handle.clone(), text.clone());
+            tx_status_notice.set_failed_status_and_emit(app_handle.clone(), e.to_string());
         });
 
     Ok(())

--- a/tauri-app/src-tauri/src/commands/wallet.rs
+++ b/tauri-app/src-tauri/src/commands/wallet.rs
@@ -10,7 +10,7 @@ pub async fn get_address_from_ledger(
 ) -> Result<Address, String> {
     let ledger_client = LedgerClient::new(derivation_index, chain_id, rpc_url.clone())
         .await
-        .map_err(|e| format!("{}", e.to_string()))?;
+        .map_err(|e| e.to_string())?;
     let ledger_address = ethers_address_to_alloy(ledger_client.client.address());
 
     Ok(ledger_address)

--- a/tauri-app/src/lib/InputToken.svelte
+++ b/tauri-app/src/lib/InputToken.svelte
@@ -4,8 +4,8 @@
   import { imask } from '@imask/svelte';
   import { isAddress } from 'viem';
 
-  export let decimals: string = '';
-  export let decimalsRaw: number;
+  let decimalsRaw: string = '';
+  export let decimals: number;
   export let address: string = '';
 
   $: isAddressValid = address && address.length > 0 && isAddress(address);
@@ -20,11 +20,11 @@
   };
 
   function decimalsComplete({ detail }: { detail: InputMask }) {
-    decimals = detail.value;
+    decimalsRaw = detail.value;
     if (detail.unmaskedValue.length === 0) {
-      decimalsRaw = 0;
+      decimals = 0;
     } else {
-      decimalsRaw = parseInt(detail.unmaskedValue);
+      decimals = parseInt(detail.unmaskedValue);
     }
   }
 </script>
@@ -43,7 +43,7 @@
   </div>
   <div class="w-32 grow-0 break-all">
     <input
-      value={decimals}
+      value={decimalsRaw}
       class="focus:border-primary-500 focus:ring-primary-500 dark:focus:border-primary-500 dark:focus:ring-primary-500 block w-full rounded-lg border-gray-300 bg-gray-50 p-2.5 text-sm text-gray-900 disabled:cursor-not-allowed disabled:opacity-50 rtl:text-right dark:border-gray-500 dark:bg-gray-600 dark:text-white dark:placeholder-gray-400"
       use:imask={decimalsMaskOptions}
       on:complete={decimalsComplete}

--- a/tauri-app/src/lib/InputToken.svelte
+++ b/tauri-app/src/lib/InputToken.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-  import { Alert, Helper, Input } from 'flowbite-svelte';
-  import { InfoCircleSolid } from 'flowbite-svelte-icons';
+  import { Helper, Input } from 'flowbite-svelte';
   import type { InputMask } from 'imask';
   import { imask } from '@imask/svelte';
   import { isAddress } from 'viem';
@@ -22,7 +21,11 @@
 
   function decimalsComplete({ detail }: { detail: InputMask }) {
     decimals = detail.value;
-    decimalsRaw = parseInt(detail.unmaskedValue);
+    if (detail.unmaskedValue.length === 0) {
+      decimalsRaw = 0;
+    } else {
+      decimalsRaw = parseInt(detail.unmaskedValue);
+    }
   }
 </script>
 
@@ -47,11 +50,4 @@
     />
     <Helper class="break-word mt-2 text-sm">Decimals</Helper>
   </div>
-  {#if decimalsRaw === 0}
-    <Alert color="yellow" border class="mt-2">
-      <InfoCircleSolid slot="icon" class="h-6 w-6" />
-      This token does not specify a number of decimals. <br />You are inputting the raw integer
-      amount with 0 decimal places.
-    </Alert>
-  {/if}
 </div>

--- a/tauri-app/src/lib/InputToken.svelte
+++ b/tauri-app/src/lib/InputToken.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+  import { Alert, Helper, Input } from 'flowbite-svelte';
+  import { InfoCircleSolid } from 'flowbite-svelte-icons';
+  import type { InputMask } from 'imask';
+  import { imask } from '@imask/svelte';
+  import { isAddress } from 'viem';
+
+  export let decimals: string = '';
+  export let decimalsRaw: number;
+  export let address: string = '';
+
+  $: isAddressValid = address && address.length > 0 && isAddress(address);
+
+  const decimalsMaskOptions = {
+    mask: Number,
+    min: 0,
+    lazy: false,
+    scale: 0,
+    thousandsSeparator: '',
+    radix: '.',
+  };
+
+  function decimalsComplete({ detail }: { detail: InputMask }) {
+    decimals = detail.value;
+    decimalsRaw = parseInt(detail.unmaskedValue);
+  }
+</script>
+
+<div class="flex w-full items-start justify-start space-x-2">
+  <div class="grow">
+    <div class="relative flex">
+      <Input label="Token Address" name="address" required bind:value={address} />
+    </div>
+
+    {#if !isAddressValid && address.length > 0}
+      <Helper class="mt-2 text-sm" color="red">Invalid Address</Helper>
+    {/if}
+
+    <Helper class="mt-2 text-sm">Token Address</Helper>
+  </div>
+  <div class="w-32 grow-0 break-all">
+    <input
+      value={decimals}
+      class="focus:border-primary-500 focus:ring-primary-500 dark:focus:border-primary-500 dark:focus:ring-primary-500 block w-full rounded-lg border-gray-300 bg-gray-50 p-2.5 text-sm text-gray-900 disabled:cursor-not-allowed disabled:opacity-50 rtl:text-right dark:border-gray-500 dark:bg-gray-600 dark:text-white dark:placeholder-gray-400"
+      use:imask={decimalsMaskOptions}
+      on:complete={decimalsComplete}
+    />
+    <Helper class="break-word mt-2 text-sm">Decimals</Helper>
+  </div>
+  {#if decimalsRaw === 0}
+    <Alert color="yellow" border class="mt-2">
+      <InfoCircleSolid slot="icon" class="h-6 w-6" />
+      This token does not specify a number of decimals. <br />You are inputting the raw integer
+      amount with 0 decimal places.
+    </Alert>
+  {/if}
+</div>

--- a/tauri-app/src/lib/InputTokenAmount.svelte
+++ b/tauri-app/src/lib/InputTokenAmount.svelte
@@ -7,9 +7,9 @@
 
   export let symbol: string | undefined = undefined;
   export let decimals: number = 0;
-  export let maxValueRaw: bigint | undefined = undefined;
-  export let value: string = '';
-  export let valueRaw: bigint;
+  export let maxValue: bigint | undefined = undefined;
+  let valueRaw: string = '';
+  export let value: bigint;
 
   $: maskOptions = {
     mask: Number,
@@ -21,23 +21,23 @@
   };
 
   function complete({ detail }: { detail: InputMask }) {
-    value = detail.value;
+    valueRaw = detail.value;
 
     if (detail.unmaskedValue.length === 0) {
-      valueRaw = 0n;
+      value = 0n;
     } else {
       try {
-        valueRaw = parseUnits(detail.unmaskedValue, decimals);
+        value = parseUnits(detail.unmaskedValue, decimals);
         // eslint-disable-next-line no-empty
       } catch (e) {}
     }
   }
 
   function fillMaxValue() {
-    if (!maxValueRaw) return;
+    if (!maxValue) return;
 
-    valueRaw = maxValueRaw;
-    value = formatUnits(maxValueRaw, decimals);
+    value = maxValue;
+    valueRaw = formatUnits(maxValue, decimals);
   }
 </script>
 
@@ -45,12 +45,12 @@
   <div class="relative flex w-full">
     <input
       class="focus:border-primary-500 focus:ring-primary-500 dark:focus:border-primary-500 dark:focus:ring-primary-500 block w-full rounded-lg border-gray-300 bg-gray-50 p-2.5 text-sm text-gray-900 disabled:cursor-not-allowed disabled:opacity-50 rtl:text-right dark:border-gray-500 dark:bg-gray-600 dark:text-white dark:placeholder-gray-400"
-      {value}
+      value={valueRaw}
       use:imask={maskOptions}
       on:complete={complete}
     />
 
-    {#if maxValueRaw}
+    {#if maxValue}
       <div class="absolute right-20 flex h-10 flex-col justify-center">
         <Button color="blue" class="px-2 py-1" size="xs" pill on:click={fillMaxValue}>MAX</Button>
       </div>

--- a/tauri-app/src/lib/InputTokenAmount.svelte
+++ b/tauri-app/src/lib/InputTokenAmount.svelte
@@ -5,13 +5,13 @@
   import type { InputMask } from 'imask';
   import { imask } from '@imask/svelte';
 
-  export let symbol: string;
+  export let symbol: string | undefined = undefined;
   export let decimals: number = 0;
   export let maxValueRaw: bigint | undefined = undefined;
   export let value: string = '';
   export let valueRaw: bigint;
 
-  const maskOptions = {
+  $: maskOptions = {
     mask: Number,
     min: 0,
     lazy: false,
@@ -39,7 +39,7 @@
 <div class="w-full">
   <div class="relative flex w-full">
     <input
-      class="focus:border-primary-500 block w-full border-s-0 border-gray-300 bg-gray-50 p-2.5 text-sm text-gray-900 first:rounded-s-lg first:border-s last:rounded-e-lg last:border-e disabled:cursor-not-allowed disabled:opacity-50 rtl:text-right dark:border-gray-500 dark:bg-gray-600 dark:text-white dark:placeholder-gray-400"
+      class="focus:border-primary-500 focus:ring-primary-500 dark:focus:border-primary-500 dark:focus:ring-primary-500 block w-full rounded-lg border-gray-300 bg-gray-50 p-2.5 text-sm text-gray-900 disabled:cursor-not-allowed disabled:opacity-50 rtl:text-right dark:border-gray-500 dark:bg-gray-600 dark:text-white dark:placeholder-gray-400"
       {value}
       use:imask={maskOptions}
       on:complete={complete}
@@ -51,9 +51,11 @@
       </div>
     {/if}
 
-    <InputAddon>
-      {symbol}
-    </InputAddon>
+    {#if symbol}
+      <InputAddon>
+        {symbol}
+      </InputAddon>
+    {/if}
   </div>
   {#if decimals === 0}
     <Alert color="yellow" border class="mt-2">

--- a/tauri-app/src/lib/InputTokenAmount.svelte
+++ b/tauri-app/src/lib/InputTokenAmount.svelte
@@ -44,14 +44,15 @@
 <div class="w-full">
   <div class="relative flex w-full">
     <input
-      class="focus:border-primary-500 focus:ring-primary-500 dark:focus:border-primary-500 dark:focus:ring-primary-500 block w-full rounded-lg border-gray-300 bg-gray-50 p-2.5 text-sm text-gray-900 disabled:cursor-not-allowed disabled:opacity-50 rtl:text-right dark:border-gray-500 dark:bg-gray-600 dark:text-white dark:placeholder-gray-400"
+      class={`focus:border-primary-500 focus:ring-primary-500 dark:focus:border-primary-500 dark:focus:ring-primary-500 block w-full rounded-lg border-gray-300 bg-gray-50 p-2.5 text-sm text-gray-900 disabled:cursor-not-allowed disabled:opacity-50 rtl:text-right dark:border-gray-500 dark:bg-gray-600 dark:text-white dark:placeholder-gray-400 ${symbol && '!rounded-none !rounded-l-lg'}`}
+
       value={valueRaw}
       use:imask={maskOptions}
       on:complete={complete}
     />
 
     {#if maxValue}
-      <div class="absolute right-20 flex h-10 flex-col justify-center">
+      <div class="absolute right-[5.8rem] flex h-10 flex-col justify-center">
         <Button color="blue" class="px-2 py-1" size="xs" pill on:click={fillMaxValue}>MAX</Button>
       </div>
     {/if}

--- a/tauri-app/src/lib/InputTokenAmount.svelte
+++ b/tauri-app/src/lib/InputTokenAmount.svelte
@@ -22,10 +22,15 @@
 
   function complete({ detail }: { detail: InputMask }) {
     value = detail.value;
-    try {
-      valueRaw = parseUnits(detail.unmaskedValue, decimals);
-      // eslint-disable-next-line no-empty
-    } catch (e) {}
+
+    if (detail.unmaskedValue.length === 0) {
+      valueRaw = 0n;
+    } else {
+      try {
+        valueRaw = parseUnits(detail.unmaskedValue, decimals);
+        // eslint-disable-next-line no-empty
+      } catch (e) {}
+    }
   }
 
   function fillMaxValue() {

--- a/tauri-app/src/lib/InputVaultId.svelte
+++ b/tauri-app/src/lib/InputVaultId.svelte
@@ -5,8 +5,8 @@
   import { fromHex } from 'viem';
   import { HEX_INPUT_REGEX } from '$lib/utils/hex';
 
-  export let value: string = '';
-  export let valueRaw: bigint;
+  let valueRaw: string = '';
+  export let value: bigint;
   export let required = true;
 
   const maskOptions = {
@@ -16,17 +16,17 @@
   };
 
   function complete({ detail }: { detail: InputMask }) {
-    value = detail.value;
+    valueRaw = detail.value;
 
     if (detail.unmaskedValue.length === 0) {
-      valueRaw = 0n;
+      value = 0n;
     } else {
       let valuePrefixed = detail.unmaskedValue;
       if (detail.unmaskedValue.substring(0, 2) !== '0x') {
         valuePrefixed = `0x${valuePrefixed}`;
       }
       try {
-        valueRaw = fromHex(valuePrefixed as `0x${string}`, 'bigint');
+        value = fromHex(valuePrefixed as `0x${string}`, 'bigint');
         // eslint-disable-next-line no-empty
       } catch (e) {}
     }
@@ -36,7 +36,7 @@
 <div class="w-full">
   <input
     {required}
-    {value}
+    value={valueRaw}
     class="focus:border-primary-500 focus:ring-primary-500 dark:focus:border-primary-500 dark:focus:ring-primary-500 block w-full rounded-lg border-gray-300 bg-gray-50 p-2.5 text-sm text-gray-900 disabled:cursor-not-allowed disabled:opacity-50 rtl:text-right dark:border-gray-500 dark:bg-gray-600 dark:text-white dark:placeholder-gray-400"
     use:imask={maskOptions}
     on:complete={complete}

--- a/tauri-app/src/lib/InputVaultId.svelte
+++ b/tauri-app/src/lib/InputVaultId.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+  import { Helper } from 'flowbite-svelte';
+  import type { InputMask } from 'imask';
+  import { imask } from '@imask/svelte';
+  import { fromHex } from 'viem';
+  import { HEX_INPUT_REGEX } from '$lib/utils/hex';
+
+  export let value: string = '';
+  export let valueRaw: bigint;
+  export let required = true;
+
+  const maskOptions = {
+    // hexadecimal string, optionally starting with 0x
+    mask: HEX_INPUT_REGEX,
+    lazy: false,
+  };
+
+  function complete({ detail }: { detail: InputMask }) {
+    value = detail.value;
+
+    if (detail.unmaskedValue.length === 0) {
+      valueRaw = 0n;
+    } else {
+      let valuePrefixed = detail.unmaskedValue;
+      if (detail.unmaskedValue.substring(0, 2) !== '0x') {
+        valuePrefixed = `0x${valuePrefixed}`;
+      }
+      try {
+        valueRaw = fromHex(valuePrefixed as `0x${string}`, 'bigint');
+        // eslint-disable-next-line no-empty
+      } catch (e) {}
+    }
+  }
+</script>
+
+<div class="w-full">
+  <input
+    {required}
+    {value}
+    class="focus:border-primary-500 focus:ring-primary-500 dark:focus:border-primary-500 dark:focus:ring-primary-500 block w-full rounded-lg border-gray-300 bg-gray-50 p-2.5 text-sm text-gray-900 disabled:cursor-not-allowed disabled:opacity-50 rtl:text-right dark:border-gray-500 dark:bg-gray-600 dark:text-white dark:placeholder-gray-400"
+    use:imask={maskOptions}
+    on:complete={complete}
+  />
+  <Helper class="mt-2 text-sm">
+    A hex identifier to distinguish this Vault from others with the same Token and Owner
+  </Helper>
+</div>

--- a/tauri-app/src/lib/ModalVaultDeposit.svelte
+++ b/tauri-app/src/lib/ModalVaultDeposit.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Button, Modal, Label, ButtonGroup, Spinner } from 'flowbite-svelte';
+  import { Button, Modal, Label, ButtonGroup, Spinner, Helper } from 'flowbite-svelte';
   import type { TokenVault } from '$lib/typeshare/vault';
   import InputTokenAmount from '$lib/InputTokenAmount.svelte';
   import { vaultDeposit } from '$lib/utils/vaultDeposit';
@@ -33,6 +33,9 @@
     <p class="break-all font-normal leading-tight text-gray-700 dark:text-gray-400">
       {vault.vault.vault_id}
     </p>
+    <Helper class="mt-2 text-sm">
+      A hex identifier to distinguish this Vault from others with the same Token and Owner
+    </Helper>
   </div>
 
   <div>

--- a/tauri-app/src/lib/ModalVaultDeposit.svelte
+++ b/tauri-app/src/lib/ModalVaultDeposit.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
-  import { Button, Modal, Label, ButtonGroup, Spinner, Helper } from 'flowbite-svelte';
+  import { Button, Modal, Label, ButtonGroup, Spinner } from 'flowbite-svelte';
   import type { TokenVault } from '$lib/typeshare/vault';
   import InputTokenAmount from '$lib/InputTokenAmount.svelte';
   import { vaultDeposit } from '$lib/utils/vaultDeposit';
+  import { toHex } from 'viem';
 
   export let open = false;
   export let vault: TokenVault;
@@ -32,11 +33,8 @@
       Vault ID
     </h5>
     <p class="break-all font-normal leading-tight text-gray-700 dark:text-gray-400">
-      {vault.vault.vault_id}
+      {toHex(vault.vault.vault_id)}
     </p>
-    <Helper class="mt-2 text-sm">
-      A hex identifier to distinguish this Vault from others with the same Token and Owner
-    </Helper>
   </div>
 
   <div>

--- a/tauri-app/src/lib/ModalVaultDeposit.svelte
+++ b/tauri-app/src/lib/ModalVaultDeposit.svelte
@@ -6,20 +6,18 @@
 
   export let open = false;
   export let vault: TokenVault;
-  let amount: string = '';
-  let amountRaw: bigint;
+  let amount: bigint;
   let isSubmitting = false;
 
   function reset() {
-    amount = '';
-    amountRaw = 0n;
+    amount = 0n;
     isSubmitting = false;
     open = false;
   }
 
   async function execute() {
     isSubmitting = true;
-    await vaultDeposit(vault.vault.vault_id, vault.token.id, amountRaw);
+    await vaultDeposit(vault.vault.vault_id, vault.token.id, amount);
     reset();
     isSubmitting = false;
   }
@@ -75,7 +73,6 @@
     <ButtonGroup class="w-full">
       <InputTokenAmount
         bind:value={amount}
-        bind:valueRaw={amountRaw}
         symbol={vault.token.symbol}
         decimals={vault.token.decimals}
       />
@@ -85,7 +82,7 @@
   <svelte:fragment slot="footer">
     <div class="flex w-full justify-end space-x-4">
       <Button color="alternative" on:click={reset} disabled={isSubmitting}>Cancel</Button>
-      <Button on:click={execute} disabled={!amountRaw || amountRaw === 0n || isSubmitting}>
+      <Button on:click={execute} disabled={!amount || amount === 0n || isSubmitting}>
         {#if isSubmitting}
           <Spinner class="mr-2 h-4 w-4" color="white" />
         {/if}

--- a/tauri-app/src/lib/ModalVaultDeposit.svelte
+++ b/tauri-app/src/lib/ModalVaultDeposit.svelte
@@ -17,8 +17,11 @@
 
   async function execute() {
     isSubmitting = true;
-    await vaultDeposit(vault.vault.vault_id, vault.token.id, amount);
-    reset();
+    try {
+      await vaultDeposit(vault.vault.vault_id, vault.token.id, amount);
+      reset();
+      // eslint-disable-next-line no-empty
+    } catch (e) {}
     isSubmitting = false;
   }
 </script>

--- a/tauri-app/src/lib/ModalVaultDepositGeneric.svelte
+++ b/tauri-app/src/lib/ModalVaultDepositGeneric.svelte
@@ -7,30 +7,24 @@
 
   export let open = false;
 
-  let vaultId: string = '';
-  let vaultIdRaw: bigint = 0n;
+  let vaultId: bigint = 0n;
   let tokenAddress: string = '';
-  let tokenDecimals: string = '';
-  let tokenDecimalsRaw: number = 0;
-  let amount: string = '';
-  let amountRaw: bigint;
+  let tokenDecimals: number = 0;
+  let amount: bigint;
   let isSubmitting = false;
 
   function reset() {
-    vaultId = '';
-    vaultIdRaw = 0n;
+    vaultId = 0n;
     tokenAddress = '';
-    tokenDecimals = '';
-    tokenDecimalsRaw = 0;
-    amount = '';
-    amountRaw = 0n;
+    tokenDecimals = 0;
+    amount = 0n;
     isSubmitting = false;
     open = false;
   }
 
   async function execute() {
     isSubmitting = true;
-    await vaultDeposit(vaultIdRaw, tokenAddress, amountRaw);
+    await vaultDeposit(vaultId, tokenAddress, amount);
     reset();
     isSubmitting = false;
   }
@@ -41,18 +35,14 @@
     <h5 class="mb-2 w-full text-xl font-bold tracking-tight text-gray-900 dark:text-white">
       Vault ID
     </h5>
-    <InputVaultId bind:value={vaultId} bind:valueRaw={vaultIdRaw} />
+    <InputVaultId bind:value={vaultId} />
   </div>
 
   <div>
     <h5 class="mb-2 w-full text-xl font-bold tracking-tight text-gray-900 dark:text-white">
       Token
     </h5>
-    <InputToken
-      bind:address={tokenAddress}
-      bind:decimals={tokenDecimals}
-      bind:decimalsRaw={tokenDecimalsRaw}
-    />
+    <InputToken bind:address={tokenAddress} bind:decimals={tokenDecimals} />
   </div>
 
   <div class="mb-6">
@@ -62,13 +52,13 @@
     >
       Amount
     </Label>
-    <InputTokenAmount bind:value={amount} bind:valueRaw={amountRaw} decimals={tokenDecimalsRaw} />
+    <InputTokenAmount bind:value={amount} decimals={tokenDecimals} />
   </div>
 
   <svelte:fragment slot="footer">
     <div class="flex w-full justify-end space-x-4">
       <Button color="alternative" on:click={reset} disabled={isSubmitting}>Cancel</Button>
-      <Button on:click={execute} disabled={!amountRaw || amountRaw === 0n || isSubmitting}>
+      <Button on:click={execute} disabled={!amount || amount === 0n || isSubmitting}>
         {#if isSubmitting}
           <Spinner class="mr-2 h-4 w-4" color="white" />
         {/if}

--- a/tauri-app/src/lib/ModalVaultDepositGeneric.svelte
+++ b/tauri-app/src/lib/ModalVaultDepositGeneric.svelte
@@ -6,7 +6,6 @@
   import InputVaultId from './InputVaultId.svelte';
 
   export let open = false;
-
   let vaultId: bigint = 0n;
   let tokenAddress: string = '';
   let tokenDecimals: number = 0;
@@ -24,8 +23,11 @@
 
   async function execute() {
     isSubmitting = true;
-    await vaultDeposit(vaultId, tokenAddress, amount);
-    reset();
+    try {
+      await vaultDeposit(vaultId, tokenAddress, amount);
+      reset();
+      // eslint-disable-next-line no-empty
+    } catch (e) {}
     isSubmitting = false;
   }
 </script>
@@ -57,8 +59,8 @@
 
   <svelte:fragment slot="footer">
     <div class="flex w-full justify-end space-x-4">
-      <Button color="alternative" on:click={reset} disabled={isSubmitting}>Cancel</Button>
-      <Button on:click={execute} disabled={!amount || amount === 0n || isSubmitting}>
+      <Button color="alternative" on:click={reset} disabled={$isSubmitting}>Cancel</Button>
+      <Button on:click={execute} disabled={!amount || amount === 0n || $isSubmitting}>
         {#if isSubmitting}
           <Spinner class="mr-2 h-4 w-4" color="white" />
         {/if}

--- a/tauri-app/src/lib/ModalVaultDepositGeneric.svelte
+++ b/tauri-app/src/lib/ModalVaultDepositGeneric.svelte
@@ -1,20 +1,27 @@
 <script lang="ts">
-  import { Button, Modal, Label, Spinner, Input, Helper } from 'flowbite-svelte';
+  import { Button, Modal, Label, Spinner } from 'flowbite-svelte';
   import InputTokenAmount from '$lib/InputTokenAmount.svelte';
   import { vaultDeposit } from '$lib/utils/vaultDeposit';
   import InputToken from '$lib/InputToken.svelte';
+  import InputVaultId from './InputVaultId.svelte';
 
   export let open = false;
 
-  let vaultId: bigint;
-  let tokenAddress: string;
-  let tokenDecimals: number;
-
+  let vaultId: string = '';
+  let vaultIdRaw: bigint = 0n;
+  let tokenAddress: string = '';
+  let tokenDecimals: string = '';
+  let tokenDecimalsRaw: number = 0;
   let amount: string = '';
   let amountRaw: bigint;
   let isSubmitting = false;
 
   function reset() {
+    vaultId = '';
+    vaultIdRaw = 0n;
+    tokenAddress = '';
+    tokenDecimals = '';
+    tokenDecimalsRaw = 0;
     amount = '';
     amountRaw = 0n;
     isSubmitting = false;
@@ -23,28 +30,29 @@
 
   async function execute() {
     isSubmitting = true;
-    await vaultDeposit(vaultId, tokenAddress, amountRaw);
+    await vaultDeposit(vaultIdRaw, tokenAddress, amountRaw);
     reset();
     isSubmitting = false;
   }
 </script>
 
-<Modal title="Withdraw from Vault" bind:open outsideclose size="sm" on:close={reset}>
+<Modal title="Deposit to Vault" bind:open outsideclose size="sm" on:close={reset}>
   <div>
     <h5 class="mb-2 w-full text-xl font-bold tracking-tight text-gray-900 dark:text-white">
       Vault ID
     </h5>
-    <Input label="Vault ID" name="vaultId" required bind:value={vaultId} />
-    <Helper class="mt-2 text-sm">
-      A hex identifier to distinguish this Vault from others with the same Token and Owner
-    </Helper>
+    <InputVaultId bind:value={vaultId} bind:valueRaw={vaultIdRaw} />
   </div>
 
   <div>
     <h5 class="mb-2 w-full text-xl font-bold tracking-tight text-gray-900 dark:text-white">
       Token
     </h5>
-    <InputToken bind:address={tokenAddress} bind:decimalsRaw={tokenDecimals} />
+    <InputToken
+      bind:address={tokenAddress}
+      bind:decimals={tokenDecimals}
+      bind:decimalsRaw={tokenDecimalsRaw}
+    />
   </div>
 
   <div class="mb-6">
@@ -54,7 +62,7 @@
     >
       Amount
     </Label>
-    <InputTokenAmount bind:value={amount} bind:valueRaw={amountRaw} decimals={tokenDecimals} />
+    <InputTokenAmount bind:value={amount} bind:valueRaw={amountRaw} decimals={tokenDecimalsRaw} />
   </div>
 
   <svelte:fragment slot="footer">

--- a/tauri-app/src/lib/ModalVaultDepositGeneric.svelte
+++ b/tauri-app/src/lib/ModalVaultDepositGeneric.svelte
@@ -1,0 +1,71 @@
+<script lang="ts">
+  import { Button, Modal, Label, Spinner, Input, Helper } from 'flowbite-svelte';
+  import InputTokenAmount from '$lib/InputTokenAmount.svelte';
+  import { vaultDeposit } from '$lib/utils/vaultDeposit';
+  import InputToken from '$lib/InputToken.svelte';
+
+  export let open = false;
+
+  let vaultId: bigint;
+  let tokenAddress: string;
+  let tokenDecimals: number;
+
+  let amount: string = '';
+  let amountRaw: bigint;
+  let isSubmitting = false;
+
+  function reset() {
+    amount = '';
+    amountRaw = 0n;
+    isSubmitting = false;
+    open = false;
+  }
+
+  async function execute() {
+    isSubmitting = true;
+    await vaultDeposit(vaultId, tokenAddress, amountRaw);
+    reset();
+    isSubmitting = false;
+  }
+</script>
+
+<Modal title="Withdraw from Vault" bind:open outsideclose size="sm" on:close={reset}>
+  <div>
+    <h5 class="mb-2 w-full text-xl font-bold tracking-tight text-gray-900 dark:text-white">
+      Vault ID
+    </h5>
+    <Input label="Vault ID" name="vaultId" required bind:value={vaultId} />
+    <Helper class="mt-2 text-sm">
+      A hex identifier to distinguish this Vault from others with the same Token and Owner
+    </Helper>
+  </div>
+
+  <div>
+    <h5 class="mb-2 w-full text-xl font-bold tracking-tight text-gray-900 dark:text-white">
+      Token
+    </h5>
+    <InputToken bind:address={tokenAddress} bind:decimalsRaw={tokenDecimals} />
+  </div>
+
+  <div class="mb-6">
+    <Label
+      for="amount"
+      class="mb-2 w-full text-xl font-bold tracking-tight text-gray-900 dark:text-white"
+    >
+      Amount
+    </Label>
+    <InputTokenAmount bind:value={amount} bind:valueRaw={amountRaw} decimals={tokenDecimals} />
+  </div>
+
+  <svelte:fragment slot="footer">
+    <div class="flex w-full justify-end space-x-4">
+      <Button color="alternative" on:click={reset} disabled={isSubmitting}>Cancel</Button>
+      <Button on:click={execute} disabled={!amountRaw || amountRaw === 0n || isSubmitting}>
+        {#if isSubmitting}
+          <Spinner class="mr-2 h-4 w-4" color="white" />
+        {/if}
+        Submit Deposit
+      </Button>
+    </div>
+  </svelte:fragment>
+</Modal>

--- a/tauri-app/src/lib/ModalVaultDepositGeneric.svelte
+++ b/tauri-app/src/lib/ModalVaultDepositGeneric.svelte
@@ -59,8 +59,8 @@
 
   <svelte:fragment slot="footer">
     <div class="flex w-full justify-end space-x-4">
-      <Button color="alternative" on:click={reset} disabled={$isSubmitting}>Cancel</Button>
-      <Button on:click={execute} disabled={!amount || amount === 0n || $isSubmitting}>
+      <Button color="alternative" on:click={reset} disabled={isSubmitting}>Cancel</Button>
+      <Button on:click={execute} disabled={!amount || amount === 0n || isSubmitting}>
         {#if isSubmitting}
           <Spinner class="mr-2 h-4 w-4" color="white" />
         {/if}

--- a/tauri-app/src/lib/ModalVaultWithdraw.svelte
+++ b/tauri-app/src/lib/ModalVaultWithdraw.svelte
@@ -70,7 +70,7 @@
       for="amount"
       class="mb-2 w-full text-xl font-bold tracking-tight text-gray-900 dark:text-white"
     >
-      Amount
+      Target Amount
     </Label>
     <InputTokenAmount
       bind:value={amount}
@@ -81,7 +81,7 @@
 
     <Helper color="red" class="h-6 text-sm">
       {#if amountGTBalance}
-        Amount cannot exceed available balance.
+        Target amount cannot exceed available balance.
       {/if}
     </Helper>
   </div>

--- a/tauri-app/src/lib/ModalVaultWithdraw.svelte
+++ b/tauri-app/src/lib/ModalVaultWithdraw.svelte
@@ -19,8 +19,11 @@
 
   async function execute() {
     isSubmitting = true;
-    await vaultWithdraw(vault.vault.vault_id, vault.token.id, amount);
-    reset();
+    try {
+      await vaultWithdraw(vault.vault.vault_id, vault.token.id, amount);
+      reset();
+      // eslint-disable-next-line no-empty
+    } catch (e) {}
     isSubmitting = false;
   }
 </script>

--- a/tauri-app/src/lib/ModalVaultWithdraw.svelte
+++ b/tauri-app/src/lib/ModalVaultWithdraw.svelte
@@ -6,22 +6,20 @@
 
   export let open = false;
   export let vault: TokenVault;
-  let amount: string = '';
-  let amountRaw: bigint = 0n;
+  let amount: bigint = 0n;
   let amountGTBalance: boolean;
   let isSubmitting = false;
 
-  $: amountGTBalance = vault !== undefined && amountRaw > vault.balance;
+  $: amountGTBalance = vault !== undefined && amount > vault.balance;
 
   function reset() {
-    amount = '';
-    amountRaw = 0n;
+    amount = 0n;
     open = false;
   }
 
   async function execute() {
     isSubmitting = true;
-    await vaultWithdraw(vault.vault.vault_id, vault.token.id, amountRaw);
+    await vaultWithdraw(vault.vault.vault_id, vault.token.id, amount);
     reset();
     isSubmitting = false;
   }
@@ -73,10 +71,9 @@
     </Label>
     <InputTokenAmount
       bind:value={amount}
-      bind:valueRaw={amountRaw}
       symbol={vault.token.symbol}
       decimals={vault.token.decimals}
-      maxValueRaw={vault.balance}
+      maxValue={vault.balance}
     />
 
     <Helper color="red" class="h-6 text-sm">
@@ -92,7 +89,7 @@
 
       <Button
         on:click={execute}
-        disabled={!amountRaw || amountRaw === 0n || amountGTBalance || isSubmitting}
+        disabled={!amount || amount === 0n || amountGTBalance || isSubmitting}
       >
         {#if isSubmitting}
           <Spinner class="mr-2 h-4 w-4" color="white" />

--- a/tauri-app/src/lib/ModalVaultWithdraw.svelte
+++ b/tauri-app/src/lib/ModalVaultWithdraw.svelte
@@ -3,6 +3,7 @@
   import type { TokenVault } from '$lib/typeshare/vault';
   import InputTokenAmount from './InputTokenAmount.svelte';
   import { vaultWithdraw } from '$lib/utils/vaultWithdraw';
+  import { toHex } from 'viem';
 
   export let open = false;
   export let vault: TokenVault;
@@ -34,7 +35,7 @@
       Vault ID
     </h5>
     <p class="break-all font-normal leading-tight text-gray-700 dark:text-gray-400">
-      {vault.vault.vault_id}
+      {toHex(vault.vault.vault_id)}
     </p>
   </div>
 

--- a/tauri-app/src/lib/ModalVaultWithdraw.svelte
+++ b/tauri-app/src/lib/ModalVaultWithdraw.svelte
@@ -11,7 +11,7 @@
   let amountGTBalance: boolean;
   let isSubmitting = false;
 
-  $: amountGTBalance = amountRaw > vault.balance;
+  $: amountGTBalance = vault !== undefined && amountRaw > vault.balance;
 
   function reset() {
     amount = '';

--- a/tauri-app/src/lib/ModalVaultWithdrawGeneric.svelte
+++ b/tauri-app/src/lib/ModalVaultWithdrawGeneric.svelte
@@ -24,8 +24,11 @@
 
   async function execute() {
     isSubmitting = true;
-    await vaultWithdraw(vaultId, tokenAddress, amount);
-    reset();
+    try {
+      await vaultWithdraw(vaultId, tokenAddress, amount);
+      reset();
+      // eslint-disable-next-line no-empty
+    } catch (e) {}
     isSubmitting = false;
   }
 </script>

--- a/tauri-app/src/lib/ModalVaultWithdrawGeneric.svelte
+++ b/tauri-app/src/lib/ModalVaultWithdrawGeneric.svelte
@@ -53,7 +53,7 @@
       for="amount"
       class="mb-2 w-full text-xl font-bold tracking-tight text-gray-900 dark:text-white"
     >
-      Amount
+      Target Amount
     </Label>
     <InputTokenAmount bind:value={amount} decimals={tokenDecimals} />
   </div>

--- a/tauri-app/src/lib/ModalVaultWithdrawGeneric.svelte
+++ b/tauri-app/src/lib/ModalVaultWithdrawGeneric.svelte
@@ -1,20 +1,27 @@
 <script lang="ts">
-  import { Button, Modal, Label, Spinner, Input, Helper } from 'flowbite-svelte';
+  import { Button, Modal, Label, Spinner } from 'flowbite-svelte';
   import InputTokenAmount from '$lib/InputTokenAmount.svelte';
   import { vaultWithdraw } from '$lib/utils/vaultWithdraw';
   import InputToken from '$lib/InputToken.svelte';
+  import InputVaultId from './InputVaultId.svelte';
 
   export let open = false;
 
-  let vaultId: bigint;
+  let vaultId: string;
+  let vaultIdRaw: bigint;
   let tokenAddress: string;
-  let tokenDecimals: number;
-
+  let tokenDecimals: string;
+  let tokenDecimalsRaw: number = 0;
   let amount: string = '';
   let amountRaw: bigint;
   let isSubmitting = false;
 
   function reset() {
+    vaultId = '';
+    vaultIdRaw = 0n;
+    tokenAddress = '';
+    tokenDecimals = '';
+    tokenDecimalsRaw = 0;
     amount = '';
     amountRaw = 0n;
     isSubmitting = false;
@@ -23,7 +30,7 @@
 
   async function execute() {
     isSubmitting = true;
-    await vaultWithdraw(vaultId, tokenAddress, amountRaw);
+    await vaultWithdraw(vaultIdRaw, tokenAddress, amountRaw);
     reset();
     isSubmitting = false;
   }
@@ -34,17 +41,18 @@
     <h5 class="mb-2 w-full text-xl font-bold tracking-tight text-gray-900 dark:text-white">
       Vault ID
     </h5>
-    <Input label="Vault ID" name="vaultId" required bind:value={vaultId} />
-    <Helper class="mt-2 text-sm">
-      A hex identifier to distinguish this Vault from others with the same Token and Owner
-    </Helper>
+    <InputVaultId bind:value={vaultId} bind:valueRaw={vaultIdRaw} />
   </div>
 
   <div>
     <h5 class="mb-2 w-full text-xl font-bold tracking-tight text-gray-900 dark:text-white">
       Token
     </h5>
-    <InputToken bind:address={tokenAddress} bind:decimalsRaw={tokenDecimals} />
+    <InputToken
+      bind:address={tokenAddress}
+      bind:decimals={tokenDecimals}
+      bind:decimalsRaw={tokenDecimalsRaw}
+    />
   </div>
 
   <div class="mb-6">
@@ -54,7 +62,7 @@
     >
       Amount
     </Label>
-    <InputTokenAmount bind:value={amount} bind:valueRaw={amountRaw} decimals={tokenDecimals} />
+    <InputTokenAmount bind:value={amount} bind:valueRaw={amountRaw} decimals={tokenDecimalsRaw} />
   </div>
 
   <svelte:fragment slot="footer">

--- a/tauri-app/src/lib/ModalVaultWithdrawGeneric.svelte
+++ b/tauri-app/src/lib/ModalVaultWithdrawGeneric.svelte
@@ -7,30 +7,24 @@
 
   export let open = false;
 
-  let vaultId: string;
-  let vaultIdRaw: bigint;
+  let vaultId: bigint;
   let tokenAddress: string;
-  let tokenDecimals: string;
-  let tokenDecimalsRaw: number = 0;
-  let amount: string = '';
-  let amountRaw: bigint;
+  let tokenDecimals: number = 0;
+  let amount: bigint;
   let isSubmitting = false;
 
   function reset() {
-    vaultId = '';
-    vaultIdRaw = 0n;
+    vaultId = 0n;
     tokenAddress = '';
-    tokenDecimals = '';
-    tokenDecimalsRaw = 0;
-    amount = '';
-    amountRaw = 0n;
+    tokenDecimals = 0;
+    amount = 0n;
     isSubmitting = false;
     open = false;
   }
 
   async function execute() {
     isSubmitting = true;
-    await vaultWithdraw(vaultIdRaw, tokenAddress, amountRaw);
+    await vaultWithdraw(vaultId, tokenAddress, amount);
     reset();
     isSubmitting = false;
   }
@@ -41,18 +35,14 @@
     <h5 class="mb-2 w-full text-xl font-bold tracking-tight text-gray-900 dark:text-white">
       Vault ID
     </h5>
-    <InputVaultId bind:value={vaultId} bind:valueRaw={vaultIdRaw} />
+    <InputVaultId bind:value={vaultId} />
   </div>
 
   <div>
     <h5 class="mb-2 w-full text-xl font-bold tracking-tight text-gray-900 dark:text-white">
       Token
     </h5>
-    <InputToken
-      bind:address={tokenAddress}
-      bind:decimals={tokenDecimals}
-      bind:decimalsRaw={tokenDecimalsRaw}
-    />
+    <InputToken bind:address={tokenAddress} bind:decimals={tokenDecimals} />
   </div>
 
   <div class="mb-6">
@@ -62,13 +52,13 @@
     >
       Amount
     </Label>
-    <InputTokenAmount bind:value={amount} bind:valueRaw={amountRaw} decimals={tokenDecimalsRaw} />
+    <InputTokenAmount bind:value={amount} decimals={tokenDecimals} />
   </div>
 
   <svelte:fragment slot="footer">
     <div class="flex w-full justify-end space-x-4">
       <Button color="alternative" on:click={reset} disabled={isSubmitting}>Cancel</Button>
-      <Button on:click={execute} disabled={!amountRaw || amountRaw === 0n || isSubmitting}>
+      <Button on:click={execute} disabled={!amount || amount === 0n || isSubmitting}>
         {#if isSubmitting}
           <Spinner class="mr-2 h-4 w-4" color="white" />
         {/if}

--- a/tauri-app/src/lib/ModalVaultWithdrawGeneric.svelte
+++ b/tauri-app/src/lib/ModalVaultWithdrawGeneric.svelte
@@ -1,0 +1,71 @@
+<script lang="ts">
+  import { Button, Modal, Label, Spinner, Input, Helper } from 'flowbite-svelte';
+  import InputTokenAmount from '$lib/InputTokenAmount.svelte';
+  import { vaultWithdraw } from '$lib/utils/vaultWithdraw';
+  import InputToken from '$lib/InputToken.svelte';
+
+  export let open = false;
+
+  let vaultId: bigint;
+  let tokenAddress: string;
+  let tokenDecimals: number;
+
+  let amount: string = '';
+  let amountRaw: bigint;
+  let isSubmitting = false;
+
+  function reset() {
+    amount = '';
+    amountRaw = 0n;
+    isSubmitting = false;
+    open = false;
+  }
+
+  async function execute() {
+    isSubmitting = true;
+    await vaultWithdraw(vaultId, tokenAddress, amountRaw);
+    reset();
+    isSubmitting = false;
+  }
+</script>
+
+<Modal title="Withdraw from Vault" bind:open outsideclose size="sm" on:close={reset}>
+  <div>
+    <h5 class="mb-2 w-full text-xl font-bold tracking-tight text-gray-900 dark:text-white">
+      Vault ID
+    </h5>
+    <Input label="Vault ID" name="vaultId" required bind:value={vaultId} />
+    <Helper class="mt-2 text-sm">
+      A hex identifier to distinguish this Vault from others with the same Token and Owner
+    </Helper>
+  </div>
+
+  <div>
+    <h5 class="mb-2 w-full text-xl font-bold tracking-tight text-gray-900 dark:text-white">
+      Token
+    </h5>
+    <InputToken bind:address={tokenAddress} bind:decimalsRaw={tokenDecimals} />
+  </div>
+
+  <div class="mb-6">
+    <Label
+      for="amount"
+      class="mb-2 w-full text-xl font-bold tracking-tight text-gray-900 dark:text-white"
+    >
+      Amount
+    </Label>
+    <InputTokenAmount bind:value={amount} bind:valueRaw={amountRaw} decimals={tokenDecimals} />
+  </div>
+
+  <svelte:fragment slot="footer">
+    <div class="flex w-full justify-end space-x-4">
+      <Button color="alternative" on:click={reset} disabled={isSubmitting}>Cancel</Button>
+      <Button on:click={execute} disabled={!amountRaw || amountRaw === 0n || isSubmitting}>
+        {#if isSubmitting}
+          <Spinner class="mr-2 h-4 w-4" color="white" />
+        {/if}
+        Make Withdrawal
+      </Button>
+    </div>
+  </svelte:fragment>
+</Modal>

--- a/tauri-app/src/lib/utils/hex.ts
+++ b/tauri-app/src/lib/utils/hex.ts
@@ -1,0 +1,1 @@
+export const HEX_INPUT_REGEX = /^(0x)?([0-9a-f]+)?$/;

--- a/tauri-app/src/lib/utils/vaultDeposit.ts
+++ b/tauri-app/src/lib/utils/vaultDeposit.ts
@@ -2,8 +2,6 @@ import { get } from 'svelte/store';
 import { invoke } from '@tauri-apps/api';
 import { rpcUrl, orderbookAddress, walletDerivationIndex } from '../stores/settings';
 import { chainId } from '$lib/stores/chain';
-import { toasts } from '$lib/stores/toasts';
-import { ToastMessageType } from '$lib/typeshare/toast';
 
 export async function vaultDeposit(vaultId: bigint, token: string, amount: bigint) {
   try {
@@ -22,10 +20,6 @@ export async function vaultDeposit(vaultId: bigint, token: string, amount: bigin
         max_fee_per_gas: '400000000000',
       }
     });
-  }  catch(e) {
-    toasts.add({
-      message_type: ToastMessageType.Error,
-      text: e as string
-    });
-  }
+  // eslint-disable-next-line no-empty
+  } catch(e) { }
 };

--- a/tauri-app/src/lib/utils/vaultDeposit.ts
+++ b/tauri-app/src/lib/utils/vaultDeposit.ts
@@ -4,22 +4,19 @@ import { rpcUrl, orderbookAddress, walletDerivationIndex } from '../stores/setti
 import { chainId } from '$lib/stores/chain';
 
 export async function vaultDeposit(vaultId: bigint, token: string, amount: bigint) {
-  try {
-    await invoke("vault_deposit", {
-      depositArgs: {
-        vault_id: vaultId.toString(),
-        token,
-        amount: amount.toString(),
-      },
-      transactionArgs: {
-        rpc_url: get(rpcUrl),
-        orderbook_address: get(orderbookAddress),
-        derivation_index: get(walletDerivationIndex),
-        chain_id: get(chainId),
-        max_priority_fee_per_gas: '400000000000',
-        max_fee_per_gas: '400000000000',
-      }
-    });
-  // eslint-disable-next-line no-empty
-  } catch(e) { }
-};
+  await invoke("vault_deposit", {
+    depositArgs: {
+      vault_id: vaultId.toString(),
+      token,
+      amount: amount.toString(),
+    },
+    transactionArgs: {
+      rpc_url: get(rpcUrl),
+      orderbook_address: get(orderbookAddress),
+      derivation_index: get(walletDerivationIndex),
+      chain_id: get(chainId),
+      max_priority_fee_per_gas: '400000000000',
+      max_fee_per_gas: '400000000000',
+    }
+  });
+}

--- a/tauri-app/src/lib/utils/vaultWithdraw.ts
+++ b/tauri-app/src/lib/utils/vaultWithdraw.ts
@@ -4,22 +4,19 @@ import { rpcUrl, orderbookAddress, walletDerivationIndex } from '../stores/setti
 import { chainId } from '$lib/stores/chain';
 
 export async function vaultWithdraw(vaultId: bigint, token: string, targetAmount: bigint) {
-  try {
-    await invoke("vault_withdraw", {
-      withdrawArgs: {
-        vault_id: vaultId.toString(),
-        token,
-        target_amount: targetAmount.toString(),
-      },
-      transactionArgs: {
-        rpc_url: get(rpcUrl),
-        orderbook_address: get(orderbookAddress),
-        derivation_index: get(walletDerivationIndex),
-        chain_id: get(chainId),
-        max_priority_fee_per_gas: '400000000000',
-        max_fee_per_gas: '400000000000',
-      }
-    });
-  // eslint-disable-next-line no-empty
-  } catch(e) { }
-};
+  await invoke("vault_withdraw", {
+    withdrawArgs: {
+      vault_id: vaultId.toString(),
+      token,
+      target_amount: targetAmount.toString(),
+    },
+    transactionArgs: {
+      rpc_url: get(rpcUrl),
+      orderbook_address: get(orderbookAddress),
+      derivation_index: get(walletDerivationIndex),
+      chain_id: get(chainId),
+      max_priority_fee_per_gas: '400000000000',
+      max_fee_per_gas: '400000000000',
+    }
+  });
+}

--- a/tauri-app/src/lib/utils/vaultWithdraw.ts
+++ b/tauri-app/src/lib/utils/vaultWithdraw.ts
@@ -2,8 +2,6 @@ import { get } from 'svelte/store';
 import { invoke } from '@tauri-apps/api';
 import { rpcUrl, orderbookAddress, walletDerivationIndex } from '../stores/settings';
 import { chainId } from '$lib/stores/chain';
-import { toasts } from '$lib/stores/toasts';
-import { ToastMessageType } from '$lib/typeshare/toast';
 
 export async function vaultWithdraw(vaultId: bigint, token: string, targetAmount: bigint) {
   try {
@@ -22,10 +20,6 @@ export async function vaultWithdraw(vaultId: bigint, token: string, targetAmount
         max_fee_per_gas: '400000000000',
       }
     });
-  } catch(e) {
-    toasts.add({
-      message_type: ToastMessageType.Error,
-      text: e as string
-    });
-  }
+  // eslint-disable-next-line no-empty
+  } catch(e) { }
 };

--- a/tauri-app/src/routes/vaults/+page.svelte
+++ b/tauri-app/src/routes/vaults/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { redirectIfSettingsNotDefined } from '$lib/utils/redirect';
   import {
-    Heading,
+    Button,
     Table,
     TableBody,
     TableBodyCell,
@@ -20,7 +20,16 @@
   vaultsList.refetch();
 </script>
 
-<Heading tag="h1" class="mb-8 text-center text-4xl font-bold">Vaults</Heading>
+<div class="flex w-full">
+  <div class="flex-1"></div>
+  <h1 class="flex-0 mb-8 text-4xl font-bold text-gray-900 dark:text-white">Vaults</h1>
+  <div class="flex-1">
+    <div class="flex justify-end space-x-2">
+      <Button color="green" size="xs" on:click={toggleDepositModal}>Deposit</Button>
+      <Button color="blue" size="xs" on:click={toggleWithdrawModal}>Withdraw</Button>
+    </div>
+  </div>
+</div>
 
 {#if $vaultsList.length === 0}
   <div class="text-center text-gray-900 dark:text-white">No Vaults found</div>

--- a/tauri-app/src/routes/vaults/+page.svelte
+++ b/tauri-app/src/routes/vaults/+page.svelte
@@ -13,6 +13,7 @@
   import { vaultsList } from '$lib/stores/vaultsList';
   import ModalVaultDepositGeneric from '$lib/ModalVaultDepositGeneric.svelte';
   import ModalVaultWithdrawGeneric from '$lib/ModalVaultWithdrawGeneric.svelte';
+  import { toHex } from 'viem';
 
   let showDepositModal = false;
   let showWithdrawModal = false;
@@ -56,7 +57,7 @@
     <TableBody>
       {#each $vaultsList as vault}
         <TableBodyRow on:click={() => gotoVault(vault.id)}>
-          <TableBodyCell tdClass="break-all px-4 py-2">{vault.vault_id}</TableBodyCell>
+          <TableBodyCell tdClass="break-all px-4 py-2">{toHex(vault.vault_id)}</TableBodyCell>
           <TableBodyCell tdClass="break-all px-4 py-2">{vault.owner.id}</TableBodyCell>
           <TableBodyCell tdClass="break-word p-2">{vault.token.name}</TableBodyCell>
           <TableBodyCell tdClass="break-all p-2">

--- a/tauri-app/src/routes/vaults/+page.svelte
+++ b/tauri-app/src/routes/vaults/+page.svelte
@@ -11,9 +11,21 @@
   } from 'flowbite-svelte';
   import { goto } from '$app/navigation';
   import { vaultsList } from '$lib/stores/vaultsList';
+  import ModalVaultDepositGeneric from '$lib/ModalVaultDepositGeneric.svelte';
+  import ModalVaultWithdrawGeneric from '$lib/ModalVaultWithdrawGeneric.svelte';
+
+  let showDepositModal = false;
+  let showWithdrawModal = false;
 
   function gotoVault(id: string) {
     goto(`/vaults/${id}`);
+  }
+
+  function toggleDepositModal() {
+    showDepositModal = !showDepositModal;
+  }
+  function toggleWithdrawModal() {
+    showWithdrawModal = !showWithdrawModal;
   }
 
   redirectIfSettingsNotDefined();
@@ -56,3 +68,6 @@
     </TableBody>
   </Table>
 {/if}
+
+<ModalVaultDepositGeneric bind:open={showDepositModal} />
+<ModalVaultWithdrawGeneric bind:open={showWithdrawModal} />

--- a/tauri-app/src/routes/vaults/[id]/+page.svelte
+++ b/tauri-app/src/routes/vaults/[id]/+page.svelte
@@ -17,6 +17,7 @@
   import utc from 'dayjs/plugin/utc';
   import bigIntSupport from 'dayjs/plugin/bigIntSupport';
   import ModalVaultWithdraw from '$lib/ModalVaultWithdraw.svelte';
+  import { walletAddress } from '$lib/stores/settings';
   dayjs.extend(utc);
   dayjs.extend(bigIntSupport);
 
@@ -86,12 +87,14 @@
         </p>
       </div>
 
-      <div class="pt-4">
-        <div class="flex justify-center space-x-20">
-          <Button color="green" size="xl" on:click={toggleDepositModal}>Deposit</Button>
-          <Button color="blue" size="xl" on:click={toggleWithdrawModal}>Withdraw</Button>
+      {#if $walletAddress !== '' && vault.owner.id === $walletAddress}
+        <div class="pt-4">
+          <div class="flex justify-center space-x-20">
+            <Button color="green" size="xl" on:click={toggleDepositModal}>Deposit</Button>
+            <Button color="blue" size="xl" on:click={toggleWithdrawModal}>Withdraw</Button>
+          </div>
         </div>
-      </div>
+      {/if}
     </Card>
 
     <div class="max-w-screen-xl space-y-12">

--- a/tauri-app/src/routes/vaults/[id]/+page.svelte
+++ b/tauri-app/src/routes/vaults/[id]/+page.svelte
@@ -18,6 +18,7 @@
   import bigIntSupport from 'dayjs/plugin/bigIntSupport';
   import ModalVaultWithdraw from '$lib/ModalVaultWithdraw.svelte';
   import { walletAddress } from '$lib/stores/settings';
+  import { toHex } from 'viem';
   dayjs.extend(utc);
   dayjs.extend(bigIntSupport);
 
@@ -55,7 +56,7 @@
           Vault ID
         </h5>
         <p class="break-all font-normal leading-tight text-gray-700 dark:text-gray-400">
-          {vault.vault.vault_id}
+          {toHex(vault.vault.vault_id)}
         </p>
       </div>
 

--- a/tauri-app/src/tests/hex.test.ts
+++ b/tauri-app/src/tests/hex.test.ts
@@ -1,0 +1,49 @@
+// sum.test.js
+import { expect, test } from 'vitest'
+import { HEX_INPUT_REGEX } from '../lib/utils/hex';
+
+
+test('HEX_INPUT_REGEX matches user typing hex input', () => {
+  expect(HEX_INPUT_REGEX.test('a')).toBeTruthy();
+  expect(HEX_INPUT_REGEX.test('ab')).toBeTruthy();
+  expect(HEX_INPUT_REGEX.test('abc')).toBeTruthy();
+  expect(HEX_INPUT_REGEX.test('abcdef1234567890')).toBeTruthy();
+  expect(HEX_INPUT_REGEX.test('1')).toBeTruthy();
+  expect(HEX_INPUT_REGEX.test('12')).toBeTruthy();
+  expect(HEX_INPUT_REGEX.test('123')).toBeTruthy();
+  expect(HEX_INPUT_REGEX.test('1234567890abcdef')).toBeTruthy();
+});
+
+test('HEX_INPUT_REGEX matches user typing hex input prefixed by "0x"', () => {
+  expect(HEX_INPUT_REGEX.test('0')).toBeTruthy();
+  expect(HEX_INPUT_REGEX.test('0x')).toBeTruthy();
+  expect(HEX_INPUT_REGEX.test('0xa')).toBeTruthy();
+  expect(HEX_INPUT_REGEX.test('0xab')).toBeTruthy();
+  expect(HEX_INPUT_REGEX.test('0xabc')).toBeTruthy();
+  expect(HEX_INPUT_REGEX.test('0xabcdef1234567890')).toBeTruthy();
+  expect(HEX_INPUT_REGEX.test('0x1')).toBeTruthy();
+  expect(HEX_INPUT_REGEX.test('0x12')).toBeTruthy();
+  expect(HEX_INPUT_REGEX.test('0x123')).toBeTruthy();
+  expect(HEX_INPUT_REGEX.test('0x1234567890abcdef')).toBeTruthy();
+});
+
+test('HEX_INPUT_REGEX does not match user typing invalid hex input', () => {
+  expect(HEX_INPUT_REGEX.test('0xx')).toBeFalsy();
+  expect(HEX_INPUT_REGEX.test('0xg')).toBeFalsy();
+  expect(HEX_INPUT_REGEX.test('0xag')).toBeFalsy();
+  expect(HEX_INPUT_REGEX.test('0xabg')).toBeFalsy();
+  expect(HEX_INPUT_REGEX.test('0xabcdef1234567890g')).toBeFalsy();
+  expect(HEX_INPUT_REGEX.test('0x1g')).toBeFalsy();
+  expect(HEX_INPUT_REGEX.test('0x12g')).toBeFalsy();
+  expect(HEX_INPUT_REGEX.test('0x123g')).toBeFalsy();
+  expect(HEX_INPUT_REGEX.test('0x1234567890abcdefg')).toBeFalsy();
+
+  expect(HEX_INPUT_REGEX.test('g')).toBeFalsy();
+  expect(HEX_INPUT_REGEX.test('ag')).toBeFalsy();
+  expect(HEX_INPUT_REGEX.test('abg')).toBeFalsy();
+  expect(HEX_INPUT_REGEX.test('abcdef1234567890g')).toBeFalsy();
+  expect(HEX_INPUT_REGEX.test('1g')).toBeFalsy();
+  expect(HEX_INPUT_REGEX.test('12g')).toBeFalsy();
+  expect(HEX_INPUT_REGEX.test('123g')).toBeFalsy();
+  expect(HEX_INPUT_REGEX.test('1234567890abcdefg')).toBeFalsy();
+});


### PR DESCRIPTION
Resolves #135

**overview**
- only show 'deposit' and 'withdraw' buttons on Vault Detail page if wallet address in settings matches owner address of vault
- add 'deposit' and 'withdraw' buttons to Vault List page -- clicking them opens a generic model, where the user can enter a vault id, token address, token decimals, and amount
  - vault id input field is masked to hexadecimal values only (optionally prefixed with "0x")
  - decimals field is masked to integers only
- basic test for hexadecimal field input mask regex
  - add nix command to run ui tests with vitest: `ob-tauri-test`
  - run `ob-tauri-test` nix command in ci
- always display vault id as hex
- minor refactoring of input wrapper svelte components
- avoid duplicate errors toasts from failed transactions

![image](https://github.com/rainlanguage/rain.orderbook/assets/159270/2751c166-6bd2-48b6-9802-cbcbedd96f0b)
![image](https://github.com/rainlanguage/rain.orderbook/assets/159270/93fd3fa8-b209-4a88-a9ef-9d9cba5e6264)
![image](https://github.com/rainlanguage/rain.orderbook/assets/159270/7f1e4dec-d878-45fc-8544-6cf08e9204ff)
![image](https://github.com/rainlanguage/rain.orderbook/assets/159270/660942bd-eb53-4b7f-a2db-112ec6645796)
