### PR TITLE
fix(ci): keep WALLETCONNECT_PROJECT_ID env variable in nix shell

### DIFF
--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -45,7 +45,7 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           WALLETCONNECT_PROJECT_ID: ${{ secrets.WALLETCONNECT_PROJECT_ID }}
         with:
-          tauriScript: "nix develop -i --keep APPLE_CERTIFICATE --keep APPLE_CERTIFICATE_PASSWORD --keep APPLE_SIGNING_IDENTITY --keep APPLE_ID --keep APPLE_PASSWORD --keep APPLE_TEAM_ID .#tauri-shell --command cargo tauri"
+          tauriScript: "nix develop -i --keep APPLE_CERTIFICATE --keep APPLE_CERTIFICATE_PASSWORD --keep APPLE_SIGNING_IDENTITY --keep APPLE_ID --keep APPLE_PASSWORD --keep APPLE_TEAM_ID --keep WALLETCONNECT_PROJECT_ID .#tauri-shell --command cargo tauri"
           tagName: app-v__VERSION__-${{ github.sha }} # the action automatically replaces \_\_VERSION\_\_ with the app version
           releaseName: "App v__VERSION__-${{ github.sha }}"
           releaseBody: "See the assets to download this version and install."


### PR DESCRIPTION
Keep env variable WALLETCONNECT_PROJECT_ID passed from github secrets in nix shell command for building tauri app