### PR TITLE
build: specify typeshare fork as distinct git repo

### DIFF
--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -1,4 +1,4 @@
-name: "publish"
+name: Tauri Publish
 
 # This will trigger the action on each push to the `release` branch.
 on:

--- a/.github/workflows/tauri.yaml
+++ b/.github/workflows/tauri.yaml
@@ -2,18 +2,27 @@ name: Tauri builds
 on: [push]
 
 jobs:
-  build-tauri:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-          fetch-depth: 0
-      - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v4
-      - uses: DeterminateSystems/magic-nix-cache-action@v2
+  strategy:
+    fail-fast: true
+    matrix:
+      platform: [
+          macos-13,
+          macos-14,
+          ubuntu-22.04,
+        ]
 
-      - run: ./prep-tauri.sh
+    build-tauri:
+      runs-on: ${{ matrix.os }}
+      steps:
+        - uses: actions/checkout@v4
+          with:
+            submodules: recursive
+            fetch-depth: 0
+        - name: Install Nix
+          uses: DeterminateSystems/nix-installer-action@v4
+        - uses: DeterminateSystems/magic-nix-cache-action@v2
 
-      - run: nix develop .#tauri-shell --command cargo tauri build --verbose
-        working-directory: ./tauri-app
+        - run: ./prep-tauri.sh
+
+        - run: nix develop .#tauri-shell --command cargo tauri build --verbose
+          working-directory: ./tauri-app

--- a/.github/workflows/tauri.yaml
+++ b/.github/workflows/tauri.yaml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        platform: [
+        os: [
             macos-13,
             macos-14,
             ubuntu-22.04,

--- a/.github/workflows/tauri.yaml
+++ b/.github/workflows/tauri.yaml
@@ -2,27 +2,27 @@ name: Tauri builds
 on: [push]
 
 jobs:
-  strategy:
-    fail-fast: true
-    matrix:
-      platform: [
-          macos-13,
-          macos-14,
-          ubuntu-22.04,
-        ]
+  build-tauri:
+    strategy:
+      fail-fast: true
+      matrix:
+        platform: [
+            macos-13,
+            macos-14,
+            ubuntu-22.04,
+          ]
 
-    build-tauri:
-      runs-on: ${{ matrix.os }}
-      steps:
-        - uses: actions/checkout@v4
-          with:
-            submodules: recursive
-            fetch-depth: 0
-        - name: Install Nix
-          uses: DeterminateSystems/nix-installer-action@v4
-        - uses: DeterminateSystems/magic-nix-cache-action@v2
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v4
+      - uses: DeterminateSystems/magic-nix-cache-action@v2
 
-        - run: ./prep-tauri.sh
+      - run: ./prep-tauri.sh
 
-        - run: nix develop .#tauri-shell --command cargo tauri build --verbose
-          working-directory: ./tauri-app
+      - run: nix develop .#tauri-shell --command cargo tauri build --verbose
+        working-directory: ./tauri-app

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6727,7 +6727,7 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 [[package]]
 name = "typeshare"
 version = "1.0.1"
-source = "git+https://github.com/1password/typeshare?rev=556b44aafd5304eedf17206800f69834e3820b7c#556b44aafd5304eedf17206800f69834e3820b7c"
+source = "git+https://github.com/tomjw64/typeshare?rev=556b44aafd5304eedf17206800f69834e3820b7c#556b44aafd5304eedf17206800f69834e3820b7c"
 dependencies = [
  "chrono",
  "serde",
@@ -6738,7 +6738,7 @@ dependencies = [
 [[package]]
 name = "typeshare-annotation"
 version = "1.0.2"
-source = "git+https://github.com/1password/typeshare?rev=556b44aafd5304eedf17206800f69834e3820b7c#556b44aafd5304eedf17206800f69834e3820b7c"
+source = "git+https://github.com/tomjw64/typeshare?rev=556b44aafd5304eedf17206800f69834e3820b7c#556b44aafd5304eedf17206800f69834e3820b7c"
 dependencies = [
  "quote",
  "syn 1.0.109",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ comfy-table = "7.1.0"
 cynic-codegen = { version = "3.4.0", features = ["rkyv"] }
 cynic = "3.4.0"
 chrono = "0.4.31"
-typeshare = { git = "https://github.com/1password/typeshare", rev = "556b44aafd5304eedf17206800f69834e3820b7c" }
+typeshare = { git = "https://github.com/tomjw64/typeshare", rev = "556b44aafd5304eedf17206800f69834e3820b7c" }
 thiserror = "1.0.56"
 strict-yaml-rust = "0.1.2"
 dotrain = { git = "https://github.com/rainlanguage/dotrain", rev = "b813542cb1c9a2399664a606761f3a3db7b842af" }

--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,7 @@
               
               mkdir /tmp/cargo
               export CARGO_HOME=/tmp/cargo/         
-              cargo install --git https://github.com/1Password/typeshare --rev 556b44aafd5304eedf17206800f69834e3820b7c
+              cargo install --git https://github.com/tomjw64/typeshare --rev 556b44aafd5304eedf17206800f69834e3820b7c
               export PATH=$PATH:$CARGO_HOME/bin
 
               typeshare crates/subgraph/src/types/vault_balance_changes_list.rs  crates/subgraph/src/types/vault_balance_change.rs --lang=typescript --output-file=tauri-app/src/lib/typeshare/vaultBalanceChangesList.ts;

--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,7 @@
               mkdir -p tauri-app/src/lib/typeshare
               
               mkdir /tmp/cargo
-              export CARGO_HOME=/tmp/cargo/         
+              export CARGO_HOME=$(mktemp -d)
               cargo install --git https://github.com/tomjw64/typeshare --rev 556b44aafd5304eedf17206800f69834e3820b7c
               export PATH=$PATH:$CARGO_HOME/bin
 

--- a/tauri-app/src-tauri/Cargo.lock
+++ b/tauri-app/src-tauri/Cargo.lock
@@ -6455,7 +6455,7 @@ dependencies = [
  "serde_yaml",
  "strict-yaml-rust",
  "thiserror",
- "typeshare 1.0.1 (git+https://github.com/1password/typeshare?rev=556b44aafd5304eedf17206800f69834e3820b7c)",
+ "typeshare 1.0.1 (git+https://github.com/tomjw64/typeshare?rev=556b44aafd5304eedf17206800f69834e3820b7c)",
  "url",
 ]
 
@@ -6501,7 +6501,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
- "typeshare 1.0.1 (git+https://github.com/1password/typeshare?rev=556b44aafd5304eedf17206800f69834e3820b7c)",
+ "typeshare 1.0.1 (git+https://github.com/tomjw64/typeshare?rev=556b44aafd5304eedf17206800f69834e3820b7c)",
  "url",
 ]
 
@@ -6517,7 +6517,7 @@ dependencies = [
  "reqwest",
  "serde",
  "thiserror",
- "typeshare 1.0.1 (git+https://github.com/1password/typeshare?rev=556b44aafd5304eedf17206800f69834e3820b7c)",
+ "typeshare 1.0.1 (git+https://github.com/tomjw64/typeshare?rev=556b44aafd5304eedf17206800f69834e3820b7c)",
 ]
 
 [[package]]
@@ -9234,12 +9234,12 @@ dependencies = [
 [[package]]
 name = "typeshare"
 version = "1.0.1"
-source = "git+https://github.com/1password/typeshare?rev=556b44aafd5304eedf17206800f69834e3820b7c#556b44aafd5304eedf17206800f69834e3820b7c"
+source = "git+https://github.com/tomjw64/typeshare?rev=556b44aafd5304eedf17206800f69834e3820b7c#556b44aafd5304eedf17206800f69834e3820b7c"
 dependencies = [
  "chrono",
  "serde",
  "serde_json",
- "typeshare-annotation 1.0.2 (git+https://github.com/1password/typeshare?rev=556b44aafd5304eedf17206800f69834e3820b7c)",
+ "typeshare-annotation 1.0.2 (git+https://github.com/tomjw64/typeshare?rev=556b44aafd5304eedf17206800f69834e3820b7c)",
 ]
 
 [[package]]
@@ -9255,7 +9255,7 @@ dependencies = [
 [[package]]
 name = "typeshare-annotation"
 version = "1.0.2"
-source = "git+https://github.com/1password/typeshare?rev=556b44aafd5304eedf17206800f69834e3820b7c#556b44aafd5304eedf17206800f69834e3820b7c"
+source = "git+https://github.com/tomjw64/typeshare?rev=556b44aafd5304eedf17206800f69834e3820b7c#556b44aafd5304eedf17206800f69834e3820b7c"
 dependencies = [
  "quote",
  "syn 1.0.109",


### PR DESCRIPTION
Mac os builds failed because I switched typeshare to a fork (https://github.com/1Password/typeshare/pull/140), but only referenced the commit hash, not the actual fork url. This updates the typeshare dep to the fork url.

Also:
- run "Tauri Build" ci action on all platforms we're targeting (to avoid build issues like this slipping past PR review)
- rename "publish" ci action to "Tauri Publish" for consistency
- Resolves #436 