### PR TITLE
refactor parser error handling, pass better error message deployer contract address is bad

### DIFF
--- a/crates/common/src/deposit.rs
+++ b/crates/common/src/deposit.rs
@@ -1,5 +1,4 @@
-use crate::error::WritableTransactionExecuteError;
-use crate::transaction::TransactionArgs;
+use crate::transaction::{TransactionArgs, WritableTransactionExecuteError};
 use alloy_ethers_typecast::transaction::{WriteTransaction, WriteTransactionStatus};
 use alloy_primitives::{Address, U256};
 use rain_orderbook_bindings::{IOrderBookV3::depositCall, IERC20::approveCall};

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -1,8 +1,8 @@
+pub mod abi_error;
 pub mod add_order;
 pub mod csv;
 pub mod deposit;
 pub mod dotrain_add_order_lsp;
-pub mod error;
 pub mod forked_evm_cache;
 pub mod frontmatter;
 pub mod meta;

--- a/crates/common/src/transaction.rs
+++ b/crates/common/src/transaction.rs
@@ -2,7 +2,7 @@ use alloy_ethers_typecast::{
     client::{LedgerClient, LedgerClientError},
     gas_fee_middleware::GasFeeSpeed,
     transaction::{
-        ReadableClientError, ReadableClientHttp, WriteContractParameters,
+        ReadableClientError, ReadableClientHttp, WritableClientError, WriteContractParameters,
         WriteContractParametersBuilder, WriteContractParametersBuilderError,
     },
 };
@@ -10,6 +10,18 @@ use alloy_primitives::{ruint::FromUintError, Address, U256};
 use alloy_sol_types::SolCall;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum WritableTransactionExecuteError {
+    #[error(transparent)]
+    WritableClient(#[from] WritableClientError),
+    #[error(transparent)]
+    TransactionArgs(#[from] TransactionArgsError),
+    #[error(transparent)]
+    LedgerClient(#[from] LedgerClientError),
+    #[error("Invalid input args: {0}")]
+    InvalidArgs(String),
+}
 
 #[derive(Error, Debug)]
 pub enum TransactionArgsError {

--- a/crates/common/src/withdraw.rs
+++ b/crates/common/src/withdraw.rs
@@ -1,4 +1,4 @@
-use crate::{error::WritableTransactionExecuteError, transaction::TransactionArgs};
+use crate::transaction::{TransactionArgs, WritableTransactionExecuteError};
 use alloy_ethers_typecast::transaction::{WriteTransaction, WriteTransactionStatus};
 use alloy_primitives::{Address, U256};
 use rain_orderbook_bindings::IOrderBookV3::withdrawCall;

--- a/tauri-app/src-tauri/src/error.rs
+++ b/tauri-app/src-tauri/src/error.rs
@@ -1,7 +1,7 @@
 use alloy_ethers_typecast::{client::LedgerClientError, transaction::ReadableClientError};
 use alloy_primitives::ruint::FromUintError;
 use rain_orderbook_common::{
-    add_order::AddOrderArgsError, error::ForkParseError, meta::TryDecodeRainlangSourceError,
+    add_order::AddOrderArgsError, rainlang::ForkParseError, meta::TryDecodeRainlangSourceError,
     utils::timestamp::FormatTimestampDisplayError, csv::TryIntoCsvError,
 };
 use rain_orderbook_subgraph_client::{


### PR DESCRIPTION
Resolves #326 
Resolves #260 
Resolves #327 

All these linked issues were actually just that the deployer address in my .rain file didn't match a deployer for the chain I was using, so the call to read the Parser address returned no bytes.

![image](https://github.com/rainlanguage/rain.orderbook/assets/159270/80b54720-779f-4690-a2b1-0e72db03bf3b)
