### PR TITLE
fix(tauri/ui): display time in local tz & format

### DIFF
--- a/tauri-app/src/lib/utils/time.ts
+++ b/tauri-app/src/lib/utils/time.ts
@@ -1,12 +1,10 @@
 import dayjs from 'dayjs';
-import utc from 'dayjs/plugin/utc';
 import bigIntSupport from 'dayjs/plugin/bigIntSupport';
-dayjs.extend(utc);
+import localizedFormat from 'dayjs/plugin/localizedFormat';
 dayjs.extend(bigIntSupport);
+dayjs.extend(localizedFormat);
 
 export function formatTimestampSecondsAsLocal(timestampSeconds: bigint) {
   return dayjs(timestampSeconds  * BigInt('1000'))
-    .utc(true)
-    .local()
-    .format('DD/MM/YYYY h:mm A');
+    .format('L LT');
 }


### PR DESCRIPTION
times were incorrectly displaying as utc, now they are displayed in local time (and localized formatting) as expected.