### PR TITLE
chore: cleanup error types and map_errs

### DIFF
--- a/crates/common/src/add_order.rs
+++ b/crates/common/src/add_order.rs
@@ -35,7 +35,7 @@ pub enum AddOrderArgsError {
     FromHexError(#[from] FromHexError),
     #[error(transparent)]
     WritableClientError(#[from] WritableClientError),
-    #[error("TransactionArgs error: {0}")]
+    #[error(transparent)]
     TransactionArgs(#[from] TransactionArgsError),
     #[error(transparent)]
     RainMetaError(#[from] RainMetaError),

--- a/crates/common/src/deposit.rs
+++ b/crates/common/src/deposit.rs
@@ -37,22 +37,16 @@ impl DepositArgs {
         transaction_args: TransactionArgs,
         transaction_status_changed: S,
     ) -> Result<(), WritableTransactionExecuteError> {
-        let ledger_client = transaction_args
-            .clone()
-            .try_into_ledger_client()
-            .await
-            .map_err(WritableTransactionExecuteError::TransactionArgs)?;
+        let ledger_client = transaction_args.clone().try_into_ledger_client().await?;
 
         let approve_call = self.into_approve_call(transaction_args.orderbook_address);
         let params = transaction_args
             .try_into_write_contract_parameters(approve_call, self.token)
-            .await
-            .map_err(WritableTransactionExecuteError::TransactionArgs)?;
+            .await?;
 
         WriteTransaction::new(ledger_client.client, params, 4, transaction_status_changed)
             .execute()
-            .await
-            .map_err(WritableTransactionExecuteError::WritableClient)?;
+            .await?;
 
         Ok(())
     }
@@ -63,22 +57,16 @@ impl DepositArgs {
         transaction_args: TransactionArgs,
         transaction_status_changed: S,
     ) -> Result<(), WritableTransactionExecuteError> {
-        let ledger_client = transaction_args
-            .clone()
-            .try_into_ledger_client()
-            .await
-            .map_err(WritableTransactionExecuteError::TransactionArgs)?;
+        let ledger_client = transaction_args.clone().try_into_ledger_client().await?;
 
         let deposit_call: depositCall = self.clone().into();
         let params = transaction_args
             .try_into_write_contract_parameters(deposit_call, transaction_args.orderbook_address)
-            .await
-            .map_err(WritableTransactionExecuteError::TransactionArgs)?;
+            .await?;
 
         WriteTransaction::new(ledger_client.client, params, 4, transaction_status_changed)
             .execute()
-            .await
-            .map_err(WritableTransactionExecuteError::WritableClient)?;
+            .await?;
 
         Ok(())
     }

--- a/crates/common/src/error.rs
+++ b/crates/common/src/error.rs
@@ -5,11 +5,11 @@ use crate::transaction::TransactionArgsError;
 
 #[derive(Error, Debug)]
 pub enum WritableTransactionExecuteError {
-    #[error("WritableClient error: {0}")]
+    #[error(transparent)]
     WritableClient(#[from] WritableClientError),
-    #[error("TransactionArgs error: {0}")]
+    #[error(transparent)]
     TransactionArgs(#[from] TransactionArgsError),
-    #[error("LedgerClient error: {0}")]
+    #[error(transparent)]
     LedgerClient(#[from] LedgerClientError),
     #[error("Invalid input args: {0}")]
     InvalidArgs(String),

--- a/crates/common/src/remove_order.rs
+++ b/crates/common/src/remove_order.rs
@@ -48,11 +48,7 @@ impl RemoveOrderArgs {
         transaction_args: TransactionArgs,
         transaction_status_changed: S,
     ) -> Result<(), RemoveOrderArgsError> {
-        let ledger_client = transaction_args
-            .clone()
-            .try_into_ledger_client()
-            .await
-            .map_err(RemoveOrderArgsError::TransactionArgs)?;
+        let ledger_client = transaction_args.clone().try_into_ledger_client().await?;
 
         let remove_order_call: removeOrderCall = self.try_into()?;
         let params = transaction_args
@@ -60,13 +56,11 @@ impl RemoveOrderArgs {
                 remove_order_call,
                 transaction_args.orderbook_address,
             )
-            .await
-            .map_err(RemoveOrderArgsError::TransactionArgs)?;
+            .await?;
 
         WriteTransaction::new(ledger_client.client, params, 4, transaction_status_changed)
             .execute()
-            .await
-            .map_err(RemoveOrderArgsError::WritableClientError)?;
+            .await?;
 
         Ok(())
     }

--- a/crates/common/src/subgraph.rs
+++ b/crates/common/src/subgraph.rs
@@ -26,10 +26,7 @@ impl From<SubgraphPaginationArgs> for OrdersListQueryVariables {
     fn from(val: SubgraphPaginationArgs) -> Self {
         let (skip, first): (Option<i32>, Option<i32>) = val.into();
 
-        OrdersListQueryVariables {
-            skip,
-            first,
-        }
+        OrdersListQueryVariables { skip, first }
     }
 }
 
@@ -37,17 +34,14 @@ impl From<SubgraphPaginationArgs> for VaultsListQueryVariables {
     fn from(val: SubgraphPaginationArgs) -> Self {
         let (skip, first): (Option<i32>, Option<i32>) = val.into();
 
-        Self {
-            skip,
-            first,
-        }
+        Self { skip, first }
     }
 }
 impl From<SubgraphPaginationArgs> for (Option<i32>, Option<i32>) {
     fn from(val: SubgraphPaginationArgs) -> Self {
         let page: i32 = val.page.saturating_sub(1).into();
         let page_size: i32 = val.page_size.into();
-        
+
         (Some(page_size * page), Some(page_size))
     }
 }

--- a/crates/common/src/withdraw.rs
+++ b/crates/common/src/withdraw.rs
@@ -28,22 +28,16 @@ impl WithdrawArgs {
         transaction_args: TransactionArgs,
         transaction_status_changed: S,
     ) -> Result<(), WritableTransactionExecuteError> {
-        let ledger_client = transaction_args
-            .clone()
-            .try_into_ledger_client()
-            .await
-            .map_err(WritableTransactionExecuteError::TransactionArgs)?;
+        let ledger_client = transaction_args.clone().try_into_ledger_client().await?;
 
         let withdraw_call: withdrawCall = self.clone().into();
         let params = transaction_args
             .try_into_write_contract_parameters(withdraw_call, transaction_args.orderbook_address)
-            .await
-            .map_err(WritableTransactionExecuteError::TransactionArgs)?;
+            .await?;
 
         WriteTransaction::new(ledger_client.client, params, 4, transaction_status_changed)
             .execute()
-            .await
-            .map_err(WritableTransactionExecuteError::WritableClient)?;
+            .await?;
 
         Ok(())
     }

--- a/crates/subgraph/src/client.rs
+++ b/crates/subgraph/src/client.rs
@@ -49,8 +49,7 @@ impl OrderbookSubgraphClient {
     ) -> Result<Vec<vaults_list::TokenVault>, OrderbookSubgraphClientError> {
         let data = self
             .query::<VaultsListQuery, VaultsListQueryVariables>(self.url.clone(), variables.into())
-            .await
-            .map_err(OrderbookSubgraphClientError::CynicClientError)?;
+            .await?;
 
         Ok(data.token_vaults)
     }
@@ -64,8 +63,7 @@ impl OrderbookSubgraphClient {
                 self.url.clone(),
                 VaultDetailQueryVariables { id: &id },
             )
-            .await
-            .map_err(OrderbookSubgraphClientError::CynicClientError)?;
+            .await?;
         let vault = data
             .token_vault
             .ok_or(OrderbookSubgraphClientError::Empty)?;

--- a/crates/subgraph/src/cynic_client.rs
+++ b/crates/subgraph/src/cynic_client.rs
@@ -27,13 +27,10 @@ pub trait CynicClient {
             .post(base_url.clone())
             .json(&request_body)
             .send()
-            .await
-            .map_err(CynicClientError::Request)?;
+            .await?;
 
-        let response_deserialized: GraphQlResponse<R> = response
-            .json::<GraphQlResponse<R>>()
-            .await
-            .map_err(CynicClientError::Request)?;
+        let response_deserialized: GraphQlResponse<R> =
+            response.json::<GraphQlResponse<R>>().await?;
 
         match response_deserialized.errors {
             Some(errors) => Err(CynicClientError::GraphqlError(errors)),


### PR DESCRIPTION
Still learning how to work with rust errors -- this seems cleaner.

- make some error types transparent
- avoid map_err unless necessary