### PR TITLE
WIP 2024 02 05 refactor fork

### DIFF
--- a/crates/common/src/decode_abi_error.rs
+++ b/crates/common/src/decode_abi_error.rs
@@ -47,7 +47,7 @@ impl std::fmt::Display for AbiDecodedErrorType {
 }
 
 /// decodes an error returned from calling a contract by searching its selector in registry
-pub async fn abi_decode_error<'a>(
+pub async fn decode_abi_error<'a>(
     error_data: &[u8],
 ) -> Result<AbiDecodedErrorType, AbiDecodeFailedErrors<'a>> {
     let (hash_bytes, args_data) = error_data.split_at(4);
@@ -132,7 +132,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_error_decoder() {
-        let res = abi_decode_error(&[26, 198, 105, 8])
+        let res = decode_abi_error(&[26, 198, 105, 8])
             .await
             .expect("failed to get error selector");
         assert_eq!(

--- a/crates/common/src/deposit.rs
+++ b/crates/common/src/deposit.rs
@@ -1,5 +1,4 @@
-use crate::error::WritableTransactionExecuteError;
-use crate::transaction::TransactionArgs;
+use crate::{transaction::TransactionArgs, transaction_error::WritableTransactionExecuteError};
 use alloy_ethers_typecast::transaction::{WriteTransaction, WriteTransactionStatus};
 use alloy_primitives::{Address, U256};
 use rain_orderbook_bindings::{IOrderBookV3::depositCall, IERC20::approveCall};

--- a/crates/common/src/fork.rs
+++ b/crates/common/src/fork.rs
@@ -1,6 +1,6 @@
 use crate::add_order::AddOrderArgsError;
 use crate::decode_abi_error::{AbiDecodeFailedErrors, AbiDecodedErrorType};
-use crate::{add_order::AddOrderArgs, decode_abi_error::abi_decode_error};
+use crate::{add_order::AddOrderArgs, decode_abi_error::decode_abi_error};
 use alloy_primitives::hex::decode;
 use alloy_sol_types::SolCall;
 use forker::ForkedEvm;
@@ -110,7 +110,7 @@ pub async fn fork_call<'a>(
 
     if result.reverted {
         // decode result bytes to error selectors if it was a revert
-        Ok(Err(abi_decode_error(&result.result).await?))
+        Ok(Err(decode_abi_error(&result.result).await?))
     } else {
         Ok(Ok(result.result))
     }

--- a/crates/common/src/fork.rs
+++ b/crates/common/src/fork.rs
@@ -14,6 +14,7 @@ use std::sync::{MutexGuard, PoisonError};
 use std::{collections::HashMap, sync::Mutex};
 use thiserror::Error;
 
+/// arbitrary address used to call contracts from in fork
 const FROM_ADDRESS: &str = "0x5855A7b48a1f9811392B89F18A8e27347EF84E42";
 
 /// static hashmap of fork evm instances, used for caching instances between runs

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -1,8 +1,9 @@
 pub mod add_order;
+pub mod decode_abi_error;
 pub mod deposit;
-pub mod error;
 pub mod fork;
 pub mod remove_order;
 pub mod subgraph;
 pub mod transaction;
+pub mod transaction_error;
 pub mod withdraw;

--- a/crates/common/src/transaction_error.rs
+++ b/crates/common/src/transaction_error.rs
@@ -1,0 +1,15 @@
+use crate::transaction::TransactionArgsError;
+use alloy_ethers_typecast::{client::LedgerClientError, transaction::WritableClientError};
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum WritableTransactionExecuteError {
+    #[error(transparent)]
+    WritableClient(#[from] WritableClientError),
+    #[error(transparent)]
+    TransactionArgs(#[from] TransactionArgsError),
+    #[error(transparent)]
+    LedgerClient(#[from] LedgerClientError),
+    #[error("Invalid input args: {0}")]
+    InvalidArgs(String),
+}

--- a/crates/common/src/withdraw.rs
+++ b/crates/common/src/withdraw.rs
@@ -1,8 +1,9 @@
-use crate::{error::WritableTransactionExecuteError, transaction::TransactionArgs};
 use alloy_ethers_typecast::transaction::{WriteTransaction, WriteTransactionStatus};
 use alloy_primitives::{Address, U256};
 use rain_orderbook_bindings::IOrderBookV3::withdrawCall;
 use serde::{Deserialize, Serialize};
+
+use crate::{transaction::TransactionArgs, transaction_error::WritableTransactionExecuteError};
 
 #[derive(Clone, Deserialize, Serialize, Debug)]
 pub struct WithdrawArgs {


### PR DESCRIPTION
some refactoring to make the work in #171 and #127 a bit cleaner / more legible:
- split out abi decoding fn and types into separate file
- move fork call errors into fork.rs
- function rename

**todo**
- [ ] avoid deeply nested conditionals
- [ ] avoid double-wrapped return
- [ ] clarifying comments for constants
- [ ] pass around Address instead of byte arrays