### PR TITLE
feat(tauri): set WEBKIT_DISABLE_COMPOSITING_MODE=1 on linux

### DIFF
--- a/tauri-app/src-tauri/src/main.rs
+++ b/tauri-app/src-tauri/src/main.rs
@@ -18,12 +18,18 @@ use commands::order_clear::{order_clears_list, order_clears_list_write_csv};
 use commands::wallet::get_address_from_ledger;
 
 fn main() {
-    // Disable webkitgtk Accelerated Compositing to avoid a blank screen
-    // See https://github.com/tauri-apps/tauri/issues/5143
     if std::env::consts::OS == "linux" {
+        // Disable webkitgtk Accelerated Compositing to avoid a blank screen
+        // See https://github.com/tauri-apps/tauri/issues/5143
         std::env::set_var("WEBKIT_DISABLE_COMPOSITING_MODE", "1");
+        run_tauri_app();
+        std::env::remove_var("WEBKIT_DISABLE_COMPOSITING_MODE");
+    } else {
+        run_tauri_app();
     }
-    
+}
+
+fn run_tauri_app() {
     tauri::Builder::default()
         .invoke_handler(tauri::generate_handler![
             vaults_list,
@@ -49,9 +55,4 @@ fn main() {
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
-
-    // Cleanup env var
-    if std::env::consts::OS == "linux" {
-        std::env::remove_var("WEBKIT_DISABLE_COMPOSITING_MODE");
-    }
 }

--- a/tauri-app/src-tauri/src/main.rs
+++ b/tauri-app/src-tauri/src/main.rs
@@ -18,6 +18,12 @@ use commands::order_clear::{order_clears_list, order_clears_list_write_csv};
 use commands::wallet::get_address_from_ledger;
 
 fn main() {
+    // Disable webkitgtk Accelerated Compositing to avoid a blank screen
+    // See https://github.com/tauri-apps/tauri/issues/5143
+    if std::env::consts::OS == "linux" {
+        std::env::set_var("WEBKIT_DISABLE_COMPOSITING_MODE", "1");
+    }
+    
     tauri::Builder::default()
         .invoke_handler(tauri::generate_handler![
             vaults_list,
@@ -43,4 +49,9 @@ fn main() {
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
+
+    // Cleanup env var
+    if std::env::consts::OS == "linux" {
+        std::env::remove_var("WEBKIT_DISABLE_COMPOSITING_MODE");
+    }
 }


### PR DESCRIPTION
Resolves #214 
Sets WEBKIT_DISABLE_COMPOSITING_MODE=1 in the tauri main function on linux, so the user doesn't have to do it manually when running the binary.