### PR TITLE
2024 03 15 always show codemirror problems

### DIFF
--- a/tauri-app/package-lock.json
+++ b/tauri-app/package-lock.json
@@ -18,7 +18,7 @@
         "dayjs": "^1.11.10",
         "lightweight-charts": "^4.1.3",
         "lodash": "^4.17.21",
-        "svelte-codemirror-editor": "^1.2.0",
+        "svelte-codemirror-editor": "^1.3.0",
         "thememirror": "^2.0.1",
         "uuid": "^9.0.1",
         "viem": "^2.4.0"
@@ -5599,9 +5599,9 @@
       }
     },
     "node_modules/svelte-codemirror-editor": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/svelte-codemirror-editor/-/svelte-codemirror-editor-1.2.0.tgz",
-      "integrity": "sha512-OEf52U4bBeyDFCMtPH+ZYCtYT+KdyjUw+l19V72Bxeadh2LdPOWC0WSEP+hXRleg/94VC5NgfgqHXf3DqoVZUA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/svelte-codemirror-editor/-/svelte-codemirror-editor-1.3.0.tgz",
+      "integrity": "sha512-Y39m9CsL0d30gGYYjJURWjKwAMEyiH42FojYiAXVKneGQ9cntOwOlloEk2Rhyy9ay29rSYYncskbnhAYNokIqw==",
       "peerDependencies": {
         "codemirror": "^6.0.0",
         "svelte": "^3.0.0 || ^4.0.0"

--- a/tauri-app/package.json
+++ b/tauri-app/package.json
@@ -54,7 +54,7 @@
     "dayjs": "^1.11.10",
     "lightweight-charts": "^4.1.3",
     "lodash": "^4.17.21",
-    "svelte-codemirror-editor": "^1.2.0",
+    "svelte-codemirror-editor": "^1.3.0",
     "thememirror": "^2.0.1",
     "uuid": "^9.0.1",
     "viem": "^2.4.0"

--- a/tauri-app/src/lib/components/CodeMirrorConfigString.svelte
+++ b/tauri-app/src/lib/components/CodeMirrorConfigString.svelte
@@ -34,7 +34,7 @@
 	on:ready={(e) => { openLintPanel(e.detail); }}
 />
 
-<style>
+<style global>
 	:global(.ͼ1 .cm-panel.cm-panel-lint ul [aria-selected]) {
 		background-color: inherit;
 	}

--- a/tauri-app/src/lib/components/CodeMirrorConfigString.svelte
+++ b/tauri-app/src/lib/components/CodeMirrorConfigString.svelte
@@ -29,7 +29,13 @@
 		"&": {
 			width: "100%",
 		},
-		...styles,
+		...styles
 	}}
 	on:ready={(e) => { openLintPanel(e.detail); }}
 />
+
+<style>
+	:global(.ͼ1 .cm-panel.cm-panel-lint ul [aria-selected]) {
+		background-color: inherit;
+	}
+</style>

--- a/tauri-app/src/lib/components/CodeMirrorConfigString.svelte
+++ b/tauri-app/src/lib/components/CodeMirrorConfigString.svelte
@@ -4,6 +4,7 @@
 	import { yaml } from '@codemirror/lang-yaml';
 	import { parseConfigStringProblems } from '$lib/services/config';
 	import { RawRainlangExtension } from 'codemirror-rainlang';
+	import { openLintPanel } from '@codemirror/lint';
 
 	export let value: string;
 	export let disabled = false;
@@ -28,6 +29,7 @@
 		"&": {
 			width: "100%",
 		},
-		...styles
+		...styles,
 	}}
+	on:ready={(e) => { openLintPanel(e.detail); }}
 />

--- a/tauri-app/src/lib/components/CodeMirrorDotrain.svelte
+++ b/tauri-app/src/lib/components/CodeMirrorDotrain.svelte
@@ -2,6 +2,7 @@
 	import CodeMirror from 'svelte-codemirror-editor';
 	import { RawRainlangExtension } from 'codemirror-rainlang';
 	import { codeMirrorTheme } from '$lib/stores/darkMode';
+	import { openLintPanel } from '@codemirror/lint';
 
 	export let value: string;
 	export let disabled = false;
@@ -20,6 +21,7 @@
 		"&": {
 			width: "100%",
 		},
-		...styles
+		...styles,
 	}}
+	on:ready={(e) => { openLintPanel(e.detail); }}
 />

--- a/tauri-app/src/lib/components/CodeMirrorDotrain.svelte
+++ b/tauri-app/src/lib/components/CodeMirrorDotrain.svelte
@@ -26,7 +26,7 @@
 	on:ready={(e) => { openLintPanel(e.detail); }}
 />
 
-<style>
+<style global>
 	:global(.ͼ1 .cm-panel.cm-panel-lint ul [aria-selected]) {
 		background-color: inherit;
 	}

--- a/tauri-app/src/lib/components/CodeMirrorDotrain.svelte
+++ b/tauri-app/src/lib/components/CodeMirrorDotrain.svelte
@@ -25,3 +25,9 @@
 	}}
 	on:ready={(e) => { openLintPanel(e.detail); }}
 />
+
+<style>
+	:global(.ͼ1 .cm-panel.cm-panel-lint ul [aria-selected]) {
+		background-color: inherit;
+	}
+</style>


### PR DESCRIPTION
Partially improves #211 
- Bump svelte-codemirror-editor
- Show problems panel by default in settings page and add order codemirror editors

There is still an issue where the problems panel disappears upon toggling light / dark mode. Waiting on merging of a PR to svelte-codemirror-editor (https://github.com/touchifyapp/svelte-codemirror-editor/pull/33) to resolve to resolve.

![image](https://github.com/rainlanguage/rain.orderbook/assets/159270/aa8edf57-5d92-4b2b-a772-13a95aef9513)
![image](https://github.com/rainlanguage/rain.orderbook/assets/159270/8fd3172e-3237-49dd-8809-79b81a3725c0)
