### PR TITLE
WIP 2024 01 28 cli remove order

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3697,9 +3697,12 @@ dependencies = [
 name = "rain_orderbook_subgraph_queries"
 version = "0.0.1"
 dependencies = [
+ "alloy-primitives 0.5.4",
  "cynic",
  "cynic-codegen",
+ "rain_orderbook_bindings",
  "reqwest",
+ "ruint",
  "serde",
  "thiserror",
  "typeshare",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ chrono = "0.4.31"
 typeshare = "1.0.1"
 thiserror = "1.0.56"
 strict-yaml-rust = "0.1.2"
+ruint = "1.11.1"
 dotrain = { git = "https://github.com/rainlanguage/dotrain.git", rev = "8fcc7651df8abc49c72c648ac8e9c80b5e057e70" }
 rain-meta = { path = "lib/rain.metadata/crates/cli" }
 rain_interpreter_bindings = { path = "lib/rain.interpreter/crates/bindings" }

--- a/crates/cli/src/commands/order/detail.rs
+++ b/crates/cli/src/commands/order/detail.rs
@@ -6,7 +6,7 @@ use tracing::info;
 
 #[derive(Args, Clone)]
 pub struct CliOrderDetailArgs {
-    #[arg(short, long, help = "ID of the Order")]
+    #[arg(short='i', long, help = "ID of the Order")]
     order_id: String,
 }
 

--- a/crates/cli/src/commands/order/mod.rs
+++ b/crates/cli/src/commands/order/mod.rs
@@ -1,6 +1,7 @@
 mod add;
 mod detail;
 mod list;
+mod remove;
 
 use crate::execute::Execute;
 use add::AddOrder;
@@ -8,6 +9,7 @@ use anyhow::Result;
 use clap::Parser;
 use detail::Detail;
 use list::List;
+use remove::RemoveOrder;
 
 #[derive(Parser)]
 pub enum Order {
@@ -19,6 +21,9 @@ pub enum Order {
 
     #[command(about = "Create an Order", alias = "add")]
     Create(AddOrder),
+
+    #[command(about = "Remove an Order", alias = "rm")]
+    Remove(RemoveOrder),
 }
 
 impl Execute for Order {
@@ -27,6 +32,7 @@ impl Execute for Order {
             Order::List(list) => list.execute().await,
             Order::Detail(detail) => detail.execute().await,
             Order::Create(create) => create.execute().await,
+            Order::Remove(remove) => remove.execute().await,
         }
     }
 }

--- a/crates/cli/src/commands/order/remove.rs
+++ b/crates/cli/src/commands/order/remove.rs
@@ -18,7 +18,7 @@ impl Execute for RemoveOrder {
             .await?
             .order(self.cmd_args.order_id.clone().into())
             .await?;
-        let remove_order_args: RemoveOrderArgs = order.try_into()?;
+        let remove_order_args: RemoveOrderArgs = order.into();
 
         let mut tx_args: TransactionArgs = self.transaction_args.clone().into();
         tx_args.try_fill_chain_id().await?;

--- a/crates/cli/src/commands/order/remove.rs
+++ b/crates/cli/src/commands/order/remove.rs
@@ -1,13 +1,12 @@
 use crate::{
     execute::Execute, status::display_write_transaction_status,
-    transaction::CliTransactionCommandArgs,
+    transaction::CliTransactionSubgraphCommandArgs,
 };
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use clap::Args;
-use rain_orderbook_common::add_order::RemoveOrderArgs;
+use rain_orderbook_common::remove_order::RemoveOrderArgs;
+use rain_orderbook_common::subgraph::SubgraphArgs;
 use rain_orderbook_common::transaction::TransactionArgs;
-use std::fs::read_to_string;
-use std::path::PathBuf;
 
 pub type RemoveOrder = CliTransactionSubgraphCommandArgs<CliRemoveOrderArgs>;
 
@@ -18,8 +17,7 @@ impl Execute for RemoveOrder {
             .to_subgraph_client()
             .await?
             .order(self.cmd_args.order_id.clone().into())
-            .await?
-            .into();
+            .await?;
         let remove_order_args: RemoveOrderArgs = order.try_into()?;
 
         let mut tx_args: TransactionArgs = self.transaction_args.clone().into();
@@ -38,10 +36,6 @@ impl Execute for RemoveOrder {
 
 #[derive(Args, Clone)]
 pub struct CliRemoveOrderArgs {
-    #[arg(
-        short
-        long,
-        help = "ID of the Order"
-    )]
+    #[arg(short, long, help = "ID of the Order")]
     order_id: String,
 }

--- a/crates/cli/src/commands/order/remove.rs
+++ b/crates/cli/src/commands/order/remove.rs
@@ -36,6 +36,6 @@ impl Execute for RemoveOrder {
 
 #[derive(Args, Clone)]
 pub struct CliRemoveOrderArgs {
-    #[arg(short, long, help = "ID of the Order")]
+    #[arg(short='i', long, help = "ID of the Order")]
     order_id: String,
 }

--- a/crates/cli/src/commands/order/remove.rs
+++ b/crates/cli/src/commands/order/remove.rs
@@ -1,0 +1,47 @@
+use crate::{
+    execute::Execute, status::display_write_transaction_status,
+    transaction::CliTransactionCommandArgs,
+};
+use anyhow::{anyhow, Result};
+use clap::Args;
+use rain_orderbook_common::add_order::RemoveOrderArgs;
+use rain_orderbook_common::transaction::TransactionArgs;
+use std::fs::read_to_string;
+use std::path::PathBuf;
+
+pub type RemoveOrder = CliTransactionSubgraphCommandArgs<CliRemoveOrderArgs>;
+
+impl Execute for RemoveOrder {
+    async fn execute(&self) -> Result<()> {
+        let subgraph_args: SubgraphArgs = self.subgraph_args.clone().into();
+        let order = subgraph_args
+            .to_subgraph_client()
+            .await?
+            .order(self.cmd_args.order_id.clone().into())
+            .await?
+            .into();
+        let remove_order_args: RemoveOrderArgs = order.try_into()?;
+
+        let mut tx_args: TransactionArgs = self.transaction_args.clone().into();
+        tx_args.try_fill_chain_id().await?;
+
+        println!("----- Remove Order -----");
+        remove_order_args
+            .execute(tx_args, |status| {
+                display_write_transaction_status(status);
+            })
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[derive(Args, Clone)]
+pub struct CliRemoveOrderArgs {
+    #[arg(
+        short
+        long,
+        help = "ID of the Order"
+    )]
+    order_id: String,
+}

--- a/crates/cli/src/commands/vault/deposit.rs
+++ b/crates/cli/src/commands/vault/deposit.rs
@@ -37,7 +37,7 @@ pub struct CliDepositArgs {
     #[arg(short, long, help = "The token address in hex format")]
     token: Address,
 
-    #[arg(short, long, help = "The ID of the vault")]
+    #[arg(short='i', long, help = "The ID of the vault")]
     vault_id: U256,
 
     #[arg(short, long, help = "The amount to deposit")]

--- a/crates/cli/src/commands/vault/detail.rs
+++ b/crates/cli/src/commands/vault/detail.rs
@@ -6,7 +6,7 @@ use tracing::info;
 
 #[derive(Args, Clone)]
 pub struct CliVaultDetailArgs {
-    #[arg(short, long, help = "ID of the Vault")]
+    #[arg(short='i', long, help = "ID of the Vault")]
     vault_id: String,
 }
 

--- a/crates/cli/src/commands/vault/withdraw.rs
+++ b/crates/cli/src/commands/vault/withdraw.rs
@@ -29,7 +29,7 @@ pub struct CliWithdrawArgs {
     #[arg(short, long, help = "The token address in hex format")]
     token: Address,
 
-    #[arg(short, long, help = "The ID of the vault")]
+    #[arg(short='i', long, help = "The ID of the vault")]
     vault_id: U256,
 
     #[arg(short = 'a', long, help = "The target amount to withdraw")]

--- a/crates/cli/src/transaction.rs
+++ b/crates/cli/src/transaction.rs
@@ -1,3 +1,4 @@
+use crate::subgraph::CliSubgraphArgs;
 use alloy_primitives::{Address, U256};
 use clap::Args;
 use clap::FromArgMatches;
@@ -50,4 +51,16 @@ pub struct CliTransactionCommandArgs<T: FromArgMatches + Args> {
 
     #[clap(flatten)]
     pub transaction_args: CliTransactionArgs,
+}
+
+#[derive(Parser, Clone)]
+pub struct CliTransactionSubgraphCommandArgs<T: FromArgMatches + Args> {
+    #[clap(flatten)]
+    pub cmd_args: T,
+
+    #[clap(flatten)]
+    pub transaction_args: CliTransactionArgs,
+
+    #[clap(flatten)]
+    pub subgraph_args: CliSubgraphArgs,
 }

--- a/crates/common/src/add_order.rs
+++ b/crates/common/src/add_order.rs
@@ -17,7 +17,6 @@ use std::sync::{Arc, RwLock};
 use strict_yaml_rust::{scanner::ScanError, StrictYaml, StrictYamlLoader};
 use thiserror::Error;
 
-
 #[derive(Error, Debug)]
 pub enum AddOrderArgsError {
     #[error("frontmatter is not valid strict yaml: {0}")]
@@ -250,11 +249,10 @@ impl AddOrderArgs {
 #[cfg(test)]
 mod tests {
     use super::*;
-        
+
     #[test]
     fn test_try_parse_frontmatter() {
-        let frontmatter = 
-            "
+        let frontmatter = "
 orderbook:
     order:
         deployer: 0x1111111111111111111111111111111111111111
@@ -267,17 +265,31 @@ orderbook:
               decimals: 18
               vaultId: 0x2
 ";
-        let args = AddOrderArgs {
-            dotrain: "".into(),
-        };
+        let args = AddOrderArgs { dotrain: "".into() };
 
-        let (deployer, valid_inputs, valid_outputs) = args.try_parse_frontmatter(frontmatter).unwrap();
-        
-        assert_eq!(deployer, "0x1111111111111111111111111111111111111111".parse::<Address>().unwrap());
-        assert_eq!(valid_inputs[0].token, "0x0000000000000000000000000000000000000001".parse::<Address>().unwrap());
+        let (deployer, valid_inputs, valid_outputs) =
+            args.try_parse_frontmatter(frontmatter).unwrap();
+
+        assert_eq!(
+            deployer,
+            "0x1111111111111111111111111111111111111111"
+                .parse::<Address>()
+                .unwrap()
+        );
+        assert_eq!(
+            valid_inputs[0].token,
+            "0x0000000000000000000000000000000000000001"
+                .parse::<Address>()
+                .unwrap()
+        );
         assert_eq!(valid_inputs[0].decimals, 18);
         assert_eq!(valid_inputs[0].vaultId, U256::from(1));
-        assert_eq!(valid_outputs[0].token, "0x0000000000000000000000000000000000000002".parse::<Address>().unwrap());
+        assert_eq!(
+            valid_outputs[0].token,
+            "0x0000000000000000000000000000000000000002"
+                .parse::<Address>()
+                .unwrap()
+        );
         assert_eq!(valid_outputs[0].decimals, 18);
         assert_eq!(valid_outputs[0].vaultId, U256::from(2));
     }
@@ -291,11 +303,20 @@ price: 2e18;
 max-amount: 100e18,
 price: 2e18;
 ";
-        let args = AddOrderArgs {
-            dotrain: "".into()
-        };
+        let args = AddOrderArgs { dotrain: "".into() };
 
         let meta_bytes = args.try_generate_meta(rainlang).unwrap();
-        assert_eq!(meta_bytes, vec![255, 10, 137, 198, 116, 238, 120, 116, 163, 0, 88, 68, 10, 109, 97, 120, 45, 97, 109, 111, 117, 110, 116, 58, 32, 49, 48, 48, 101, 49, 56, 44, 10, 112, 114, 105, 99, 101, 58, 32, 50, 101, 49, 56, 59, 10, 10, 109, 97, 120, 45, 97, 109, 111, 117, 110, 116, 58, 32, 49, 48, 48, 101, 49, 56, 44, 10, 112, 114, 105, 99, 101, 58, 32, 50, 101, 49, 56, 59, 10, 1, 27, 255, 19, 16, 158, 65, 51, 111, 242, 2, 120, 24, 97, 112, 112, 108, 105, 99, 97, 116, 105, 111, 110, 47, 111, 99, 116, 101, 116, 45, 115, 116, 114, 101, 97, 109]); 
+        assert_eq!(
+            meta_bytes,
+            vec![
+                255, 10, 137, 198, 116, 238, 120, 116, 163, 0, 88, 68, 10, 109, 97, 120, 45, 97,
+                109, 111, 117, 110, 116, 58, 32, 49, 48, 48, 101, 49, 56, 44, 10, 112, 114, 105,
+                99, 101, 58, 32, 50, 101, 49, 56, 59, 10, 10, 109, 97, 120, 45, 97, 109, 111, 117,
+                110, 116, 58, 32, 49, 48, 48, 101, 49, 56, 44, 10, 112, 114, 105, 99, 101, 58, 32,
+                50, 101, 49, 56, 59, 10, 1, 27, 255, 19, 16, 158, 65, 51, 111, 242, 2, 120, 24, 97,
+                112, 112, 108, 105, 99, 97, 116, 105, 111, 110, 47, 111, 99, 116, 101, 116, 45,
+                115, 116, 114, 101, 97, 109
+            ]
+        );
     }
 }

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -4,3 +4,4 @@ pub mod error;
 pub mod subgraph;
 pub mod transaction;
 pub mod withdraw;
+pub mod remove_order;

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod add_order;
 pub mod deposit;
 pub mod error;
+pub mod remove_order;
 pub mod subgraph;
 pub mod transaction;
 pub mod withdraw;
-pub mod remove_order;

--- a/crates/common/src/remove_order.rs
+++ b/crates/common/src/remove_order.rs
@@ -1,0 +1,73 @@
+use crate::transaction::{TransactionArgs, TransactionArgsError};
+use alloy_ethers_typecast::transaction::{
+    WritableClientError, WriteTransaction, WriteTransactionStatus,
+};
+use alloy_primitives::hex::FromHexError;
+
+use rain_orderbook_bindings::IOrderBookV3::removeOrderCall;
+use rain_orderbook_subgraph_queries::types::{
+    order::Order as OrderDetail, order_traits::OrderDetailError,
+};
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum RemoveOrderArgsError {
+    #[error(transparent)]
+    WritableClientError(#[from] WritableClientError),
+    #[error(transparent)]
+    TransactionArgs(#[from] TransactionArgsError),
+    #[error(transparent)]
+    FromHexError(#[from] FromHexError),
+    #[error(transparent)]
+    OrderDetailError(#[from] OrderDetailError),
+}
+
+pub struct RemoveOrderArgs {
+    pub order: OrderDetail,
+}
+
+impl From<OrderDetail> for RemoveOrderArgs {
+    fn from(order: OrderDetail) -> Self {
+        Self { order }
+    }
+}
+
+impl TryInto<removeOrderCall> for RemoveOrderArgs {
+    type Error = OrderDetailError;
+
+    fn try_into(self) -> Result<removeOrderCall, OrderDetailError> {
+        Ok(removeOrderCall {
+            order: self.order.try_into()?,
+        })
+    }
+}
+
+impl RemoveOrderArgs {
+    pub async fn execute<S: Fn(WriteTransactionStatus<removeOrderCall>)>(
+        self,
+        transaction_args: TransactionArgs,
+        transaction_status_changed: S,
+    ) -> Result<(), RemoveOrderArgsError> {
+        let ledger_client = transaction_args
+            .clone()
+            .try_into_ledger_client()
+            .await
+            .map_err(RemoveOrderArgsError::TransactionArgs)?;
+
+        let remove_order_call: removeOrderCall = self.try_into()?;
+        let params = transaction_args
+            .try_into_write_contract_parameters(
+                remove_order_call,
+                transaction_args.orderbook_address,
+            )
+            .await
+            .map_err(RemoveOrderArgsError::TransactionArgs)?;
+
+        WriteTransaction::new(ledger_client.client, params, 4, transaction_status_changed)
+            .execute()
+            .await
+            .map_err(RemoveOrderArgsError::WritableClientError)?;
+
+        Ok(())
+    }
+}

--- a/crates/subgraph/Cargo.toml
+++ b/crates/subgraph/Cargo.toml
@@ -14,6 +14,9 @@ reqwest = { workspace = true }
 thiserror = { workspace = true }
 typeshare = { workspace = true }
 serde = { workspace = true }
+alloy-primitives = { workspace = true }
+rain_orderbook_bindings = { workspace = true }
+ruint = { workspace = true }
 
 [build-dependencies]
 cynic-codegen = { workspace = true }

--- a/crates/subgraph/queries/order.graphql
+++ b/crates/subgraph/queries/order.graphql
@@ -12,19 +12,27 @@ query OrderQuery($id: ID!) {
     timestamp
     handleIO
    	validInputs {
-      token {
+      tokenVault {
         id
-        name
-        symbol
-        decimals
+        vaultId
+        token {
+          id
+          name
+          symbol
+          decimals
+        }
       }
     }
     validOutputs {
-      token {
+      tokenVault {
         id
-        name
-        symbol
-        decimals
+        vaultId
+        token {
+          id
+          name
+          symbol
+          decimals
+        }
       }
     }
     meta {

--- a/crates/subgraph/queries/order.graphql
+++ b/crates/subgraph/queries/order.graphql
@@ -10,6 +10,7 @@ query OrderQuery($id: ID!) {
     expressionDeployer
     expression
     timestamp
+    handleIO
    	validInputs {
       token {
         id

--- a/crates/subgraph/src/types/mod.rs
+++ b/crates/subgraph/src/types/mod.rs
@@ -1,4 +1,5 @@
 pub mod order;
+pub mod order_traits;
 pub mod orders;
 pub mod vault;
 pub mod vaults;

--- a/crates/subgraph/src/types/order.rs
+++ b/crates/subgraph/src/types/order.rs
@@ -27,6 +27,8 @@ pub struct Order {
     pub expression_deployer: Bytes,
     pub expression: Bytes,
     pub timestamp: BigInt,
+    #[cynic(rename = "handleIO")]
+    pub handle_io: bool,
     pub valid_inputs: Option<Vec<Io>>,
     pub valid_outputs: Option<Vec<Io>>,
     pub meta: Option<RainMetaV1>,

--- a/crates/subgraph/src/types/order.rs
+++ b/crates/subgraph/src/types/order.rs
@@ -45,6 +45,14 @@ pub struct RainMetaV1 {
 #[derive(cynic::QueryFragment, Debug, Clone, Serialize)]
 #[cynic(graphql_type = "IO")]
 pub struct Io {
+    pub token_vault: TokenVault,
+}
+
+#[typeshare]
+#[derive(cynic::QueryFragment, Debug, Clone, Serialize)]
+pub struct TokenVault {
+    pub id: cynic::Id,
+    pub vault_id: BigInt,
     pub token: Erc20,
 }
 

--- a/crates/subgraph/src/types/order_traits.rs
+++ b/crates/subgraph/src/types/order_traits.rs
@@ -139,7 +139,7 @@ mod tests {
         );
         assert_eq!(
             order_v2.validOutputs[0].token,
-            "0x0000000000000000000000000000000000000005"
+            "0x0000000000000000000000000000000000000006"
                 .parse::<Address>()
                 .unwrap()
         );

--- a/crates/subgraph/src/types/order_traits.rs
+++ b/crates/subgraph/src/types/order_traits.rs
@@ -1,0 +1,147 @@
+use crate::types::order::Order as OrderDetail;
+use alloy_primitives::{hex::FromHexError, Address, U256};
+use rain_orderbook_bindings::IOrderBookV3::{EvaluableV2, OrderV2, IO};
+use ruint::ParseError;
+use std::num::TryFromIntError;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum OrderDetailError {
+    #[error(transparent)]
+    FromHexError(#[from] FromHexError),
+    #[error(transparent)]
+    TryFromIntError(#[from] TryFromIntError),
+    #[error(transparent)]
+    ParseError(#[from] ParseError),
+}
+
+impl TryInto<OrderV2> for OrderDetail {
+    type Error = OrderDetailError;
+
+    fn try_into(self) -> Result<OrderV2, OrderDetailError> {
+        Ok(OrderV2 {
+            owner: self.owner.id.0.parse::<Address>()?,
+            handleIO: self.handle_io,
+            evaluable: EvaluableV2 {
+                interpreter: self.interpreter.0.parse::<Address>()?,
+                store: self.interpreter_store.0.parse::<Address>()?,
+                expression: self.expression.0.parse::<Address>()?,
+            },
+            validInputs: self
+                .valid_inputs
+                .unwrap_or(vec![])
+                .into_iter()
+                .map(|v| -> Result<IO, OrderDetailError> {
+                    Ok(IO {
+                        token: v.token_vault.token.id.into_inner().parse::<Address>()?,
+                        decimals: v.token_vault.token.decimals.try_into()?,
+                        vaultId: U256::from_str_radix(v.token_vault.vault_id.0.as_str(), 16)?,
+                    })
+                })
+                .collect::<Result<Vec<IO>, OrderDetailError>>()?,
+            validOutputs: self
+                .valid_outputs
+                .unwrap_or(vec![])
+                .into_iter()
+                .map(|v| -> Result<IO, OrderDetailError> {
+                    Ok(IO {
+                        token: v.token_vault.token.id.into_inner().parse::<Address>()?,
+                        decimals: v.token_vault.token.decimals.try_into()?,
+                        vaultId: U256::from_str_radix(v.token_vault.vault_id.0.as_str(), 16)?,
+                    })
+                })
+                .collect::<Result<Vec<IO>, OrderDetailError>>()?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::order::{Account, RainMetaV1, Io, BigInt, Bytes, Erc20, TokenVault};
+
+    #[test]
+    fn test_try_into_call() {
+        let order_detail = OrderDetail {
+            id: "1".into(),
+            owner: Account {
+                id: Bytes("0x0000000000000000000000000000000000000001".into()),
+            },
+            order_active: true,
+            interpreter: Bytes("0x0000000000000000000000000000000000000002".into()),
+            interpreter_store: Bytes("0x0000000000000000000000000000000000000003".into()),
+            expression_deployer: Bytes("".into()),
+            expression: Bytes("0x0000000000000000000000000000000000000004".into()),
+            timestamp: BigInt("".into()),
+            handle_io: true,
+            valid_inputs: Some(vec![Io {
+                token_vault: TokenVault {
+                    id: "".into(),
+                    vault_id: BigInt("1".into()),
+                    token: Erc20 {
+                        id: cynic::Id::new("0x0000000000000000000000000000000000000005"),
+                        name: "".into(),
+                        symbol: "ABC".into(),
+                        decimals: 18,
+                    },
+                },
+            }]),
+            valid_outputs: Some(vec![Io {
+                token_vault: TokenVault {
+                    id: "".into(),
+                    vault_id: BigInt("2".into()),
+                    token: Erc20 {
+                        id: cynic::Id::new("0x0000000000000000000000000000000000000006"),
+                        name: "".into(),
+                        symbol: "DEF".into(),
+                        decimals: 18,
+                    },
+                },
+            }]),
+            meta: Some(RainMetaV1 {
+                meta_bytes: Bytes("0x1".into()),
+                content: vec![],
+            }),
+        };
+
+        let order_v2: OrderV2 = order_detail.try_into().unwrap();
+
+        assert_eq!(
+            order_v2.owner,
+            "0x0000000000000000000000000000000000000001"
+                .parse::<Address>()
+                .unwrap()
+        );
+        assert_eq!(order_v2.handleIO, true);
+        assert_eq!(
+            order_v2.evaluable.interpreter,
+            "0x0000000000000000000000000000000000000002"
+                .parse::<Address>()
+                .unwrap()
+        );
+        assert_eq!(
+            order_v2.evaluable.store,
+            "0x0000000000000000000000000000000000000003"
+                .parse::<Address>()
+                .unwrap()
+        );
+        assert_eq!(
+            order_v2.evaluable.expression,
+            "0x0000000000000000000000000000000000000004"
+                .parse::<Address>()
+                .unwrap()
+        );
+        assert_eq!(
+            order_v2.validInputs[0].token,
+            "0x0000000000000000000000000000000000000005"
+                .parse::<Address>()
+                .unwrap()
+        );
+        assert_eq!(
+            order_v2.validOutputs[0].token,
+            "0x0000000000000000000000000000000000000005"
+                .parse::<Address>()
+                .unwrap()
+        );
+    }
+}

--- a/crates/subgraph/src/types/order_traits.rs
+++ b/crates/subgraph/src/types/order_traits.rs
@@ -29,7 +29,7 @@ impl TryInto<OrderV2> for OrderDetail {
             },
             validInputs: self
                 .valid_inputs
-                .unwrap_or(vec![])
+                .unwrap_or_default()
                 .into_iter()
                 .map(|v| -> Result<IO, OrderDetailError> {
                     Ok(IO {
@@ -41,7 +41,7 @@ impl TryInto<OrderV2> for OrderDetail {
                 .collect::<Result<Vec<IO>, OrderDetailError>>()?,
             validOutputs: self
                 .valid_outputs
-                .unwrap_or(vec![])
+                .unwrap_or_default()
                 .into_iter()
                 .map(|v| -> Result<IO, OrderDetailError> {
                     Ok(IO {
@@ -58,7 +58,7 @@ impl TryInto<OrderV2> for OrderDetail {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::order::{Account, RainMetaV1, Io, BigInt, Bytes, Erc20, TokenVault};
+    use crate::types::order::{Account, BigInt, Bytes, Erc20, Io, RainMetaV1, TokenVault};
 
     #[test]
     fn test_try_into_call() {
@@ -112,7 +112,7 @@ mod tests {
                 .parse::<Address>()
                 .unwrap()
         );
-        assert_eq!(order_v2.handleIO, true);
+        assert!(order_v2.handleIO);
         assert_eq!(
             order_v2.evaluable.interpreter,
             "0x0000000000000000000000000000000000000002"

--- a/crates/subgraph/tests/order_test.rs
+++ b/crates/subgraph/tests/order_test.rs
@@ -22,19 +22,27 @@ fn orders_query_gql_output() {
     timestamp
     handleIO
     validInputs {
-      token {
+      tokenVault {
         id
-        name
-        symbol
-        decimals
+        vaultId
+        token {
+          id
+          name
+          symbol
+          decimals
+        }
       }
     }
     validOutputs {
-      token {
+      tokenVault {
         id
-        name
-        symbol
-        decimals
+        vaultId
+        token {
+          id
+          name
+          symbol
+          decimals
+        }
       }
     }
     meta {

--- a/crates/subgraph/tests/order_test.rs
+++ b/crates/subgraph/tests/order_test.rs
@@ -20,6 +20,7 @@ fn orders_query_gql_output() {
     expressionDeployer
     expression
     timestamp
+    handleIO
     validInputs {
       token {
         id

--- a/tauri-app/src-tauri/Cargo.lock
+++ b/tauri-app/src-tauri/Cargo.lock
@@ -124,11 +124,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+
+[[package]]
 name = "alloy-ethers-typecast"
 version = "0.2.0"
-source = "git+https://github.com/rainlanguage/alloy-ethers-typecast?rev=47b2d9f073ff891254af6ece6f0efc140566d3d5#47b2d9f073ff891254af6ece6f0efc140566d3d5"
+source = "git+https://github.com/rainlanguage/alloy-ethers-typecast?rev=9e830eda8a429fda60d1a87f480241c7678266bb#9e830eda8a429fda60d1a87f480241c7678266bb"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 0.5.4",
  "alloy-sol-types",
  "async-trait",
  "derive_builder",
@@ -146,9 +152,28 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "838228983f74f30e4efbd8d42d25bfe1b5bf6450ca71ee9d7628f134fbe8ae8e"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 0.5.4",
  "alloy-sol-type-parser",
  "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-primitives"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0628ec0ba5b98b3370bb6be17b12f23bfce8ee4ad83823325a20546d9b03b78"
+dependencies = [
+ "alloy-rlp",
+ "bytes",
+ "cfg-if",
+ "const-hex",
+ "derive_more",
+ "hex-literal",
+ "itoa 1.0.10",
+ "ruint",
+ "serde",
+ "tiny-keccak",
 ]
 
 [[package]]
@@ -179,8 +204,20 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d58d9f5da7b40e9bfff0b7e7816700be4019db97d4b6359fe7f94a9e22e42ac"
 dependencies = [
+ "alloy-rlp-derive",
  "arrayvec",
  "bytes",
+]
+
+[[package]]
+name = "alloy-rlp-derive"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a047897373be4bbb0224c1afdabca92648dc57a9c9ef6e7b0be3aff7a859c83"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -219,7 +256,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a059d4d2c78f8f21e470772c75f9abd9ac6d48c2aaf6b278d1ead06ed9ac664"
 dependencies = [
  "alloy-json-abi",
- "alloy-primitives",
+ "alloy-primitives 0.5.4",
  "alloy-sol-macro",
  "const-hex",
  "serde",
@@ -446,6 +483,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-recursion"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -607,6 +655,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
+name = "bindgen"
+version = "0.66.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
+dependencies = [
+ "bitflags 2.4.1",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.48",
+ "which",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -638,6 +709,9 @@ name = "bitflags"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitvec"
@@ -647,6 +721,7 @@ checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
 dependencies = [
  "funty",
  "radium",
+ "serde",
  "tap",
  "wyz",
 ]
@@ -664,6 +739,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "blst"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c94087b935a822949d3291a9989ad2b2051ea141eda0fd4e478a75f6aa3e604b"
+dependencies = [
+ "cc",
+ "glob",
+ "threadpool",
+ "zeroize",
 ]
 
 [[package]]
@@ -790,6 +877,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "c-kzg"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac926d808fb72fe09ebf471a091d6d72918876ccf0b4989766093d2d0d24a0ef"
+dependencies = [
+ "bindgen",
+ "blst",
+ "cc",
+ "glob",
+ "hex",
+ "libc",
+ "serde",
+]
+
+[[package]]
 name = "cairo-rs"
 version = "0.15.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -872,6 +974,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfb"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -930,6 +1041,17 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67523a3b4be3ce1989d607a828d036249522dd9c1c8de7f4dd2dae43a37369d1"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -1503,6 +1625,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
 
 [[package]]
+name = "deflate"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c86f7e25f518f4b81808a2cf1c50996a61f5c2eb394b2393bd87f2a4780a432f"
+dependencies = [
+ "adler32",
+]
+
+[[package]]
 name = "der"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1666,6 +1797,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
 
 [[package]]
+name = "dotrain"
+version = "0.0.0"
+source = "git+https://github.com/rainlanguage/dotrain.git?rev=8fcc7651df8abc49c72c648ac8e9c80b5e057e70#8fcc7651df8abc49c72c648ac8e9c80b5e057e70"
+dependencies = [
+ "alloy-json-abi",
+ "alloy-primitives 0.5.4",
+ "alloy-sol-types",
+ "anyhow",
+ "async-recursion",
+ "futures",
+ "getrandom 0.2.12",
+ "js-sys",
+ "lsp-types",
+ "magic_string",
+ "once_cell",
+ "rain-meta 1.0.0 (git+https://github.com/rainprotocol/rain.metadata.git?rev=42712f1469ff7943ba7abe324216c96b8e8c707a)",
+ "regex",
+ "revm",
+ "serde",
+ "serde-wasm-bindgen 0.6.3",
+ "serde_bytes",
+ "serde_json",
+ "serde_repr",
+ "topo_sort",
+ "tsify",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
 name = "dtoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1794,6 +1955,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "enumn"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fd000fd6988e73bbe993ea3db9b1aa64906ab88766d654973924340c8cddb42"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1904,7 +2076,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "2.0.11"
-source = "git+https://github.com/gakonst/ethers-rs.git?rev=88095ba47eb6a3507f0db1767353b387b27a6e98#88095ba47eb6a3507f0db1767353b387b27a6e98"
+source = "git+https://github.com/gakonst/ethers-rs.git?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107#f0e5b194f09c533feb10d1a686ddb9e5946ec107"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -1919,7 +2091,7 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "2.0.11"
-source = "git+https://github.com/gakonst/ethers-rs.git?rev=88095ba47eb6a3507f0db1767353b387b27a6e98#88095ba47eb6a3507f0db1767353b387b27a6e98"
+source = "git+https://github.com/gakonst/ethers-rs.git?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107#f0e5b194f09c533feb10d1a686ddb9e5946ec107"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -1930,7 +2102,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "2.0.11"
-source = "git+https://github.com/gakonst/ethers-rs.git?rev=88095ba47eb6a3507f0db1767353b387b27a6e98#88095ba47eb6a3507f0db1767353b387b27a6e98"
+source = "git+https://github.com/gakonst/ethers-rs.git?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107#f0e5b194f09c533feb10d1a686ddb9e5946ec107"
 dependencies = [
  "const-hex",
  "ethers-contract-abigen",
@@ -1948,7 +2120,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "2.0.11"
-source = "git+https://github.com/gakonst/ethers-rs.git?rev=88095ba47eb6a3507f0db1767353b387b27a6e98#88095ba47eb6a3507f0db1767353b387b27a6e98"
+source = "git+https://github.com/gakonst/ethers-rs.git?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107#f0e5b194f09c533feb10d1a686ddb9e5946ec107"
 dependencies = [
  "Inflector",
  "const-hex",
@@ -1971,7 +2143,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "2.0.11"
-source = "git+https://github.com/gakonst/ethers-rs.git?rev=88095ba47eb6a3507f0db1767353b387b27a6e98#88095ba47eb6a3507f0db1767353b387b27a6e98"
+source = "git+https://github.com/gakonst/ethers-rs.git?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107#f0e5b194f09c533feb10d1a686ddb9e5946ec107"
 dependencies = [
  "Inflector",
  "const-hex",
@@ -1986,7 +2158,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "2.0.11"
-source = "git+https://github.com/gakonst/ethers-rs.git?rev=88095ba47eb6a3507f0db1767353b387b27a6e98#88095ba47eb6a3507f0db1767353b387b27a6e98"
+source = "git+https://github.com/gakonst/ethers-rs.git?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107#f0e5b194f09c533feb10d1a686ddb9e5946ec107"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -2004,7 +2176,7 @@ dependencies = [
  "rlp",
  "serde",
  "serde_json",
- "strum",
+ "strum 0.25.0",
  "syn 2.0.48",
  "tempfile",
  "thiserror",
@@ -2015,7 +2187,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "2.0.11"
-source = "git+https://github.com/gakonst/ethers-rs.git?rev=88095ba47eb6a3507f0db1767353b387b27a6e98#88095ba47eb6a3507f0db1767353b387b27a6e98"
+source = "git+https://github.com/gakonst/ethers-rs.git?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107#f0e5b194f09c533feb10d1a686ddb9e5946ec107"
 dependencies = [
  "chrono",
  "ethers-core",
@@ -2030,7 +2202,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "2.0.11"
-source = "git+https://github.com/gakonst/ethers-rs.git?rev=88095ba47eb6a3507f0db1767353b387b27a6e98#88095ba47eb6a3507f0db1767353b387b27a6e98"
+source = "git+https://github.com/gakonst/ethers-rs.git?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107#f0e5b194f09c533feb10d1a686ddb9e5946ec107"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -2056,7 +2228,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "2.0.11"
-source = "git+https://github.com/gakonst/ethers-rs.git?rev=88095ba47eb6a3507f0db1767353b387b27a6e98#88095ba47eb6a3507f0db1767353b387b27a6e98"
+source = "git+https://github.com/gakonst/ethers-rs.git?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107#f0e5b194f09c533feb10d1a686ddb9e5946ec107"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -2092,7 +2264,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "2.0.11"
-source = "git+https://github.com/gakonst/ethers-rs.git?rev=88095ba47eb6a3507f0db1767353b387b27a6e98#88095ba47eb6a3507f0db1767353b387b27a6e98"
+source = "git+https://github.com/gakonst/ethers-rs.git?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107#f0e5b194f09c533feb10d1a686ddb9e5946ec107"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -2114,7 +2286,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "2.0.11"
-source = "git+https://github.com/gakonst/ethers-rs.git?rev=88095ba47eb6a3507f0db1767353b387b27a6e98#88095ba47eb6a3507f0db1767353b387b27a6e98"
+source = "git+https://github.com/gakonst/ethers-rs.git?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107#f0e5b194f09c533feb10d1a686ddb9e5946ec107"
 dependencies = [
  "cfg-if",
  "const-hex",
@@ -2150,7 +2322,7 @@ checksum = "832a761f35ab3e6664babfbdc6cef35a4860e816ec3916dcfd0882954e98a8a8"
 dependencies = [
  "bit_field",
  "flume",
- "half",
+ "half 2.2.1",
  "lebe",
  "miniz_oxide",
  "rayon-core",
@@ -2744,6 +2916,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "graphql-introspection-query"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f2a4732cf5140bd6c082434494f785a19cfb566ab07d1382c3671f5812fed6d"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "graphql-parser"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2751,6 +2932,45 @@ checksum = "d2ebc8013b4426d5b81a4364c419a95ed0b404af2b82e2457de52d9348f0e474"
 dependencies = [
  "combine 3.8.1",
  "thiserror",
+]
+
+[[package]]
+name = "graphql_client"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cdf7b487d864c2939b23902291a5041bc4a84418268f25fda1c8d4e15ad8fa"
+dependencies = [
+ "graphql_query_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "graphql_client_codegen"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a40f793251171991c4eb75bd84bc640afa8b68ff6907bc89d3b712a22f700506"
+dependencies = [
+ "graphql-introspection-query",
+ "graphql-parser",
+ "heck 0.4.1",
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "graphql_query_derive"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00bda454f3d313f909298f626115092d348bc231025699f557b27e248475f48c"
+dependencies = [
+ "graphql_client_codegen",
+ "proc-macro2",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2840,6 +3060,12 @@ dependencies = [
 
 [[package]]
 name = "half"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+
+[[package]]
+name = "half"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b4af3693f1b705df946e9fe5631932443781d0aabb423b62fcd4d73f6d2fd0"
@@ -2884,6 +3110,11 @@ name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+dependencies = [
+ "ahash 0.8.7",
+ "allocator-api2",
+ "serde",
+]
 
 [[package]]
 name = "hashers"
@@ -3115,6 +3346,16 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "idna"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
@@ -3122,6 +3363,12 @@ dependencies = [
  "unicode-bidi",
  "unicode-normalization",
 ]
+
+[[package]]
+name = "if_chain"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb56e1aa765b4b4f3aadfab769793b7087bb03a4ea4920644a6d238e2df5b9ed"
 
 [[package]]
 name = "ignore"
@@ -3250,6 +3497,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f551f8c3a39f68f986517db0d1759de85881894fdc7db798bd2a9df9cb04b7fc"
 dependencies = [
  "cfb",
+]
+
+[[package]]
+name = "inflate"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cdb29978cc5797bd8dcc8e5bf7de604891df2a8dc576973d71a281e916db2ff"
+dependencies = [
+ "adler32",
 ]
 
 [[package]]
@@ -3591,6 +3847,15 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+dependencies = [
+ "spin 0.5.2",
+]
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lebe"
@@ -3626,6 +3891,16 @@ dependencies = [
  "core2",
  "hashbrown 0.13.2",
  "rle-decode-fast",
+]
+
+[[package]]
+name = "libloading"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c571b676ddfc9a8c12f1f3d3085a7b163966a8fd8098a90640953ce5f6170161"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3665,6 +3940,12 @@ checksum = "f30344350a2a51da54c1d53be93fade8a237e545dbcc4bdbe635413f2117cab9"
 dependencies = [
  "safemem",
 ]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -3707,10 +3988,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "lsp-types"
+version = "0.94.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66bfd44a06ae10647fe3f8214762e9369fd4248df1350924b4ef9e770a85ea1"
+dependencies = [
+ "bitflags 1.3.2",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "url",
+]
+
+[[package]]
 name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
+name = "magic_string"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8033ce8c43f7ccb207e4699f30eed50d7526379ee08fab47159f80b7934e18"
+dependencies = [
+ "base64 0.13.1",
+ "regex",
+ "serde",
+ "serde_json",
+ "vlq",
+]
 
 [[package]]
 name = "malloc_buf"
@@ -4429,6 +4736,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
 name = "pem"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4922,10 +5235,105 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
+name = "rain-meta"
+version = "1.0.0"
+dependencies = [
+ "alloy-json-abi",
+ "alloy-primitives 0.5.4",
+ "alloy-sol-types",
+ "anyhow",
+ "clap",
+ "deflate",
+ "futures",
+ "graphql_client",
+ "inflate",
+ "itertools 0.10.5",
+ "once_cell",
+ "regex",
+ "reqwest",
+ "schemars",
+ "serde",
+ "serde_bytes",
+ "serde_cbor",
+ "serde_json",
+ "strum 0.24.1",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "validator",
+]
+
+[[package]]
+name = "rain-meta"
+version = "1.0.0"
+source = "git+https://github.com/rainprotocol/rain.metadata.git?rev=42712f1469ff7943ba7abe324216c96b8e8c707a#42712f1469ff7943ba7abe324216c96b8e8c707a"
+dependencies = [
+ "alloy-json-abi",
+ "alloy-primitives 0.5.4",
+ "alloy-sol-types",
+ "anyhow",
+ "deflate",
+ "futures",
+ "graphql_client",
+ "inflate",
+ "itertools 0.10.5",
+ "once_cell",
+ "regex",
+ "reqwest",
+ "serde",
+ "serde_bytes",
+ "serde_cbor",
+ "serde_json",
+ "strum 0.24.1",
+ "validator",
+]
+
+[[package]]
+name = "rain_interpreter_bindings"
+version = "0.1.0"
+dependencies = [
+ "alloy-primitives 0.5.4",
+ "alloy-sol-types",
+]
+
+[[package]]
+name = "rain_interpreter_dispair"
+version = "0.1.0"
+dependencies = [
+ "alloy-ethers-typecast",
+ "alloy-primitives 0.5.4",
+ "alloy-sol-types",
+ "ethers",
+ "rain_interpreter_bindings",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "rain_interpreter_parser"
+version = "0.1.0"
+dependencies = [
+ "alloy-ethers-typecast",
+ "alloy-primitives 0.5.4",
+ "alloy-sol-types",
+ "ethers",
+ "rain_interpreter_bindings",
+ "rain_interpreter_dispair",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
 name = "rain_orderbook_bindings"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 0.5.4",
  "alloy-sol-types",
 ]
 
@@ -4934,13 +5342,19 @@ name = "rain_orderbook_common"
 version = "0.0.1"
 dependencies = [
  "alloy-ethers-typecast",
- "alloy-primitives",
+ "alloy-primitives 0.5.4",
  "alloy-sol-types",
+ "dotrain",
+ "rain-meta 1.0.0",
+ "rain_interpreter_bindings",
+ "rain_interpreter_dispair",
+ "rain_interpreter_parser",
  "rain_orderbook_bindings",
  "rain_orderbook_subgraph_queries",
  "serde",
+ "serde_bytes",
+ "strict-yaml-rust",
  "thiserror",
- "tracing",
  "url",
 ]
 
@@ -4948,9 +5362,12 @@ dependencies = [
 name = "rain_orderbook_subgraph_queries"
 version = "0.0.1"
 dependencies = [
+ "alloy-primitives 0.5.4",
  "cynic",
  "cynic-codegen",
+ "rain_orderbook_bindings",
  "reqwest",
+ "ruint",
  "serde",
  "thiserror",
  "typeshare",
@@ -5215,6 +5632,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "revm"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f4ca8ae0345104523b4af1a8a7ea97cfa1865cdb7a7c25d23c1a18d9b48598"
+dependencies = [
+ "auto_impl",
+ "revm-interpreter",
+ "revm-precompile",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "revm-interpreter"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f959cafdf64a7f89b014fa73dc2325001cf654b3d9400260b212d19a2ebe3da0"
+dependencies = [
+ "revm-primitives",
+ "serde",
+]
+
+[[package]]
+name = "revm-precompile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d360a88223d85709d2e95d4609eb1e19c649c47e28954bfabae5e92bb37e83e"
+dependencies = [
+ "c-kzg",
+ "k256",
+ "num",
+ "once_cell",
+ "revm-primitives",
+ "ripemd",
+ "secp256k1",
+ "sha2",
+ "substrate-bn",
+]
+
+[[package]]
+name = "revm-primitives"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51187b852d9e458816a2e19c81f1dd6c924077e1a8fccd16e4f044f865f299d7"
+dependencies = [
+ "alloy-primitives 0.4.2",
+ "alloy-rlp",
+ "auto_impl",
+ "bitflags 2.4.1",
+ "bitvec",
+ "c-kzg",
+ "enumn",
+ "hashbrown 0.14.3",
+ "hex",
+ "serde",
+]
+
+[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5387,6 +5862,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustc-hex"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5556,7 +6037,7 @@ checksum = "c767fd6fa65d9ccf9cf026122c1b555f2ef9a4f0cea69da4d7dbc3e258d30967"
 dependencies = [
  "proc-macro2",
  "quote",
- "serde_derive_internals",
+ "serde_derive_internals 0.26.0",
  "syn 1.0.109",
 ]
 
@@ -5623,6 +6104,24 @@ dependencies = [
  "pkcs8",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
+dependencies = [
+ "secp256k1-sys",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a129b9e9efbfb223753b9163c4ab3b13cff7fd9c7f010fbac25ab4099fa07e"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -5727,6 +6226,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-wasm-bindgen"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3b143e2833c57ab9ad3ea280d21fd34e285a42837aeb0ee301f4f41890fa00e"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "serde-wasm-bindgen"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9b713f70513ae1f8d92665bbbbda5c295c2cf1da5542881ae5eefe20c9af132"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b8497c313fd43ab992087548117643f6fcd935cbf36f176ffda0aacf9591734"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_cbor"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
+dependencies = [
+ "half 1.8.2",
+ "serde",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5749,6 +6289,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_derive_internals"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e578a843d40b4189a4d66bba51d7684f57da5bd7c304c64e14bd63efbef49509"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "serde_fmt"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5763,6 +6314,7 @@ version = "1.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "176e46fa42316f18edd598015a5166857fc835ec732f5215eac6b7bdbf0a84f4"
 dependencies = [
+ "indexmap 2.1.0",
  "itoa 1.0.10",
  "ryu",
  "serde",
@@ -5945,6 +6497,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6098,6 +6665,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strict-yaml-rust"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4de3bec6b49628704d8198d3da035998ae2ac4f6b995a1aa01b934828f1f71a3"
+dependencies = [
+ "linked-hash-map",
+]
+
+[[package]]
 name = "string_cache"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6131,11 +6707,33 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+dependencies = [
+ "strum_macros 0.24.3",
+]
+
+[[package]]
+name = "strum"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.25.3",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -6149,6 +6747,19 @@ dependencies = [
  "quote",
  "rustversion",
  "syn 2.0.48",
+]
+
+[[package]]
+name = "substrate-bn"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b5bbfa79abbae15dd642ea8176a21a635ff3c00059961d1ea27ad04e5b441c"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "lazy_static",
+ "rand 0.8.5",
+ "rustc-hex",
 ]
 
 [[package]]
@@ -6475,7 +7086,7 @@ name = "tauri-app"
 version = "0.0.0"
 dependencies = [
  "alloy-ethers-typecast",
- "alloy-primitives",
+ "alloy-primitives 0.5.4",
  "alloy-sol-types",
  "chrono",
  "rain_orderbook_common",
@@ -6822,6 +7433,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
+]
+
+[[package]]
 name = "tiff"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6896,7 +7516,9 @@ dependencies = [
  "libc",
  "mio",
  "num_cpus",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.48.0",
@@ -7042,6 +7664,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "topo_sort"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "156552d3c80df430aaac98c605a4e0eb7da8d06029cce2d40b4a6b095a34b37e"
+
+[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7155,6 +7783,30 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tsify"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6b26cf145f2f3b9ff84e182c448eaf05468e247f148cf3d2a7d67d78ff023a0"
+dependencies = [
+ "serde",
+ "serde-wasm-bindgen 0.5.0",
+ "tsify-macros",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "tsify-macros"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a94b0f0954b3e59bfc2c246b4c8574390d94a4ad4ad246aaf2fb07d7dfd3b47"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals 0.28.0",
+ "syn 2.0.48",
+]
 
 [[package]]
 name = "tungstenite"
@@ -7321,7 +7973,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
 dependencies = [
  "form_urlencoded",
- "idna",
+ "idna 0.5.0",
  "percent-encoding",
  "serde",
 ]
@@ -7357,6 +8009,48 @@ dependencies = [
  "getrandom 0.2.12",
  "serde",
  "sha1_smol",
+]
+
+[[package]]
+name = "validator"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b92f40481c04ff1f4f61f304d61793c7b56ff76ac1469f1beb199b1445b253bd"
+dependencies = [
+ "idna 0.4.0",
+ "lazy_static",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "url",
+ "validator_derive",
+]
+
+[[package]]
+name = "validator_derive"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc44ca3088bb3ba384d9aecf40c6a23a676ce23e09bdaca2073d99c207f864af"
+dependencies = [
+ "if_chain",
+ "lazy_static",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 1.0.109",
+ "validator_types",
+]
+
+[[package]]
+name = "validator_types"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "111abfe30072511849c5910134e8baf8dc05de4c0e5903d681cbd5c9c4d611e3"
+dependencies = [
+ "proc-macro2",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -7424,6 +8118,12 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "vlq"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65dd7eed29412da847b0f78bcec0ac98588165988a8cfe41d4ea1d429f8ccfff"
 
 [[package]]
 name = "void"
@@ -7663,6 +8363,18 @@ name = "weezl"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9193164d4de03a926d909d3bc7c30543cecb35400c02114792c2cae20d5e2dbb"
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix",
+]
 
 [[package]]
 name = "winapi"

--- a/tauri-app/src/routes/orders/[id]/+page.svelte
+++ b/tauri-app/src/routes/orders/[id]/+page.svelte
@@ -63,7 +63,7 @@
           Input Token(s)
         </h5>
         <p class="break-all font-normal leading-tight text-gray-700 dark:text-gray-400">
-          {order.valid_inputs?.map((t) => t.token.name)}
+          {order.valid_inputs?.map((t) => t.token_vault.token.name)}
         </p>
       </div>
 
@@ -72,7 +72,7 @@
           Output Token(s)
         </h5>
         <p class="break-all font-normal leading-tight text-gray-700 dark:text-gray-400">
-          {order.valid_outputs?.map((t) => t.token.name)}
+          {order.valid_outputs?.map((t) => t.token_vault.token.name)}
         </p>
       </div>
 


### PR DESCRIPTION
Adds CLI command `order remove` that takes an `--order-id`, queries the subgraph for order data and then calls removeOrder.