### PR TITLE
fix: macos dynamic linking error preventing launch

### DIFF
--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -1,10 +1,7 @@
 name: 'publish'
 
 # This will trigger the action on each push to the `release` branch.
-on:
-  push:
-    branches:
-      - main
+on: [push]
 
 jobs:
   publish-tauri:
@@ -62,3 +59,4 @@ jobs:
           tagName: app-v__VERSION__-${{ github.sha }} # the action automatically replaces \_\_VERSION\_\_ with the app version
           releaseName: 'App v__VERSION__-${{ github.sha }}'
           releaseBody: 'See the assets to download this version and install.'
+          releaseDraft: true

--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -1,7 +1,10 @@
 name: 'publish'
 
 # This will trigger the action on each push to the `release` branch.
-on: [push]
+on:
+  push:
+    branches:
+      - main
 
 jobs:
   publish-tauri:
@@ -11,7 +14,11 @@ jobs:
       fail-fast: false
       matrix:
         platform: [
-          macos-11,
+          macos-12,
+          macos-14,
+          ubuntu-20.04
+          # Someone who cares can make windows work.
+          # windows-latest
         ]
 
     runs-on: ${{ matrix.platform }}
@@ -55,4 +62,3 @@ jobs:
           tagName: app-v__VERSION__-${{ github.sha }} # the action automatically replaces \_\_VERSION\_\_ with the app version
           releaseName: 'App v__VERSION__-${{ github.sha }}'
           releaseBody: 'See the assets to download this version and install.'
-          releaseDraft: true

--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -11,11 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [
-          macos-latest,
-          macos-14,
-          ubuntu-20.04
-          # Someone who cares can make windows work.
-          # windows-latest
+          macos-11,
         ]
 
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -15,6 +15,7 @@ jobs:
       matrix:
         platform: [
           macos-latest,
+          macos-14,
           ubuntu-20.04
           # Someone who cares can make windows work.
           # windows-latest

--- a/tauri-app/src-tauri/tauri.conf.json
+++ b/tauri-app/src-tauri/tauri.conf.json
@@ -35,10 +35,7 @@
         "icons/128x128@2x.png",
         "icons/icon.icns",
         "icons/icon.ico"
-      ],
-      "macOS": {
-        "signingIdentity": "-"
-      }
+      ]
     },
     "security": {
       "csp": null


### PR DESCRIPTION
Improves #224 
- Reverts #219 
- builds binaries both on an x86_64 mac and an aarch64 mac

The aarch64 binaries run properly. The x86_64 ones still crash on launch with the same error. 