### PR TITLE
chore: rename config structs FooString -> FooConfigSource and ConfigS…

### DIFF
--- a/crates/cli/src/commands/chart/mod.rs
+++ b/crates/cli/src/commands/chart/mod.rs
@@ -1,7 +1,7 @@
 use crate::execute::Execute;
 use anyhow::{anyhow, Result};
 use clap::Args;
-use rain_orderbook_app_settings::{string_structs::ConfigString, Config};
+use rain_orderbook_app_settings::{config_source::ConfigSource, Config};
 use rain_orderbook_common::dotrain::RainDocument;
 use rain_orderbook_common::fuzz::FuzzRunner;
 use std::fs::read_to_string;
@@ -22,7 +22,7 @@ impl Execute for Chart {
     async fn execute(&self) -> Result<()> {
         let dotrain = read_to_string(self.dotrain_file.clone()).map_err(|e| anyhow!(e))?;
         let frontmatter = RainDocument::get_front_matter(&dotrain).unwrap();
-        let config_string: ConfigString = frontmatter.to_string().try_into()?;
+        let config_string: ConfigSource = frontmatter.to_string().try_into()?;
         let config: Config = config_string.try_into()?;
         let mut fuzzer = FuzzRunner::new(&dotrain, config, None).await;
         let chart_data = fuzzer.build_chart_datas().await?;

--- a/crates/common/src/frontmatter.rs
+++ b/crates/common/src/frontmatter.rs
@@ -1,8 +1,8 @@
 use dotrain::RainDocument;
-use rain_orderbook_app_settings::{config::ParseConfigStringError, string_structs::ConfigString};
+use rain_orderbook_app_settings::{config::ParseConfigSourceError, config_source::ConfigSource};
 
 /// Parse dotrain frontmatter and merges it with top Config if given
-pub fn parse_frontmatter(dotrain: String) -> Result<ConfigString, ParseConfigStringError> {
+pub fn parse_frontmatter(dotrain: String) -> Result<ConfigSource, ParseConfigSourceError> {
     let frontmatter = RainDocument::get_front_matter(dotrain.as_str()).unwrap_or("");
     Ok(frontmatter.to_string().try_into()?)
 }

--- a/crates/common/src/fuzz/mod.rs
+++ b/crates/common/src/fuzz/mod.rs
@@ -267,7 +267,7 @@ impl FuzzRunner {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rain_orderbook_app_settings::string_structs::ConfigString;
+    use rain_orderbook_app_settings::config_source::ConfigSource;
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
     async fn test_fuzz_runner() {
@@ -300,7 +300,7 @@ b: fuzzed;
 :;
     "#;
         let frontmatter = RainDocument::get_front_matter(dotrain).unwrap();
-        let settings = serde_yaml::from_str::<ConfigString>(frontmatter).unwrap();
+        let settings = serde_yaml::from_str::<ConfigSource>(frontmatter).unwrap();
         let config = settings
             .try_into()
             .map_err(|e| println!("{:?}", e))
@@ -363,7 +363,7 @@ b: fuzzed;
     :;
         "#;
         let frontmatter = RainDocument::get_front_matter(dotrain).unwrap();
-        let settings = serde_yaml::from_str::<ConfigString>(frontmatter).unwrap();
+        let settings = serde_yaml::from_str::<ConfigSource>(frontmatter).unwrap();
 
         let config = settings
             .try_into()

--- a/crates/settings/src/config_source.rs
+++ b/crates/settings/src/config_source.rs
@@ -7,25 +7,25 @@ use url::Url;
 #[typeshare]
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 #[serde(rename_all = "kebab-case")]
-pub struct ConfigString {
+pub struct ConfigSource {
     #[serde(default)]
-    pub networks: HashMap<String, NetworkString>,
+    pub networks: HashMap<String, NetworkConfigSource>,
     #[serde(default)]
     pub subgraphs: HashMap<String, Url>,
     #[serde(default)]
-    pub orderbooks: HashMap<String, OrderbookString>,
+    pub orderbooks: HashMap<String, OrderbookConfigSource>,
     #[serde(default)]
-    pub tokens: HashMap<String, TokenString>,
+    pub tokens: HashMap<String, TokenConfigSource>,
     #[serde(default)]
-    pub deployers: HashMap<String, DeployerString>,
+    pub deployers: HashMap<String, DeployerConfigSource>,
     #[serde(default)]
-    pub orders: HashMap<String, OrderString>,
+    pub orders: HashMap<String, OrderConfigSource>,
     #[serde(default)]
-    pub scenarios: HashMap<String, ScenarioString>,
+    pub scenarios: HashMap<String, ScenarioConfigSource>,
     #[serde(default)]
-    pub charts: HashMap<String, ChartString>,
+    pub charts: HashMap<String, ChartConfigSource>,
     #[serde(default)]
-    pub deployments: HashMap<String, DeploymentString>,
+    pub deployments: HashMap<String, DeploymentConfigSource>,
 }
 
 #[typeshare]
@@ -52,7 +52,7 @@ pub type TokenRef = String;
 #[typeshare]
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "kebab-case")]
-pub struct NetworkString {
+pub struct NetworkConfigSource {
     pub rpc: Url,
     #[typeshare(typescript(type = "number"))]
     pub chain_id: u64,
@@ -65,7 +65,7 @@ pub struct NetworkString {
 #[typeshare]
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "kebab-case")]
-pub struct OrderbookString {
+pub struct OrderbookConfigSource {
     pub address: Address,
     pub network: Option<NetworkRef>,
     pub subgraph: Option<SubgraphRef>,
@@ -75,7 +75,7 @@ pub struct OrderbookString {
 #[typeshare]
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "kebab-case")]
-pub struct TokenString {
+pub struct TokenConfigSource {
     pub network: NetworkRef,
     pub address: Address,
     pub decimals: Option<u8>,
@@ -86,7 +86,7 @@ pub struct TokenString {
 #[typeshare]
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "kebab-case")]
-pub struct DeployerString {
+pub struct DeployerConfigSource {
     pub address: Address,
     pub network: Option<NetworkRef>,
     pub label: Option<String>,
@@ -95,7 +95,7 @@ pub struct DeployerString {
 #[typeshare]
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "kebab-case")]
-pub struct DeploymentString {
+pub struct DeploymentConfigSource {
     pub scenario: ScenarioRef,
     pub order: OrderRef,
 }
@@ -112,7 +112,7 @@ pub struct IOString {
 #[typeshare]
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "kebab-case")]
-pub struct OrderString {
+pub struct OrderConfigSource {
     pub inputs: Vec<IOString>,
     pub outputs: Vec<IOString>,
     pub network: NetworkRef,
@@ -123,19 +123,19 @@ pub struct OrderString {
 #[typeshare]
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "kebab-case")]
-pub struct ScenarioString {
+pub struct ScenarioConfigSource {
     #[serde(default)]
     pub bindings: HashMap<String, String>,
     #[typeshare(typescript(type = "number"))]
     pub runs: Option<u64>,
     pub deployer: Option<DeployerRef>,
-    pub scenarios: Option<HashMap<String, ScenarioString>>,
+    pub scenarios: Option<HashMap<String, ScenarioConfigSource>>,
 }
 
 #[typeshare]
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "kebab-case")]
-pub struct ChartString {
+pub struct ChartConfigSource {
     pub scenario: Option<ScenarioRef>,
     pub plots: HashMap<String, PlotString>,
 }
@@ -156,9 +156,9 @@ pub struct DataPointsString {
     pub y: String,
 }
 
-impl TryFrom<String> for ConfigString {
+impl TryFrom<String> for ConfigSource {
     type Error = serde_yaml::Error;
-    fn try_from(val: String) -> Result<ConfigString, Self::Error> {
+    fn try_from(val: String) -> Result<ConfigSource, Self::Error> {
         serde_yaml::from_str(&val)
     }
 }
@@ -276,7 +276,7 @@ deployments:
         order: buyETH"#
             .to_string();
 
-        let config: ConfigString = yaml_data.try_into().unwrap();
+        let config: ConfigSource = yaml_data.try_into().unwrap();
 
         // Asserting a few values to verify successful parsing
         assert_eq!(

--- a/crates/settings/src/deployment.rs
+++ b/crates/settings/src/deployment.rs
@@ -15,7 +15,7 @@ pub struct Deployment {
 }
 
 #[derive(Error, Debug, PartialEq)]
-pub enum ParseDeploymentStringError {
+pub enum ParseDeploymentConfigSourceError {
     #[error("Scenario not found: {0}")]
     ScenarioNotFoundError(String),
     #[error("Order not found: {0}")]
@@ -24,22 +24,22 @@ pub enum ParseDeploymentStringError {
     NoMatch,
 }
 
-impl DeploymentString {
+impl DeploymentConfigSource {
     pub fn try_into_deployment(
         self,
         scenarios: &HashMap<String, Arc<Scenario>>,
         orders: &HashMap<String, Arc<Order>>,
-    ) -> Result<Deployment, ParseDeploymentStringError> {
+    ) -> Result<Deployment, ParseDeploymentConfigSourceError> {
         let scenario = scenarios
             .get(&self.scenario)
-            .ok_or(ParseDeploymentStringError::ScenarioNotFoundError(
+            .ok_or(ParseDeploymentConfigSourceError::ScenarioNotFoundError(
                 self.scenario.clone(),
             ))
             .map(Arc::clone)?;
 
         let order = orders
             .get(&self.order)
-            .ok_or(ParseDeploymentStringError::OrderNotFoundError(
+            .ok_or(ParseDeploymentConfigSourceError::OrderNotFoundError(
                 self.order.clone(),
             ))
             .map(Arc::clone)?;
@@ -47,7 +47,7 @@ impl DeploymentString {
         // check validity
         if let Some(deployer) = &order.deployer {
             if deployer != &scenario.deployer {
-                return Err(ParseDeploymentStringError::NoMatch);
+                return Err(ParseDeploymentConfigSourceError::NoMatch);
             }
         };
 
@@ -91,7 +91,7 @@ mod tests {
         };
         let orders = HashMap::from([(order_name.to_string(), Arc::new(order))]);
         let scenarios = HashMap::from([(scenario_name.to_string(), Arc::new(scenario))]);
-        let deploment_string = DeploymentString {
+        let deploment_string = DeploymentConfigSource {
             scenario: scenario_name.to_string(),
             order: order_name.to_string(),
         };
@@ -119,14 +119,14 @@ mod tests {
         };
         let orders = HashMap::from([(order_name.to_string(), Arc::new(order))]);
         let scenarios = HashMap::from([(scenario_name.to_string(), Arc::new(scenario))]);
-        let deploment_string = DeploymentString {
+        let deploment_string = DeploymentConfigSource {
             scenario: other_scenario_name.to_string(),
             order: order_name.to_string(),
         };
         let result = deploment_string.try_into_deployment(&scenarios, &orders);
         assert!(matches!(
             result,
-            Err(ParseDeploymentStringError::ScenarioNotFoundError(_))
+            Err(ParseDeploymentConfigSourceError::ScenarioNotFoundError(_))
         ));
     }
 }

--- a/crates/settings/src/lib.rs
+++ b/crates/settings/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod chart;
 pub mod config;
+pub mod config_source;
 pub mod deployer;
 pub mod deployment;
 pub mod merge;
@@ -7,17 +8,16 @@ pub mod network;
 pub mod order;
 pub mod orderbook;
 pub mod scenario;
-pub mod string_structs;
 pub mod token;
 
 pub(crate) use chart::*;
+pub(crate) use config_source::*;
 pub(crate) use deployer::*;
 pub(crate) use deployment::*;
 pub(crate) use network::*;
 pub(crate) use order::*;
 pub(crate) use orderbook::*;
 pub(crate) use scenario::*;
-pub(crate) use string_structs::*;
 pub(crate) use token::*;
 
 #[cfg(test)]

--- a/crates/settings/src/merge.rs
+++ b/crates/settings/src/merge.rs
@@ -32,8 +32,8 @@ pub enum MergeError {
     DeploymentCollision(String),
 }
 
-impl ConfigString {
-    pub fn merge(&mut self, other: ConfigString) -> Result<(), MergeError> {
+impl ConfigSource {
+    pub fn merge(&mut self, other: ConfigSource) -> Result<(), MergeError> {
         // Networks
         let networks = &mut self.networks;
         for (key, value) in other.networks {
@@ -214,7 +214,7 @@ mod tests {
     use std::collections::HashMap;
     #[test]
     fn test_successful_merge() {
-        let mut config = ConfigString {
+        let mut config = ConfigSource {
             subgraphs: HashMap::new(),
             orderbooks: HashMap::new(),
             tokens: HashMap::new(),
@@ -226,7 +226,7 @@ mod tests {
             deployments: HashMap::new(),
         };
 
-        let other = ConfigString {
+        let other = ConfigSource {
             subgraphs: HashMap::new(),
             orderbooks: HashMap::new(),
             tokens: HashMap::new(),
@@ -243,7 +243,7 @@ mod tests {
 
     #[test]
     fn test_unsuccessful_merge() {
-        let mut config = ConfigString {
+        let mut config = ConfigSource {
             subgraphs: HashMap::new(),
             orderbooks: HashMap::new(),
             tokens: HashMap::new(),
@@ -255,7 +255,7 @@ mod tests {
             deployments: HashMap::new(),
         };
 
-        let mut other = ConfigString {
+        let mut other = ConfigSource {
             subgraphs: HashMap::new(),
             orderbooks: HashMap::new(),
             tokens: HashMap::new(),

--- a/crates/settings/src/network.rs
+++ b/crates/settings/src/network.rs
@@ -1,4 +1,4 @@
-use crate::string_structs::*;
+use crate::config_source::*;
 use serde::{Deserialize, Serialize};
 use std::num::ParseIntError;
 use thiserror::Error;
@@ -20,7 +20,7 @@ pub struct Network {
 }
 
 #[derive(Error, Debug, PartialEq)]
-pub enum ParseNetworkStringError {
+pub enum ParseNetworkConfigSourceError {
     #[error("Failed to parse rpc: {}", 0)]
     RpcParseError(ParseError),
     #[error("Failed to parse chain_id: {}", 0)]
@@ -29,10 +29,10 @@ pub enum ParseNetworkStringError {
     NetworkIdParseError(ParseIntError),
 }
 
-impl TryFrom<NetworkString> for Network {
-    type Error = ParseNetworkStringError;
+impl TryFrom<NetworkConfigSource> for Network {
+    type Error = ParseNetworkConfigSourceError;
 
-    fn try_from(item: NetworkString) -> Result<Self, Self::Error> {
+    fn try_from(item: NetworkConfigSource) -> Result<Self, Self::Error> {
         Ok(Network {
             rpc: item.rpc,
             chain_id: item.chain_id,
@@ -50,7 +50,7 @@ mod tests {
 
     #[test]
     fn test_try_from_network_string_success() {
-        let network_string = NetworkString {
+        let network_string = NetworkConfigSource {
             rpc: Url::parse("http://127.0.0.1:8545").unwrap(),
             chain_id: 1,
             network_id: Some(1),

--- a/crates/settings/src/token.rs
+++ b/crates/settings/src/token.rs
@@ -19,7 +19,7 @@ pub struct Token {
 }
 
 #[derive(Error, Debug, PartialEq)]
-pub enum ParseTokenStringError {
+pub enum ParseTokenConfigSourceError {
     #[error("Failed to parse address")]
     AddressParseError(FromHexError),
     #[error("Failed to parse decimals")]
@@ -28,14 +28,14 @@ pub enum ParseTokenStringError {
     NetworkNotFoundError(String),
 }
 
-impl TokenString {
+impl TokenConfigSource {
     pub fn try_into_token(
         self,
         networks: &HashMap<String, Arc<Network>>,
-    ) -> Result<Token, ParseTokenStringError> {
+    ) -> Result<Token, ParseTokenConfigSourceError> {
         let network_ref = networks
             .get(&self.network)
-            .ok_or(ParseTokenStringError::NetworkNotFoundError(
+            .ok_or(ParseTokenConfigSourceError::NetworkNotFoundError(
                 self.network.clone(),
             ))
             .map(Arc::clone)?;
@@ -66,7 +66,7 @@ mod token_tests {
     #[test]
     fn test_token_creation_success_with_all_fields() {
         let networks = setup_networks();
-        let token_string = TokenString {
+        let token_string = TokenConfigSource {
             network: "TestNetwork".to_string(),
             address: Address::repeat_byte(0x01),
             decimals: Some(18),
@@ -92,7 +92,7 @@ mod token_tests {
     #[test]
     fn test_token_creation_success_with_minimal_fields() {
         let networks = setup_networks();
-        let token_string = TokenString {
+        let token_string = TokenConfigSource {
             network: "TestNetwork".to_string(),
             address: Address::repeat_byte(0x01),
             decimals: None,
@@ -118,7 +118,7 @@ mod token_tests {
     #[test]
     fn test_token_creation_failure_due_to_invalid_network() {
         let networks = setup_networks();
-        let token_string = TokenString {
+        let token_string = TokenConfigSource {
             network: "InvalidNetwork".to_string(),
             address: Address::repeat_byte(0x01),
             decimals: None,
@@ -131,7 +131,7 @@ mod token_tests {
         assert!(token.is_err());
         assert_eq!(
             token.unwrap_err(),
-            ParseTokenStringError::NetworkNotFoundError("InvalidNetwork".to_string())
+            ParseTokenConfigSourceError::NetworkNotFoundError("InvalidNetwork".to_string())
         );
     }
 }

--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,7 @@
               # Generate Typescript types from rust types
               mkdir -p tauri-app/src/lib/typeshare
               
-              mkdir /tmp/cargo
+              mkdir -p /tmp/cargo
               export CARGO_HOME=/tmp/cargo/         
               cargo install --git https://github.com/tomjw64/typeshare --rev 556b44aafd5304eedf17206800f69834e3820b7c
               export PATH=$PATH:$CARGO_HOME/bin
@@ -41,7 +41,7 @@
 
               typeshare crates/settings/src/parse.rs --lang=typescript --output-file=tauri-app/src/lib/typeshare/appSettings.ts;
               typeshare crates/settings/src/config.rs crates/settings/src/chart.rs crates/settings/src/deployer.rs crates/settings/src/network.rs crates/settings/src/order.rs crates/settings/src/orderbook.rs crates/settings/src/scenario.rs crates/settings/src/token.rs crates/settings/src/deployment.rs --lang=typescript --output-file=tauri-app/src/lib/typeshare/config.ts;
-              typeshare crates/settings/src/string_structs.rs --lang=typescript --output-file=tauri-app/src/lib/typeshare/configString.ts;
+              typeshare crates/settings/src/config_source.rs --lang=typescript --output-file=tauri-app/src/lib/typeshare/configString.ts;
 
               typeshare tauri-app/src-tauri/src/toast.rs --lang=typescript --output-file=tauri-app/src/lib/typeshare/toast.ts;
               typeshare tauri-app/src-tauri/src/transaction_status.rs --lang=typescript --output-file=tauri-app/src/lib/typeshare/transactionStatus.ts;

--- a/tauri-app/src-tauri/src/commands/config.rs
+++ b/tauri-app/src-tauri/src/commands/config.rs
@@ -1,21 +1,21 @@
 use crate::error::CommandResult;
-use rain_orderbook_app_settings::{config::Config, string_structs::ConfigString};
+use rain_orderbook_app_settings::{config::Config, config_source::ConfigSource};
 use rain_orderbook_common::frontmatter::parse_frontmatter;
 
 #[tauri::command]
-pub fn parse_configstring(text: String) -> CommandResult<ConfigString> {
+pub fn parse_configstring(text: String) -> CommandResult<ConfigSource> {
     Ok(text.try_into()?)
 }
 
 #[tauri::command]
-pub fn merge_configstrings(dotrain: String, config_text: String) -> CommandResult<ConfigString> {
+pub fn merge_configstrings(dotrain: String, config_text: String) -> CommandResult<ConfigSource> {
     let mut dotrain_config = parse_frontmatter(dotrain)?;
-    let config: ConfigString = config_text.try_into()?;
+    let config: ConfigSource = config_text.try_into()?;
     dotrain_config.merge(config)?;
     Ok(dotrain_config)
 }
 
 #[tauri::command]
-pub fn convert_configstring_to_config(config_string: ConfigString) -> CommandResult<Config> {
+pub fn convert_configstring_to_config(config_string: ConfigSource) -> CommandResult<Config> {
     Ok(config_string.try_into()?)
 }

--- a/tauri-app/src-tauri/src/error.rs
+++ b/tauri-app/src-tauri/src/error.rs
@@ -1,6 +1,6 @@
 use alloy_ethers_typecast::{client::LedgerClientError, transaction::ReadableClientError};
 use alloy_primitives::ruint::FromUintError;
-use rain_orderbook_app_settings::config::ParseConfigStringError;
+use rain_orderbook_app_settings::config::ParseConfigSourceError;
 use rain_orderbook_app_settings::merge::MergeError;
 use rain_orderbook_common::fuzz::FuzzRunnerError;
 use rain_orderbook_common::{
@@ -54,7 +54,7 @@ pub enum CommandError {
     MergeError(#[from] MergeError),
 
     #[error(transparent)]
-    ParseConfigStringError(#[from] ParseConfigStringError),
+    ParseConfigSourceError(#[from] ParseConfigSourceError),
 
     #[error(transparent)]
     ParseConfigYamlError(#[from] serde_yaml::Error),

--- a/tauri-app/src/lib/components/CodeMirrorConfigSource.svelte
+++ b/tauri-app/src/lib/components/CodeMirrorConfigSource.svelte
@@ -2,7 +2,7 @@
 	import CodeMirror from 'svelte-codemirror-editor';
 	import { codeMirrorTheme } from '$lib/stores/darkMode';
 	import { yaml } from '@codemirror/lang-yaml';
-	import { parseConfigStringProblems } from '$lib/services/config';
+	import { parseConfigSourceProblems } from '$lib/services/config';
 	import { RawRainlangExtension } from 'codemirror-rainlang';
 	import { openLintPanel } from '@codemirror/lint';
 
@@ -13,7 +13,7 @@
  	const configStringExtension = new RawRainlangExtension({
 		hover: async () => null,
 		completion: async () => null,
-		diagnostics: async (textDocument) => parseConfigStringProblems(textDocument.text),
+		diagnostics: async (textDocument) => parseConfigSourceProblems(textDocument.text),
 	});
 </script>
 

--- a/tauri-app/src/lib/services/config.ts
+++ b/tauri-app/src/lib/services/config.ts
@@ -1,21 +1,21 @@
 import { settingsText } from "$lib/stores/settings";
 import type { Config } from "$lib/typeshare/config";
-import type { ConfigString } from "$lib/typeshare/configString";
+import type { ConfigSource } from "$lib/typeshare/configString";
 import { invoke } from "@tauri-apps/api";
 import { get } from "svelte/store";
 import { ErrorCode, type Problem } from 'codemirror-rainlang';
 
-export const parseConfigString = async (text: string): Promise<ConfigString> => invoke("parse_configstring", {text});
+export const parseConfigSource = async (text: string): Promise<ConfigSource> => invoke("parse_configstring", {text});
 
-export const mergeDotrainConfigWithSettings = async (dotrain: string): Promise<ConfigString> => invoke("merge_configstrings", {dotrain, configText: get(settingsText)});
+export const mergeDotrainConfigWithSettings = async (dotrain: string): Promise<ConfigSource> => invoke("merge_configstrings", {dotrain, configText: get(settingsText)});
 
-export const convertConfigstringToConfig = async (configString: ConfigString): Promise<Config> => invoke("convert_configstring_to_config", {configString});
+export const convertConfigstringToConfig = async (configString: ConfigSource): Promise<Config> => invoke("convert_configstring_to_config", {configString});
 
-export async function parseConfigStringProblems(text: string) {
+export async function parseConfigSourceProblems(text: string) {
   const problems: Problem[] = [];
 
   try {
-    await parseConfigString(text);
+    await parseConfigSource(text);
   } catch(e) {
     problems.push(convertErrorToProblem(e));
   }

--- a/tauri-app/src/lib/stores/settings.ts
+++ b/tauri-app/src/lib/stores/settings.ts
@@ -3,11 +3,11 @@ import { cachedWritableStore, cachedWritableStringOptional } from '$lib/storesGe
 import  find from 'lodash/find';
 import * as chains from 'viem/chains';
 import { textFileStore } from '$lib/storesGeneric/textFileStore';
-import { type ConfigString, type OrderbookRef, type OrderbookString } from '$lib/typeshare/configString';
+import { type ConfigSource, type OrderbookRef, type OrderbookConfigSource } from '$lib/typeshare/configString';
 import { getBlockNumberFromRpc } from '$lib/services/chain';
 import { toasts } from './toasts';
 import { pickBy } from 'lodash';
-import { parseConfigString } from '$lib/services/config';
+import { parseConfigSource } from '$lib/services/config';
 
 const emptyConfig = {
   deployments: {},
@@ -19,14 +19,14 @@ const emptyConfig = {
   deployers: {},
   scenarios: {},
   charts: {}
-} as ConfigString;
+} as ConfigSource;
 
 // general
 export const settingsText = cachedWritableStore<string>('settings', "", (s) => s, (s) => s);
 export const settingsFile = textFileStore('Orderbook Settings Yaml', ['yml', 'yaml'], get(settingsText));
-export const settings = asyncDerived(settingsText, async ($settingsText): Promise<ConfigString> => {
+export const settings = asyncDerived(settingsText, async ($settingsText): Promise<ConfigSource> => {
   try {
-    const config: ConfigString = await parseConfigString($settingsText);
+    const config: ConfigSource = await parseConfigSource($settingsText);
     return config;
   } catch(e) {
     toasts.error(e as string);
@@ -50,7 +50,7 @@ export const activeChainLatestBlockNumber = derived(activeNetwork, ($activeNetwo
 
 // orderbook
 export const activeOrderbookRef = cachedWritableStringOptional("settings.activeOrderbookRef");
-export const activeNetworkOrderbooks = derived([settings, activeNetworkRef], ([$settings, $activeNetworkRef]) => $settings?.orderbooks ? pickBy($settings.orderbooks, (orderbook) => orderbook.network === $activeNetworkRef) as Record<OrderbookRef, OrderbookString> : {} as Record<OrderbookRef, OrderbookString>);
+export const activeNetworkOrderbooks = derived([settings, activeNetworkRef], ([$settings, $activeNetworkRef]) => $settings?.orderbooks ? pickBy($settings.orderbooks, (orderbook) => orderbook.network === $activeNetworkRef) as Record<OrderbookRef, OrderbookConfigSource> : {} as Record<OrderbookRef, OrderbookConfigSource>);
 export const activeOrderbook =  derived([settings, activeOrderbookRef], ([$settings, $activeOrderbookRef]) => ($settings?.orderbooks !== undefined && $activeOrderbookRef !== undefined) ? $settings.orderbooks[$activeOrderbookRef] : undefined);
 export const subgraphUrl = derived([settings, activeOrderbook], ([$settings, $activeOrderbook]) => ($settings?.subgraphs !== undefined && $activeOrderbook?.subgraph !== undefined) ? $settings.subgraphs[$activeOrderbook.subgraph] : undefined);
 export const orderbookAddress = derived(activeOrderbook, ($activeOrderbook) => $activeOrderbook?.address);

--- a/tauri-app/src/routes/orders/add/+page.svelte
+++ b/tauri-app/src/routes/orders/add/+page.svelte
@@ -19,7 +19,7 @@
   import type { Config } from '$lib/typeshare/config';
   import DropdownRadio from '$lib/components/DropdownRadio.svelte';
   import { toasts } from '$lib/stores/toasts';
-  import type { ConfigString } from '$lib/typeshare/configString';
+  import type { ConfigSource } from '$lib/typeshare/configString';
   import DropdownProperty from '$lib/components/DropdownProperty.svelte';
 
   let isSubmitting = false;
@@ -27,11 +27,11 @@
   let chartData: ChartData[];
   let dotrainFile = textFileStore('Rain', ['rain']);
   let deploymentRef: string | undefined = undefined;
-  let mergedConfigString: ConfigString | undefined = undefined;
+  let mergedConfigSource: ConfigSource | undefined = undefined;
   let mergedConfig: Config | undefined = undefined;
 
-  $: deployments = (mergedConfigString !== undefined && mergedConfigString?.deployments !== undefined && mergedConfigString?.orders !== undefined) ?
-    pickBy(mergedConfigString.deployments, (d) => mergedConfigString?.orders?.[d.order]?.network === $activeNetworkRef) : {};
+  $: deployments = (mergedConfigSource !== undefined && mergedConfigSource?.deployments !== undefined && mergedConfigSource?.orders !== undefined) ?
+    pickBy(mergedConfigSource.deployments, (d) => mergedConfigSource?.orders?.[d.order]?.network === $activeNetworkRef) : {};
   $: deployment = (deploymentRef !== undefined && mergedConfig !== undefined) ? mergedConfig.deployments[deploymentRef] : undefined;
   $: bindings = deployment ? deployment.scenario.bindings : {};
   $: $dotrainFile.text, updateMergedConfig();
@@ -58,8 +58,8 @@
 
   async function updateMergedConfig() {
     try {
-      mergedConfigString = await mergeDotrainConfigWithSettings($dotrainFile.text);
-      mergedConfig = await convertConfigstringToConfig(mergedConfigString);
+      mergedConfigSource = await mergeDotrainConfigWithSettings($dotrainFile.text);
+      mergedConfig = await convertConfigstringToConfig(mergedConfigSource);
       // eslint-disable-next-line no-empty
     } catch(e) {}
   }

--- a/tauri-app/src/routes/settings/+page.svelte
+++ b/tauri-app/src/routes/settings/+page.svelte
@@ -5,7 +5,7 @@
     settingsText,
   } from '$lib/stores/settings';
   import PageHeader from '$lib/components/PageHeader.svelte';
-  import CodeMirrorConfigString from '$lib/components/CodeMirrorConfigString.svelte';
+  import CodeMirrorConfigSource from '$lib/components/CodeMirrorConfigSource.svelte';
   import ButtonLoading from '$lib/components/ButtonLoading.svelte';
   import { settingsFile }from '$lib/stores/settings';
   import FileTextarea from '$lib/components/FileTextarea.svelte';
@@ -31,7 +31,7 @@
 
 <FileTextarea textFile={settingsFile} title="Settings">
   <svelte:fragment slot="textarea">
-    <CodeMirrorConfigString
+    <CodeMirrorConfigSource
         bind:value={$settingsFile.text}
         styles={{ '&': { minHeight: '400px' } }}
       />


### PR DESCRIPTION
Resolves #425

rename config structs `FooString` -> `FooConfigSource` and `ConfigString` -> `ConfigSource`