### PR TITLE
2024 03 15 toast error styling not dismissable

### DIFF
--- a/tauri-app/src-tauri/src/toast.rs
+++ b/tauri-app/src-tauri/src/toast.rs
@@ -16,7 +16,6 @@ pub enum ToastMessageType {
 pub struct ToastPayload {
     pub message_type: ToastMessageType,
     pub text: String,
-    pub break_text: Option<bool>,
 }
 
 impl ToastPayload {
@@ -29,7 +28,6 @@ pub fn toast_error(app_handle: AppHandle, text: String) {
     let toast = ToastPayload {
         message_type: ToastMessageType::Error,
         text,
-        break_text: None,
     };
     toast.emit(app_handle);
 }

--- a/tauri-app/src/lib/components/AppToast.svelte
+++ b/tauri-app/src/lib/components/AppToast.svelte
@@ -13,22 +13,22 @@
   {#if toast.message_type === 'Success'}
     <Toast color="green">
       <CheckCircleSolid slot="icon" class="h-5 w-5" />
-      <span class={toast.break_text ? "break-all" : ''}>{toast.text}</span>
+      <span class="break-all">{toast.text}</span>
     </Toast>
   {:else if toast.message_type === 'Error'}
     <Toast color="red">
       <CloseCircleSolid slot="icon" class="h-5 w-5" />
-      <span class={toast.break_text ? "break-all" : ''}>{toast.text}</span>
+      <span class="break-all">{toast.text}</span>
     </Toast>
   {:else if toast.message_type === 'Warning'}
     <Toast color="yellow">
       <ExclamationCircleSolid slot="icon" class="h-5 w-5" />
-      <span class={toast.break_text ? "break-all" : ''}>{toast.text}</span>
+      <span class="break-all">{toast.text}</span>
     </Toast>
   {:else}
     <Toast color="blue">
       <InfoCircleSolid slot="icon" class="h-5 w-5" />
-      <span class={toast.break_text ? "break-all" : ''}>{toast.text}</span>
+      <span class="break-all">{toast.text}</span>
     </Toast>
   {/if}
 </div>

--- a/tauri-app/src/lib/components/AppToast.svelte
+++ b/tauri-app/src/lib/components/AppToast.svelte
@@ -1,34 +1,48 @@
 <script lang="ts">
   import { Toast } from 'flowbite-svelte';
-  import CheckCircleSolid from 'flowbite-svelte-icons/CheckCircleSolid.svelte';
-  import CloseCircleSolid from 'flowbite-svelte-icons/CloseCircleSolid.svelte';
-  import ExclamationCircleSolid from 'flowbite-svelte-icons/ExclamationCircleSolid.svelte';
-  import InfoCircleSolid from 'flowbite-svelte-icons/InfoCircleSolid.svelte';
+  import IconSuccess from '$lib/components/IconSuccess.svelte';
+  import IconError from '$lib/components/IconError.svelte';
+  import IconWarning from '$lib/components/IconWarning.svelte';
+  import IconInfo from '$lib/components/IconInfo.svelte';
+  import CloseSolid from 'flowbite-svelte-icons/CloseSolid.svelte';
   import type { ToastData } from '$lib/stores/toasts';
+    import { ToastMessageType } from '$lib/typeshare/toast';
 
   export let toast: ToastData;
+  let toastColor: "none" | "gray" | "red" | "yellow" | "green" | "indigo" | "purple" | "blue" | "primary" | "orange" | undefined;
+  $: toast, getToastColor();
+
+  function getToastColor() {
+    if(toast.message_type === ToastMessageType.Success) {
+      return 'green';
+    } else if (toast.message_type === ToastMessageType.Error) {
+      return 'red';
+    } else if (toast.message_type === ToastMessageType.Warning) {
+      return 'yellow';
+    } else {
+      return 'info';
+    }
+  };
 </script>
 
 <div class="mt-2">
-  {#if toast.message_type === 'Success'}
-    <Toast color="green">
-      <CheckCircleSolid slot="icon" class="h-5 w-5" />
-      <span class="break-all">{toast.text}</span>
+    <Toast color={toastColor} contentClass="w-full text-sm font-normal flex justify-start space-x-4 items-center pr-8" divClass="w-full max-w-xs p-2 text-gray-500 bg-white shadow dark:text-gray-400 dark:bg-gray-800 gap-3 relative">
+      <svelte:fragment slot="close-button" let:close>
+        <CloseSolid slot="close-button" class="h-3 w-3 top-2 right-2 absolute hover:opacity-50" on:click={(e) => close(e)}/>
+      </svelte:fragment>
+
+      {#if toast.message_type === 'Success'}
+        <IconSuccess />
+      {:else if toast.message_type === 'Error'}
+        <IconError />
+      {:else if toast.message_type === 'Warning'}
+        <IconWarning />
+      {:else}
+        <IconInfo />
+      {/if}
+
+      <div class="overflow-scroll max-h-48">
+        {toast.text}
+      </div>
     </Toast>
-  {:else if toast.message_type === 'Error'}
-    <Toast color="red">
-      <CloseCircleSolid slot="icon" class="h-5 w-5" />
-      <span class="break-all">{toast.text}</span>
-    </Toast>
-  {:else if toast.message_type === 'Warning'}
-    <Toast color="yellow">
-      <ExclamationCircleSolid slot="icon" class="h-5 w-5" />
-      <span class="break-all">{toast.text}</span>
-    </Toast>
-  {:else}
-    <Toast color="blue">
-      <InfoCircleSolid slot="icon" class="h-5 w-5" />
-      <span class="break-all">{toast.text}</span>
-    </Toast>
-  {/if}
 </div>

--- a/tauri-app/src/lib/components/IconError.svelte
+++ b/tauri-app/src/lib/components/IconError.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  import CloseCircleSolid from 'flowbite-svelte-icons/CloseCircleSolid.svelte';
+</script>
+
+<div class="rounded-lg inline-flex items-center justify-center shrink-0 text-red-500 bg-red-100 dark:bg-red-800 dark:text-red-200 w-8 h-8">
+  <CloseCircleSolid class="h-5 w-5" />
+</div>

--- a/tauri-app/src/lib/components/IconInfo.svelte
+++ b/tauri-app/src/lib/components/IconInfo.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  import InfoCircleSolid from 'flowbite-svelte-icons/InfoCircleSolid.svelte';
+</script>
+
+<div class="rounded-lg inline-flex items-center justify-center shrink-0 text-blue-500 bg-blue-100 dark:bg-blue-800 dark:text-blue-200 w-8 h-8">
+  <InfoCircleSolid class="h-5 w-5" />
+</div>

--- a/tauri-app/src/lib/components/IconSuccess.svelte
+++ b/tauri-app/src/lib/components/IconSuccess.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  import CheckCircleSolid from 'flowbite-svelte-icons/CheckCircleSolid.svelte';
+</script>
+
+<div class="rounded-lg inline-flex items-center justify-center shrink-0 text-green-500 bg-green-100 dark:bg-green-800 dark:text-green-200 w-8 h-8">
+  <CheckCircleSolid class="h-5 w-5" />
+</div>

--- a/tauri-app/src/lib/components/IconWarning.svelte
+++ b/tauri-app/src/lib/components/IconWarning.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  import ExclamationCircleSolid from 'flowbite-svelte-icons/ExclamationCircleSolid.svelte';
+</script>
+
+<div class="rounded-lg inline-flex items-center justify-center shrink-0 text-yellow-500 bg-yellow-100 dark:bg-yellow-800 dark:text-yellow-200 w-8 h-8">
+  <ExclamationCircleSolid class="h-5 w-5" />
+</div>

--- a/tauri-app/src/lib/storesGeneric/listStore.ts
+++ b/tauri-app/src/lib/storesGeneric/listStore.ts
@@ -120,7 +120,6 @@ export function listStore<T>(key: string, fetchPageHandler: (page: number) => Pr
         toasts.add({
           message_type: ToastMessageType.Success,
           text: `Exported to CSV at ${path}`,
-          break_text: true
         });
       }
     } catch(e) {

--- a/tauri-app/src/lib/storesGeneric/textFileStore.ts
+++ b/tauri-app/src/lib/storesGeneric/textFileStore.ts
@@ -81,7 +81,7 @@ export function textFileStore(name: string, extensions: string[], defaultText: s
       await writeTextFile(pathValue, get(text));
 
       path.set(pathValue as string);
-      toasts.success(`Saved to ${pathValue}`, {break_text: true});
+      toasts.success(`Saved to ${pathValue}`);
     }
     catch(e) {
       toasts.error(e as string);
@@ -104,7 +104,7 @@ export function textFileStore(name: string, extensions: string[], defaultText: s
         await writeTextFile(pathValue as string, get(text));
 
         path.set(pathValue as string);
-        toasts.success(`Saved to ${pathValue}`, {break_text: true});
+        toasts.success(`Saved to ${pathValue}`);
       }
 
     } catch(e) {

--- a/tauri-app/src/routes/orders/add/+page.svelte
+++ b/tauri-app/src/routes/orders/add/+page.svelte
@@ -80,7 +80,7 @@
     try {
       chartData = await makeChartData($dotrainFile.text, $settingsText);
     } catch(e) {
-      toasts.error(e as string, {break_text: true});
+      toasts.error(e as string);
     }
     isCharting = false;
   }


### PR DESCRIPTION
Resolves #338 

Alter styling of toast component to ensure:
- content never overflows container & close button always visible
- toast contents does not overflow page size (fix height)

![image](https://github.com/rainlanguage/rain.orderbook/assets/159270/d74b049b-929f-47e1-8af1-9881115fc102)
