### PR TITLE
feat(tauri/ui): move action buttons to header in detail pages

### DIFF
--- a/tauri-app/src/routes/orders/[id]/+page.svelte
+++ b/tauri-app/src/routes/orders/[id]/+page.svelte
@@ -27,6 +27,13 @@
 </script>
 
 <PageHeader title="Order">
+  <svelte:fragment slot="actions">
+    {#if order && $walletAddressMatchesOrBlank(order.owner.id) && order.order_active}
+      <ButtonLoading color="blue" size="xs" on:click={remove} loading={isSubmitting}>
+        Remove
+      </ButtonLoading>
+    {/if}
+  </svelte:fragment>
   <svelte:fragment slot="breadcrumbs">
     <BreadcrumbItem href="/orders">Orders</BreadcrumbItem>
   </svelte:fragment>
@@ -86,16 +93,6 @@
           {/each}
         </div>
       </div>
-
-      {#if $walletAddressMatchesOrBlank(order.owner.id) && order.order_active}
-        <div class="mt-8">
-          <div class="flex justify-center space-x-20">
-            <ButtonLoading color="blue" size="xl" on:click={remove} loading={isSubmitting}>
-              Remove
-            </ButtonLoading>
-          </div>
-        </div>
-      {/if}
     </Card>
   </div>
 {/if}

--- a/tauri-app/src/routes/vaults/[id]/+page.svelte
+++ b/tauri-app/src/routes/vaults/[id]/+page.svelte
@@ -14,7 +14,7 @@
   import { vaultDetail } from '$lib/stores/vaultDetail';
   import ModalVaultDeposit from '$lib/components/ModalVaultDeposit.svelte';
   import ModalVaultWithdraw from '$lib/components/ModalVaultWithdraw.svelte';
-  import { walletAddress } from '$lib/stores/settings';
+  import { walletAddressMatchesOrBlank } from '$lib/stores/settings';
   import { toHex } from 'viem';
   import { formatTimestampSecondsAsLocal } from '$lib/utils/time';
   import PageHeader from '$lib/components/PageHeader.svelte';
@@ -37,6 +37,12 @@
 <PageHeader title="Vault">
   <svelte:fragment slot="breadcrumbs">
     <BreadcrumbItem href="/vaults">Vaults</BreadcrumbItem>
+  </svelte:fragment>
+  <svelte:fragment slot="actions">
+    {#if vault && $walletAddressMatchesOrBlank(vault.owner.id)}
+      <Button color="green" size="xs" on:click={toggleDepositModal}>Deposit</Button>
+      <Button color="blue" size="xs" on:click={toggleWithdrawModal}>Withdraw</Button>
+    {/if}
   </svelte:fragment>
 </PageHeader>
 
@@ -81,15 +87,6 @@
           {vault.token.symbol}
         </p>
       </div>
-
-      {#if $walletAddress !== '' && vault.owner.id === $walletAddress}
-        <div class="pt-4">
-          <div class="flex justify-center space-x-20">
-            <Button color="green" size="xl" on:click={toggleDepositModal}>Deposit</Button>
-            <Button color="blue" size="xl" on:click={toggleWithdrawModal}>Withdraw</Button>
-          </div>
-        </div>
-      {/if}
     </Card>
 
     <div class="max-w-screen-xl space-y-12">


### PR DESCRIPTION
Move action buttons into header for Order Detail and Vault Detail pages. This keeps ux consistency with the list pages.

![image](https://github.com/rainlanguage/rain.orderbook/assets/159270/ac6f12c2-5982-4c9a-a7f0-06aae9577f63)
![image](https://github.com/rainlanguage/rain.orderbook/assets/159270/06c05f45-137a-4592-b113-227df3e86c38)
