### PR TITLE
refactor: rename subgraph queries for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ When this project is migrated to use the subgraph schema defined in `subgraph/sc
 
 1. Run the following commands to generate Rust types from GraphQL Queries
 ```bash
-cynic querygen --schema crates/subgraph/schema/orderbook.graphql --query crates/subgraph/queries/vault.graphql  > crates/subgraph/src/types/vault.rs
-cynic querygen --schema crates/subgraph/schema/orderbook.graphql --query crates/subgraph/queries/vaults.graphql  > crates/subgraph/src/types/vaults.rs
-cynic querygen --schema crates/subgraph/schema/orderbook.graphql --query crates/subgraph/queries/order.graphql  > crates/subgraph/src/types/order.rs
-cynic querygen --schema crates/subgraph/schema/orderbook.graphql --query crates/subgraph/queries/orders.graphql  > crates/subgraph/src/types/orders.rs
+cynic querygen --schema crates/subgraph/schema/orderbook.graphql --query crates/subgraph/queries/vaultDetail.graphql  > crates/subgraph/src/types/vault_detail.rs
+cynic querygen --schema crates/subgraph/schema/orderbook.graphql --query crates/subgraph/queries/vaultsList.graphql  > crates/subgraph/src/types/vaults_list.rs
+cynic querygen --schema crates/subgraph/schema/orderbook.graphql --query crates/subgraph/queries/orderDetail.graphql  > crates/subgraph/src/types/order_detail.rs
+cynic querygen --schema crates/subgraph/schema/orderbook.graphql --query crates/subgraph/queries/ordersList.graphql  > crates/subgraph/src/types/orders_list.rs
 ```
 
 2. Prepend each generated types file with the following:

--- a/crates/cli/src/commands/order/detail.rs
+++ b/crates/cli/src/commands/order/detail.rs
@@ -19,7 +19,7 @@ impl Execute for CliOrderDetailArgs {
         let order = subgraph_args
             .to_subgraph_client()
             .await?
-            .order(self.order_id.clone().into())
+            .order_detail(self.order_id.clone().into())
             .await?;
         info!("{:#?}", order);
 

--- a/crates/cli/src/commands/order/list.rs
+++ b/crates/cli/src/commands/order/list.rs
@@ -4,7 +4,7 @@ use chrono::{NaiveDateTime, TimeZone, Utc};
 use clap::Args;
 use comfy_table::Table;
 use rain_orderbook_common::subgraph::SubgraphArgs;
-use rain_orderbook_subgraph_client::types::orders::Order;
+use rain_orderbook_subgraph_client::types::orders_list::Order;
 
 use tracing::debug;
 #[derive(Args, Clone)]
@@ -16,7 +16,11 @@ pub struct CliOrderListArgs {
 impl Execute for CliOrderListArgs {
     async fn execute(&self) -> Result<()> {
         let subgraph_args: SubgraphArgs = self.subgraph_args.clone().into();
-        let orders = subgraph_args.to_subgraph_client().await?.orders().await?;
+        let orders = subgraph_args
+            .to_subgraph_client()
+            .await?
+            .orders_list()
+            .await?;
         debug!("{:#?}", orders);
 
         let table = build_orders_table(orders)?;

--- a/crates/cli/src/commands/order/remove.rs
+++ b/crates/cli/src/commands/order/remove.rs
@@ -26,7 +26,7 @@ impl Execute for CliOrderRemoveArgs {
         let order = subgraph_args
             .to_subgraph_client()
             .await?
-            .order(self.order_id.clone().into())
+            .order_detail(self.order_id.clone().into())
             .await?;
         let remove_order_args: RemoveOrderArgs = order.into();
 

--- a/crates/cli/src/commands/vault/detail.rs
+++ b/crates/cli/src/commands/vault/detail.rs
@@ -19,7 +19,7 @@ impl Execute for CliVaultDetailArgs {
         let vault = subgraph_args
             .to_subgraph_client()
             .await?
-            .vault(self.vault_id.clone().into())
+            .vault_detail(self.vault_id.clone().into())
             .await?;
         info!("{:#?}", vault);
 

--- a/crates/cli/src/commands/vault/list.rs
+++ b/crates/cli/src/commands/vault/list.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 use clap::Args;
 use comfy_table::Table;
 use rain_orderbook_common::subgraph::SubgraphArgs;
-use rain_orderbook_subgraph_client::types::vaults::TokenVault;
+use rain_orderbook_subgraph_client::types::vaults_list::TokenVault;
 
 use tracing::debug;
 #[derive(Args, Clone)]
@@ -15,7 +15,7 @@ pub struct CliVaultListArgs {
 impl Execute for CliVaultListArgs {
     async fn execute(&self) -> Result<()> {
         let subgraph_args: SubgraphArgs = self.subgraph_args.clone().into();
-        let vaults = subgraph_args.to_subgraph_client().await?.vaults().await?;
+        let vaults = subgraph_args.to_subgraph_client().await?.vaults_list().await?;
         debug!("{:#?}", vaults);
 
         let table = build_table(vaults)?;

--- a/crates/common/src/remove_order.rs
+++ b/crates/common/src/remove_order.rs
@@ -5,9 +5,7 @@ use alloy_ethers_typecast::transaction::{
 use alloy_primitives::hex::FromHexError;
 
 use rain_orderbook_bindings::IOrderBookV3::removeOrderCall;
-use rain_orderbook_subgraph_client::types::{
-    order::Order as OrderDetail, order_traits::OrderDetailError,
-};
+use rain_orderbook_subgraph_client::types::{order_detail::Order, order_traits::OrderDetailError};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -25,11 +23,11 @@ pub enum RemoveOrderArgsError {
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct RemoveOrderArgs {
-    pub order: OrderDetail,
+    pub order: Order,
 }
 
-impl From<OrderDetail> for RemoveOrderArgs {
-    fn from(order: OrderDetail) -> Self {
+impl From<Order> for RemoveOrderArgs {
+    fn from(order: Order) -> Self {
         Self { order }
     }
 }

--- a/crates/subgraph/queries/orderDetail.graphql
+++ b/crates/subgraph/queries/orderDetail.graphql
@@ -1,4 +1,4 @@
-query OrderQuery($id: ID!) {
+query OrderDetailQuery($id: ID!) {
   order(id: $id) {
     id
     owner {

--- a/crates/subgraph/queries/ordersList.graphql
+++ b/crates/subgraph/queries/ordersList.graphql
@@ -1,4 +1,4 @@
-query OrdersQuery {
+query OrdersListQuery {
   orders(orderBy: timestamp, orderDirection: desc) {
     id
     timestamp

--- a/crates/subgraph/queries/vaultDetail.graphql
+++ b/crates/subgraph/queries/vaultDetail.graphql
@@ -1,4 +1,4 @@
-query VaultQuery($id: ID!) {
+query VaultDetailQuery($id: ID!) {
   tokenVault(id: $id) {
     id
     owner {

--- a/crates/subgraph/queries/vaultsList.graphql
+++ b/crates/subgraph/queries/vaultsList.graphql
@@ -1,4 +1,4 @@
-query VaultsQuery {
+query VaultsListQuery {
   tokenVaults(orderBy: owner__id, orderDirection: desc) {
     id
     owner {

--- a/crates/subgraph/src/client.rs
+++ b/crates/subgraph/src/client.rs
@@ -1,9 +1,13 @@
 use crate::cynic_client::{CynicClient, CynicClientError};
 use crate::types::{
-    order::{Order, OrderQuery, OrderQueryVariables},
-    orders::{Order as OrdersListItem, OrdersQuery as OrdersListQuery},
-    vault::{TokenVault, VaultQuery, VaultQueryVariables},
-    vaults::{TokenVault as VaultsListItem, VaultsQuery as VaultsListQuery},
+    order_detail,
+    order_detail::{OrderDetailQuery, OrderDetailQueryVariables},
+    orders_list,
+    orders_list::OrdersListQuery,
+    vault_detail,
+    vault_detail::{VaultDetailQuery, VaultDetailQueryVariables},
+    vaults_list,
+    vaults_list::VaultsListQuery,
 };
 use cynic::Id;
 use reqwest::Url;
@@ -28,7 +32,9 @@ impl OrderbookSubgraphClient {
         Self { url }
     }
 
-    pub async fn orders(&self) -> Result<Vec<OrdersListItem>, OrderbookSubgraphClientError> {
+    pub async fn orders_list(
+        &self,
+    ) -> Result<Vec<orders_list::Order>, OrderbookSubgraphClientError> {
         let data = self
             .query::<OrdersListQuery, ()>(self.url.clone(), ())
             .await?;
@@ -36,7 +42,9 @@ impl OrderbookSubgraphClient {
         Ok(data.orders)
     }
 
-    pub async fn vaults(&self) -> Result<Vec<VaultsListItem>, OrderbookSubgraphClientError> {
+    pub async fn vaults_list(
+        &self,
+    ) -> Result<Vec<vaults_list::TokenVault>, OrderbookSubgraphClientError> {
         let data = self
             .query::<VaultsListQuery, ()>(self.url.clone(), ())
             .await
@@ -45,11 +53,14 @@ impl OrderbookSubgraphClient {
         Ok(data.token_vaults)
     }
 
-    pub async fn vault(&self, id: Id) -> Result<TokenVault, OrderbookSubgraphClientError> {
+    pub async fn vault_detail(
+        &self,
+        id: Id,
+    ) -> Result<vault_detail::TokenVault, OrderbookSubgraphClientError> {
         let data = self
-            .query::<VaultQuery, VaultQueryVariables>(
+            .query::<VaultDetailQuery, VaultDetailQueryVariables>(
                 self.url.clone(),
-                VaultQueryVariables { id: &id },
+                VaultDetailQueryVariables { id: &id },
             )
             .await
             .map_err(OrderbookSubgraphClientError::CynicClientError)?;
@@ -60,11 +71,14 @@ impl OrderbookSubgraphClient {
         Ok(vault)
     }
 
-    pub async fn order(&self, id: Id) -> Result<Order, OrderbookSubgraphClientError> {
+    pub async fn order_detail(
+        &self,
+        id: Id,
+    ) -> Result<order_detail::Order, OrderbookSubgraphClientError> {
         let data = self
-            .query::<OrderQuery, OrderQueryVariables>(
+            .query::<OrderDetailQuery, OrderDetailQueryVariables>(
                 self.url.clone(),
-                OrderQueryVariables { id: &id },
+                OrderDetailQueryVariables { id: &id },
             )
             .await?;
         let order = data.order.ok_or(OrderbookSubgraphClientError::Empty)?;

--- a/crates/subgraph/src/types/mod.rs
+++ b/crates/subgraph/src/types/mod.rs
@@ -1,5 +1,5 @@
-pub mod order;
+pub mod order_detail;
 pub mod order_traits;
-pub mod orders;
-pub mod vault;
-pub mod vaults;
+pub mod orders_list;
+pub mod vault_detail;
+pub mod vaults_list;

--- a/crates/subgraph/src/types/order_detail.rs
+++ b/crates/subgraph/src/types/order_detail.rs
@@ -4,14 +4,14 @@ use typeshare::typeshare;
 
 #[typeshare]
 #[derive(cynic::QueryVariables, Debug)]
-pub struct OrderQueryVariables<'a> {
+pub struct OrderDetailQueryVariables<'a> {
     pub id: &'a cynic::Id,
 }
 
 #[typeshare]
 #[derive(cynic::QueryFragment, Debug, Clone, Serialize)]
-#[cynic(graphql_type = "Query", variables = "OrderQueryVariables")]
-pub struct OrderQuery {
+#[cynic(graphql_type = "Query", variables = "OrderDetailQueryVariables")]
+pub struct OrderDetailQuery {
     #[arguments(id: $id)]
     pub order: Option<Order>,
 }

--- a/crates/subgraph/src/types/order_traits.rs
+++ b/crates/subgraph/src/types/order_traits.rs
@@ -1,4 +1,4 @@
-use crate::types::order::Order as OrderDetail;
+use crate::types::order_detail;
 use alloy_primitives::{hex::FromHexError, Address, U256};
 use rain_orderbook_bindings::IOrderBookV3::{EvaluableV2, OrderV2, IO};
 use ruint::ParseError;
@@ -15,7 +15,7 @@ pub enum OrderDetailError {
     ParseError(#[from] ParseError),
 }
 
-impl TryInto<OrderV2> for OrderDetail {
+impl TryInto<OrderV2> for order_detail::Order {
     type Error = OrderDetailError;
 
     fn try_into(self) -> Result<OrderV2, OrderDetailError> {
@@ -58,11 +58,13 @@ impl TryInto<OrderV2> for OrderDetail {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::order::{Account, BigInt, Bytes, Erc20, Io, RainMetaV1, TokenVault};
+    use crate::types::order_detail::{
+        Account, BigInt, Bytes, Erc20, Io, RainMetaV1, TokenVault, Vault,
+    };
 
     #[test]
     fn test_try_into_call() {
-        let order_detail = OrderDetail {
+        let order_detail = order_detail::Order {
             id: "1".into(),
             owner: Account {
                 id: Bytes("0x0000000000000000000000000000000000000001".into()),
@@ -78,6 +80,11 @@ mod tests {
                 token_vault: TokenVault {
                     id: "".into(),
                     vault_id: BigInt("1".into()),
+                    vault: Vault {
+                        owner: Account {
+                            id: Bytes("".into()),
+                        },
+                    },
                     token: Erc20 {
                         id: cynic::Id::new("0x0000000000000000000000000000000000000005"),
                         name: "".into(),
@@ -90,6 +97,11 @@ mod tests {
                 token_vault: TokenVault {
                     id: "".into(),
                     vault_id: BigInt("2".into()),
+                    vault: Vault {
+                        owner: Account {
+                            id: Bytes("".into()),
+                        },
+                    },
                     token: Erc20 {
                         id: cynic::Id::new("0x0000000000000000000000000000000000000006"),
                         name: "".into(),

--- a/crates/subgraph/src/types/orders_list.rs
+++ b/crates/subgraph/src/types/orders_list.rs
@@ -5,7 +5,7 @@ use typeshare::typeshare;
 #[typeshare]
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(graphql_type = "Query")]
-pub struct OrdersQuery {
+pub struct OrdersListQuery {
     #[arguments(orderBy: "timestamp", orderDirection: "desc")]
     pub orders: Vec<Order>,
 }

--- a/crates/subgraph/src/types/vault_detail.rs
+++ b/crates/subgraph/src/types/vault_detail.rs
@@ -4,21 +4,21 @@ use typeshare::typeshare;
 
 #[typeshare]
 #[derive(cynic::QueryVariables, Debug)]
-pub struct VaultQueryVariables<'a> {
+pub struct VaultDetailQueryVariables<'a> {
     pub id: &'a cynic::Id,
 }
 
 #[typeshare]
 #[derive(cynic::QueryFragment, Debug, Serialize)]
-#[cynic(graphql_type = "Query", variables = "VaultQueryVariables")]
-pub struct VaultQuery {
+#[cynic(graphql_type = "Query", variables = "VaultDetailQueryVariables")]
+pub struct VaultDetailQuery {
     #[arguments(id: $id)]
     pub token_vault: Option<TokenVault>,
 }
 
 #[typeshare]
 #[derive(cynic::QueryFragment, Debug, Serialize)]
-#[cynic(variables = "VaultQueryVariables")]
+#[cynic(variables = "VaultDetailQueryVariables")]
 pub struct TokenVault {
     pub id: cynic::Id,
     pub owner: Account,
@@ -30,7 +30,7 @@ pub struct TokenVault {
 
 #[typeshare]
 #[derive(cynic::QueryFragment, Debug, Serialize)]
-#[cynic(variables = "VaultQueryVariables")]
+#[cynic(variables = "VaultDetailQueryVariables")]
 pub struct Vault {
     pub id: cynic::Id,
     pub vault_id: BigInt,

--- a/crates/subgraph/src/types/vaults_list.rs
+++ b/crates/subgraph/src/types/vaults_list.rs
@@ -5,7 +5,7 @@ use typeshare::typeshare;
 #[typeshare]
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(graphql_type = "Query")]
-pub struct VaultsQuery {
+pub struct VaultsListQuery {
     #[arguments(orderBy: "owner__id", orderDirection: "desc")]
     pub token_vaults: Vec<TokenVault>,
 }

--- a/crates/subgraph/tests/order_test.rs
+++ b/crates/subgraph/tests/order_test.rs
@@ -1,14 +1,16 @@
 use cynic::Id;
-use rain_orderbook_subgraph_client::types::order::{OrderQuery, OrderQueryVariables};
+use rain_orderbook_subgraph_client::types::order_detail::{
+    OrderDetailQuery, OrderDetailQueryVariables,
+};
 
 #[test]
 fn orders_query_gql_output() {
     use cynic::QueryBuilder;
 
     let id = Id::new("1234");
-    let request_body = OrderQuery::build(OrderQueryVariables { id: &id });
+    let request_body = OrderDetailQuery::build(OrderDetailQueryVariables { id: &id });
 
-    let expected_query = "query OrderQuery($id: ID!) {
+    let expected_query = "query OrderDetailQuery($id: ID!) {
   order(id: $id) {
     id
     owner {

--- a/crates/subgraph/tests/orders_test.rs
+++ b/crates/subgraph/tests/orders_test.rs
@@ -1,12 +1,12 @@
-use rain_orderbook_subgraph_client::types::orders::OrdersQuery;
+use rain_orderbook_subgraph_client::types::orders_list::OrdersListQuery;
 
 #[test]
 fn orders_query_gql_output() {
     use cynic::QueryBuilder;
 
-    let request_body = OrdersQuery::build(());
+    let request_body = OrdersListQuery::build(());
 
-    let expected_query = "query OrdersQuery {
+    let expected_query = "query OrdersListQuery {
   orders(orderBy: timestamp, orderDirection: desc) {
     id
     timestamp

--- a/crates/subgraph/tests/vault_test.rs
+++ b/crates/subgraph/tests/vault_test.rs
@@ -1,14 +1,16 @@
 use cynic::Id;
-use rain_orderbook_subgraph_client::types::vault::{VaultQuery, VaultQueryVariables};
+use rain_orderbook_subgraph_client::types::vault_detail::{
+    VaultDetailQuery, VaultDetailQueryVariables,
+};
 
 #[test]
 fn vaults_query_gql_output() {
     use cynic::QueryBuilder;
 
     let id = Id::new("1234");
-    let request_body = VaultQuery::build(VaultQueryVariables { id: &id });
+    let request_body = VaultDetailQuery::build(VaultDetailQueryVariables { id: &id });
 
-    let expected_query = "query VaultQuery($id: ID!) {
+    let expected_query = "query VaultDetailQuery($id: ID!) {
   tokenVault(id: $id) {
     id
     owner {

--- a/crates/subgraph/tests/vaults_test.rs
+++ b/crates/subgraph/tests/vaults_test.rs
@@ -1,12 +1,12 @@
-use rain_orderbook_subgraph_client::types::vaults::VaultsQuery;
+use rain_orderbook_subgraph_client::types::vaults_list::VaultsListQuery;
 
 #[test]
 fn vaults_query_gql_output() {
     use cynic::QueryBuilder;
 
-    let request_body = VaultsQuery::build(());
+    let request_body = VaultsListQuery::build(());
 
-    let expected_query = "query VaultsQuery {
+    let expected_query = "query VaultsListQuery {
   tokenVaults(orderBy: owner__id, orderDirection: desc) {
     id
     owner {

--- a/flake.nix
+++ b/flake.nix
@@ -21,11 +21,11 @@
               set -euxo pipefail
 
               # Generate Typescript types from rust types
-              mkdir -p tauri-app/src/typeshare;
-              typeshare crates/subgraph/src/types/vault.rs --lang=typescript --output-file=tauri-app/src/lib/typeshare/vault.ts;
-              typeshare crates/subgraph/src/types/vaults.rs --lang=typescript --output-file=tauri-app/src/lib/typeshare/vaults.ts;
-              typeshare crates/subgraph/src/types/order.rs --lang=typescript --output-file=tauri-app/src/lib/typeshare/order.ts;
-              typeshare crates/subgraph/src/types/orders.rs --lang=typescript --output-file=tauri-app/src/lib/typeshare/orders.ts;
+              mkdir -p tauri-app/src/lib/typeshare;
+              typeshare crates/subgraph/src/types/vault_detail.rs --lang=typescript --output-file=tauri-app/src/lib/typeshare/vaultDetail.ts;
+              typeshare crates/subgraph/src/types/vaults_list.rs --lang=typescript --output-file=tauri-app/src/lib/typeshare/vaultsList.ts;
+              typeshare crates/subgraph/src/types/order_detail.rs --lang=typescript --output-file=tauri-app/src/lib/typeshare/orderDetail.ts;
+              typeshare crates/subgraph/src/types/orders_list.rs --lang=typescript --output-file=tauri-app/src/lib/typeshare/ordersList.ts;
               typeshare tauri-app/src-tauri/src/toast.rs --lang=typescript --output-file=tauri-app/src/lib/typeshare/toast.ts;
               typeshare tauri-app/src-tauri/src/transaction_status.rs --lang=typescript --output-file=tauri-app/src/lib/typeshare/transactionStatus.ts;
 

--- a/tauri-app/src-tauri/src/commands/order.rs
+++ b/tauri-app/src-tauri/src/commands/order.rs
@@ -8,29 +8,29 @@ use rain_orderbook_common::{
     transaction::TransactionArgs,
 };
 use rain_orderbook_subgraph_client::types::{
-    order::Order as OrderDetail,
-    orders::Order as OrdersListItem,
+    order_detail,
+    orders_list
 };
 use tauri::AppHandle;
 use crate::error::CommandResult;
 
 #[tauri::command]
-pub async fn orders_list(subgraph_args: SubgraphArgs) -> CommandResult<Vec<OrdersListItem>> {
+pub async fn orders_list(subgraph_args: SubgraphArgs) -> CommandResult<Vec<orders_list::Order>> {
     let orders = subgraph_args
         .to_subgraph_client()
         .await?
-        .orders()
+        .orders_list()
         .await?;
     
     Ok(orders)
 }
 
 #[tauri::command]
-pub async fn order_detail(id: String, subgraph_args: SubgraphArgs) -> CommandResult<OrderDetail> {
+pub async fn order_detail(id: String, subgraph_args: SubgraphArgs) -> CommandResult<order_detail::Order> {
     let order = subgraph_args
         .to_subgraph_client()
         .await?
-        .order(id.into())
+        .order_detail(id.into())
         .await?;
 
     Ok(order)
@@ -51,7 +51,7 @@ pub async fn order_remove(
             toast_error(app_handle.clone(), String::from("Subgraph URL is invalid"));
             e
         })?
-        .order(id.into())
+        .order_detail(id.into())
         .await
         .map_err(|e| {
             toast_error(app_handle.clone(), e.to_string());

--- a/tauri-app/src-tauri/src/commands/vault.rs
+++ b/tauri-app/src-tauri/src/commands/vault.rs
@@ -4,28 +4,28 @@ use rain_orderbook_common::{
     withdraw::WithdrawArgs,
 };
 use rain_orderbook_subgraph_client::types::{
-    vault::TokenVault as VaultDetail, vaults::TokenVault as VaultsListItem,
+    vault_detail, vaults_list
 };
 use tauri::AppHandle;
 use crate::error::CommandResult;
 
 #[tauri::command]
-pub async fn vaults_list(subgraph_args: SubgraphArgs) -> CommandResult<Vec<VaultsListItem>> {
+pub async fn vaults_list(subgraph_args: SubgraphArgs) -> CommandResult<Vec<vaults_list::TokenVault>> {
     let vaults = subgraph_args
         .to_subgraph_client()
         .await?
-        .vaults()
+        .vaults_list()
         .await?;
 
     Ok(vaults)
 }
 
 #[tauri::command]
-pub async fn vault_detail(id: String, subgraph_args: SubgraphArgs) -> CommandResult<VaultDetail> {
+pub async fn vault_detail(id: String, subgraph_args: SubgraphArgs) -> CommandResult<vault_detail::TokenVault> {
     let vault = subgraph_args
         .to_subgraph_client()
         .await?
-        .vault(id.into())
+        .vault_detail(id.into())
         .await?;
     
     Ok(vault)

--- a/tauri-app/src/lib/components/ButtonVaultLink.svelte
+++ b/tauri-app/src/lib/components/ButtonVaultLink.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { goto } from "$app/navigation";
-    import type { TokenVault } from "$lib/typeshare/order";
+    import type { TokenVault } from "$lib/typeshare/orderDetail";
     import { formatAddressShorthand } from "$lib/utils/address";
     import { Button } from "flowbite-svelte";
     import { toHex } from "viem";

--- a/tauri-app/src/lib/components/ModalVaultDeposit.svelte
+++ b/tauri-app/src/lib/components/ModalVaultDeposit.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { Button, Modal, Label, ButtonGroup } from 'flowbite-svelte';
-  import type { TokenVault } from '$lib/typeshare/vault';
+  import type { TokenVault } from '$lib/typeshare/vaultDetail';
   import InputTokenAmount from '$lib/components/InputTokenAmount.svelte';
   import { vaultDeposit } from '$lib/utils/vaultDeposit';
   import { toHex } from 'viem';

--- a/tauri-app/src/lib/components/ModalVaultWithdraw.svelte
+++ b/tauri-app/src/lib/components/ModalVaultWithdraw.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { Button, Modal, Label, Helper } from 'flowbite-svelte';
-  import type { TokenVault } from '$lib/typeshare/vault';
+  import type { TokenVault } from '$lib/typeshare/vaultDetail';
   import InputTokenAmount from '$lib/components/InputTokenAmount.svelte';
   import { vaultWithdraw } from '$lib/utils/vaultWithdraw';
   import { toHex } from 'viem';

--- a/tauri-app/src/lib/stores/orderDetail.ts
+++ b/tauri-app/src/lib/stores/orderDetail.ts
@@ -1,12 +1,12 @@
 import { get, writable } from 'svelte/store';
-import type { Order as OrderDetail } from '$lib/typeshare/order';
+import type { Order } from '$lib/typeshare/orderDetail';
 import { invoke } from '@tauri-apps/api';
 import { subgraphUrl } from '$lib/stores/settings';
 
 function useOrderDetailStore() {
   const STORAGE_KEY = "orders.orderDetail";
 
-  const { subscribe, update } = writable<{[id: string]: OrderDetail}>(localStorage.getItem(STORAGE_KEY) ? JSON.parse(localStorage.getItem(STORAGE_KEY) as string) : {});
+  const { subscribe, update } = writable<{[id: string]: Order}>(localStorage.getItem(STORAGE_KEY) ? JSON.parse(localStorage.getItem(STORAGE_KEY) as string) : {});
 
   subscribe(value => {
     if(value) {
@@ -17,7 +17,7 @@ function useOrderDetailStore() {
   });
 
   async function refetch(id: string) {
-    const res: OrderDetail = await invoke("order_detail", {id, subgraphArgs: { url: get(subgraphUrl)} });
+    const res: Order = await invoke("order_detail", {id, subgraphArgs: { url: get(subgraphUrl)} });
     update((value) => {
       return {... value, [id]: res};
     });

--- a/tauri-app/src/lib/stores/ordersList.ts
+++ b/tauri-app/src/lib/stores/ordersList.ts
@@ -1,12 +1,12 @@
 import { get, writable } from 'svelte/store';
-import type { Order as OrdersListItem } from '$lib/typeshare/orders';
+import type { Order } from '$lib/typeshare/ordersList';
 import { invoke } from '@tauri-apps/api';
 import { subgraphUrl } from '$lib/stores/settings';
 
 function useOrdersListStore() {
   const STORAGE_KEY = "orders.ordersList";
 
-  const { subscribe, set } = writable<Array<OrdersListItem>>(localStorage.getItem(STORAGE_KEY) ? JSON.parse(localStorage.getItem(STORAGE_KEY) as string) : []);
+  const { subscribe, set } = writable<Array<Order>>(localStorage.getItem(STORAGE_KEY) ? JSON.parse(localStorage.getItem(STORAGE_KEY) as string) : []);
 
   subscribe(value => {
     if(value) {
@@ -17,7 +17,7 @@ function useOrdersListStore() {
   });
 
   async function refetch() {
-    const res: Array<OrdersListItem> = await invoke("orders_list", {subgraphArgs: { url: get(subgraphUrl)} });
+    const res: Array<Order> = await invoke("orders_list", {subgraphArgs: { url: get(subgraphUrl)} });
     set(res);
   }
 

--- a/tauri-app/src/lib/stores/vaultDetail.ts
+++ b/tauri-app/src/lib/stores/vaultDetail.ts
@@ -1,12 +1,12 @@
 import { get, writable } from 'svelte/store';
-import type { TokenVault as VaultDetail } from '$lib/typeshare/vault';
+import type { TokenVault } from '$lib/typeshare/vaultDetail';
 import { invoke } from '@tauri-apps/api';
 import { subgraphUrl } from '$lib/stores/settings';
 
 function useVaultDetailStore() {
   const STORAGE_KEY = "vaults.vaultsDetail";
 
-  const { subscribe, update } = writable<{[id: string]: VaultDetail}>(localStorage.getItem(STORAGE_KEY) ? JSON.parse(localStorage.getItem(STORAGE_KEY) as string) : {});
+  const { subscribe, update } = writable<{[id: string]: TokenVault}>(localStorage.getItem(STORAGE_KEY) ? JSON.parse(localStorage.getItem(STORAGE_KEY) as string) : {});
 
   subscribe(value => {
     if(value) {
@@ -17,7 +17,7 @@ function useVaultDetailStore() {
   });
 
   async function refetch(id: string) {
-    const res: VaultDetail = await invoke("vault_detail", {id, subgraphArgs: { url: get(subgraphUrl)} });
+    const res: TokenVault = await invoke("vault_detail", {id, subgraphArgs: { url: get(subgraphUrl)} });
     update((value) => {
       return {... value, [id]: res};
     });

--- a/tauri-app/src/lib/stores/vaultsList.ts
+++ b/tauri-app/src/lib/stores/vaultsList.ts
@@ -1,12 +1,12 @@
 import { get, writable } from 'svelte/store';
-import type { TokenVault as VaultsListItem } from '$lib/typeshare/vaults';
+import type { TokenVault } from '$lib/typeshare/vaultsList';
 import { invoke } from '@tauri-apps/api';
 import { subgraphUrl } from '$lib/stores/settings';
 
 function useVaultsListStore() {
   const STORAGE_KEY = "vaults.vaultsList";
 
-  const { subscribe, set } = writable<Array<VaultsListItem>>(localStorage.getItem(STORAGE_KEY) ? JSON.parse(localStorage.getItem(STORAGE_KEY) as string) : []);
+  const { subscribe, set } = writable<Array<TokenVault>>(localStorage.getItem(STORAGE_KEY) ? JSON.parse(localStorage.getItem(STORAGE_KEY) as string) : []);
 
   subscribe(value => {
     if(value) {
@@ -17,7 +17,7 @@ function useVaultsListStore() {
   });
 
   async function refetch() {
-    const res: Array<VaultsListItem> = await invoke("vaults_list", {subgraphArgs: { url: get(subgraphUrl)} });
+    const res: Array<TokenVault> = await invoke("vaults_list", {subgraphArgs: { url: get(subgraphUrl)} });
     set(res);
   }
 


### PR DESCRIPTION
- rename subgraph queries & associated types / fns to be more explicit: 
    - vault -> vault_detail
    - vaults -> vaults_list
    - order -> order_detail
    - orders -> orders_list