### PR TITLE
Report all caught ui errors to sentry

### DIFF
--- a/tauri-app/src/lib/components/InputLedgerWallet.svelte
+++ b/tauri-app/src/lib/components/InputLedgerWallet.svelte
@@ -5,6 +5,7 @@
   import { isAddress } from 'viem';
   import { toasts } from '$lib/stores/toasts';
   import { getAddressFromLedger } from '$lib/services/wallet';
+  import { reportErrorToSentry } from '$lib/services/sentry';
 
   const maskOptions = {
     mask: Number,
@@ -30,8 +31,9 @@
     try {
       const res: string = await getAddressFromLedger(derivationIndex);
       walletAddress = res;
-    } catch (error) {
-      toasts.error(`Ledger error: ${error}`);
+    } catch (e) {
+      reportErrorToSentry(e);
+      toasts.error(`Ledger error: ${e as string}`);
     }
     isFetchingFromLedger = false;
   }

--- a/tauri-app/src/lib/components/ModalVaultDeposit.svelte
+++ b/tauri-app/src/lib/components/ModalVaultDeposit.svelte
@@ -9,7 +9,8 @@
   import { checkAllowance, ethersExecute } from '$lib/services/ethersTx';
   import { toasts } from '$lib/stores/toasts';
   import ModalExecute from './ModalExecute.svelte';
-    import { formatEthersTransactionError } from '$lib/utils/transaction';
+  import { formatEthersTransactionError } from '$lib/utils/transaction';
+  import { reportErrorToSentry } from '$lib/services/sentry';
 
   export let open = false;
   export let vault: TokenVaultDetail | TokenVaultListItem;
@@ -29,8 +30,9 @@
     isSubmitting = true;
     try {
       await vaultDeposit(vault.vault_id, vault.token.id, amount);
-      // eslint-disable-next-line no-empty
-    } catch (e) {}
+    } catch (e) {
+      reportErrorToSentry(e);
+    }
     isSubmitting = false;
     reset();
   }
@@ -53,6 +55,7 @@
       await depositTx.wait(1);
 
     } catch (e) {
+      reportErrorToSentry(e);
       toasts.error(formatEthersTransactionError(e));
     }
     isSubmitting = false;

--- a/tauri-app/src/lib/components/ModalVaultDepositGeneric.svelte
+++ b/tauri-app/src/lib/components/ModalVaultDepositGeneric.svelte
@@ -9,6 +9,7 @@
   import { toasts } from '$lib/stores/toasts';
   import ModalExecute from './ModalExecute.svelte';
   import { formatEthersTransactionError } from '$lib/utils/transaction';
+  import { reportErrorToSentry } from '$lib/services/sentry';
 
   export let open = false;
   let vaultId: bigint | undefined = undefined;
@@ -36,8 +37,9 @@
     isSubmitting = true;
     try {
       await vaultDeposit(vaultId, tokenAddress, amount);
-      // eslint-disable-next-line no-empty
-    } catch (e) {}
+    } catch (e) {
+      reportErrorToSentry(e);
+    }
     isSubmitting = false;
     reset();
   }
@@ -63,6 +65,7 @@
       await depositTx.wait(1);
 
     } catch (e) {
+      reportErrorToSentry(e);
       toasts.error(formatEthersTransactionError(e));
     }
     isSubmitting = false;

--- a/tauri-app/src/lib/components/ModalVaultWithdraw.svelte
+++ b/tauri-app/src/lib/components/ModalVaultWithdraw.svelte
@@ -9,6 +9,7 @@
   import { ethersExecute } from '$lib/services/ethersTx';
   import { toasts } from '$lib/stores/toasts';
   import ModalExecute from './ModalExecute.svelte';
+  import { reportErrorToSentry } from '$lib/services/sentry';
 
   export let open = false;
   export let vault: TokenVaultDetail | TokenVaultListItem;
@@ -31,8 +32,9 @@
     isSubmitting = true;
     try {
       await vaultWithdraw(vault.vault_id, vault.token.id, amount);
-      // eslint-disable-next-line no-empty
-    } catch (e) {}
+    } catch (e) {
+      reportErrorToSentry(e);
+    }
     isSubmitting = false;
     reset();
   }
@@ -45,8 +47,7 @@
       toasts.success("Transaction sent successfully!");
       await tx.wait(1);
     } catch (e) {
-      // eslint-disable-next-line no-console
-      console.log(e);
+      reportErrorToSentry(e);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       if (typeof e === "object" && (e as any)?.reason) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/tauri-app/src/lib/services/config.ts
+++ b/tauri-app/src/lib/services/config.ts
@@ -4,6 +4,7 @@ import type { ConfigSource } from "$lib/typeshare/configString";
 import { invoke } from "@tauri-apps/api";
 import { get } from "svelte/store";
 import { ErrorCode, type Problem } from 'codemirror-rainlang';
+import { reportErrorToSentry, SentrySeverityLevel } from '$lib/services/sentry';
 
 export const parseConfigSource = async (text: string): Promise<ConfigSource> => invoke("parse_configstring", {text});
 
@@ -17,6 +18,7 @@ export async function parseConfigSourceProblems(text: string) {
   try {
     await parseConfigSource(text);
   } catch(e) {
+    reportErrorToSentry(e, SentrySeverityLevel.Info);
     problems.push(convertErrorToProblem(e));
   }
 
@@ -29,6 +31,7 @@ export async function mergeDotrainConfigWithSettingsProblems(dotrain: string) {
   try {
     await mergeDotrainConfigWithSettings(dotrain);
   } catch(e) {
+    reportErrorToSentry(e, SentrySeverityLevel.Info);
     problems.push(convertErrorToProblem(e));
   }
 

--- a/tauri-app/src/lib/services/langServices.ts
+++ b/tauri-app/src/lib/services/langServices.ts
@@ -3,6 +3,7 @@ import { ErrorCode, type Problem, TextDocumentItem, Position, Hover, CompletionI
 import { rpcUrl } from '$lib/stores/settings';
 import { get } from 'svelte/store';
 import { forkBlockNumber } from '$lib/stores/forkBlockNumber';
+import { reportErrorToSentry, SentrySeverityLevel } from '$lib/services/sentry';
 
 /**
  * Provides problems callback by invoking related tauri command
@@ -12,6 +13,7 @@ export async function problemsCallback(textDocument: TextDocumentItem, bindings:
     return await invoke('call_lsp_problems', { textDocument, rpcUrl: get(rpcUrl), blockNumber: get(forkBlockNumber).value, bindings, deployer: deployerAddress });
   }
   catch (err) {
+    reportErrorToSentry(err, SentrySeverityLevel.Info);
     return [{
       msg: typeof err === "string" ? err : err instanceof Error ? err.message : "something went wrong!",
       position: [0, 0],

--- a/tauri-app/src/lib/services/sentry.ts
+++ b/tauri-app/src/lib/services/sentry.ts
@@ -6,6 +6,15 @@ import { handleErrorWithSentry } from '@sentry/sveltekit';
 import { arch, platform, type, version } from '@tauri-apps/api/os';
 import { getTauriVersion } from '@tauri-apps/api/app';
 
+export enum SentrySeverityLevel {
+  Fatal = "fatal",
+  Error = "error",
+  Warning = "warning",
+  Log = "log",
+  Info = "info",
+  Debug = "debug"
+}
+
 export async function initSentry() {
   if(import.meta.env.VITE_SENTRY_FORCE_DISABLED === 'true') return;
 
@@ -55,5 +64,17 @@ export function handleErrorWithSentryIfEnabled<T extends HandleClientError | Han
 
   if($enableSentry) {
     return handleErrorWithSentry(handleError);
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function reportErrorToSentry(e: any, level: Sentry.SeverityLevel = SentrySeverityLevel.Error) {
+  const $enableSentry = get(enableSentry);
+
+  if($enableSentry) {
+    Sentry.withScope(function (scope) {
+      scope.setLevel(level);
+      Sentry.captureException(e);
+    });
   }
 }

--- a/tauri-app/src/lib/services/sentry.ts
+++ b/tauri-app/src/lib/services/sentry.ts
@@ -6,6 +6,8 @@ import { handleErrorWithSentry } from '@sentry/sveltekit';
 import { arch, platform, type, version } from '@tauri-apps/api/os';
 import { getTauriVersion } from '@tauri-apps/api/app';
 
+// Sentry.SeverityLevel allowed string values as an enum
+// (to avoid spreading magic strings)
 export enum SentrySeverityLevel {
   Fatal = "fatal",
   Error = "error",

--- a/tauri-app/src/lib/services/sentry.ts
+++ b/tauri-app/src/lib/services/sentry.ts
@@ -6,8 +6,7 @@ import { handleErrorWithSentry } from '@sentry/sveltekit';
 import { arch, platform, type, version } from '@tauri-apps/api/os';
 import { getTauriVersion } from '@tauri-apps/api/app';
 
-// Sentry.SeverityLevel allowed string values as an enum
-// (to avoid spreading magic strings)
+// Copy of Sentry.SeverityLevel allowed string values as an enum (to avoid spreading magic strings)
 export enum SentrySeverityLevel {
   Fatal = "fatal",
   Error = "error",
@@ -70,7 +69,7 @@ export function handleErrorWithSentryIfEnabled<T extends HandleClientError | Han
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function reportErrorToSentry(e: any, level: Sentry.SeverityLevel = SentrySeverityLevel.Error) {
+export function reportErrorToSentry(e: any, level: SentrySeverityLevel = SentrySeverityLevel.Error) {
   const $enableSentry = get(enableSentry);
 
   if($enableSentry) {

--- a/tauri-app/src/lib/stores/settings.ts
+++ b/tauri-app/src/lib/stores/settings.ts
@@ -8,6 +8,7 @@ import { getBlockNumberFromRpc } from '$lib/services/chain';
 import { toasts } from './toasts';
 import { pickBy } from 'lodash';
 import { parseConfigSource } from '$lib/services/config';
+import { reportErrorToSentry, SentrySeverityLevel } from '$lib/services/sentry';
 
 // general
 export const settingsText = cachedWritableStore<string>('settings', "", (s) => s, (s) => s);
@@ -17,6 +18,7 @@ export const settings = asyncDerived(settingsText, async ($settingsText): Promis
     const config: ConfigSource = await parseConfigSource($settingsText);
     return config;
   } catch(e) {
+    reportErrorToSentry(e, SentrySeverityLevel.Info);
     toasts.error(e as string);
   }
 });

--- a/tauri-app/src/lib/stores/walletconnect.ts
+++ b/tauri-app/src/lib/stores/walletconnect.ts
@@ -5,6 +5,7 @@ import * as chains from 'viem/chains';
 import { type NetworkConfigSource } from '$lib/typeshare/configString';
 import { createWeb3Modal, defaultConfig } from '@web3modal/ethers5'
 import { activeNetwork } from './settings';
+import { reportErrorToSentry } from '$lib/services/sentry';
 
 const WALLETCONNECT_PROJECT_ID = import.meta.env.VITE_WALLETCONNECT_PROJECT_ID;
 
@@ -38,9 +39,8 @@ activeNetwork.subscribe(async network => {
     try {
       await oldModal.disconnect()
     } catch(e) {
-      walletconnectModal.set(undefined)
-      // eslint-disable-next-line no-console
-      console.log(e)
+      reportErrorToSentry(e);
+      walletconnectModal.set(undefined);
     }
   }
   if (network === undefined) {

--- a/tauri-app/src/lib/storesGeneric/detailStore.ts
+++ b/tauri-app/src/lib/storesGeneric/detailStore.ts
@@ -1,6 +1,7 @@
 import { toasts } from '$lib/stores/toasts';
 import { cachedWritableStore } from '$lib/storesGeneric/cachedWritableStore';
 import { derived, writable, type Invalidator, type Subscriber, type Unsubscriber } from 'svelte/store';
+import { reportErrorToSentry } from '$lib/services/sentry';
 
 
 export interface DetailStore<T> {
@@ -31,6 +32,7 @@ export function detailStore<T>(key: string, fetchById: (id: string) => Promise<T
         return {... value, [id]: res};
       });
     } catch(e) {
+      reportErrorToSentry(e);
       toasts.error(e as string);
     }
 

--- a/tauri-app/src/lib/storesGeneric/fetchableStore.ts
+++ b/tauri-app/src/lib/storesGeneric/fetchableStore.ts
@@ -1,6 +1,7 @@
 import { derived, writable } from "svelte/store";
 import { cachedWritableStore } from "./cachedWritableStore";
 import { toasts } from "$lib/stores/toasts";
+import { reportErrorToSentry } from '$lib/services/sentry';
 
 interface FetchableStoreData<T> {
   value: T,
@@ -22,6 +23,7 @@ export function fetchableStore<T>(key: string, defaultValue: T, handleFetch: () 
       const res: T = await handleFetch();
       value.set(res);
     } catch(e) {
+      reportErrorToSentry(e);
       toasts.error(e as string);
     }
     isFetching.set(false);

--- a/tauri-app/src/lib/storesGeneric/listStore.ts
+++ b/tauri-app/src/lib/storesGeneric/listStore.ts
@@ -5,6 +5,7 @@ import dayjs from 'dayjs';
 import { ToastMessageType } from '$lib/typeshare/toast';
 import { cachedWritableStore } from '$lib/storesGeneric/cachedWritableStore';
 import { flatten } from 'lodash';
+import { reportErrorToSentry, SentrySeverityLevel } from '$lib/services/sentry';
 
 type Unsubscriber = () => void;
 
@@ -75,6 +76,7 @@ export function listStore<T>(key: string, fetchPageHandler: (page: number) => Pr
         await promise;
         pageIndex.set(newPage);
       } catch(e) {
+        reportErrorToSentry(e);
         if(displayError) {
           toasts.error((e as Error).message);
         }
@@ -97,6 +99,9 @@ export function listStore<T>(key: string, fetchPageHandler: (page: number) => Pr
         await fetchPage(newPage);
         newPage += 1;
       } catch(e) {
+        // Because we don't know the total number of pages in advance,
+        // we have to attempt to fetch the next page until we receive an error.
+        reportErrorToSentry(e, SentrySeverityLevel.Info);
         hasMorePages = false;
       }
     }
@@ -123,6 +128,7 @@ export function listStore<T>(key: string, fetchPageHandler: (page: number) => Pr
         });
       }
     } catch(e) {
+      reportErrorToSentry(e);
       toasts.error(e as string);
     }
     isExporting.set(false);

--- a/tauri-app/src/lib/storesGeneric/listStore.ts
+++ b/tauri-app/src/lib/storesGeneric/listStore.ts
@@ -76,7 +76,7 @@ export function listStore<T>(key: string, fetchPageHandler: (page: number) => Pr
         await promise;
         pageIndex.set(newPage);
       } catch(e) {
-        reportErrorToSentry(e);
+        reportErrorToSentry(e, SentrySeverityLevel.Info);
         if(displayError) {
           toasts.error((e as Error).message);
         }

--- a/tauri-app/src/lib/storesGeneric/textFileStore.ts
+++ b/tauri-app/src/lib/storesGeneric/textFileStore.ts
@@ -2,6 +2,7 @@ import { toasts } from '$lib/stores/toasts';
 import { open, save } from '@tauri-apps/api/dialog';
 import { readTextFile, writeTextFile } from '@tauri-apps/api/fs';
 import { derived, get, writable, type Invalidator, type Subscriber } from "svelte/store";
+import { reportErrorToSentry } from '$lib/services/sentry';
 
 interface TextFileData {
   text: string;
@@ -64,6 +65,7 @@ export function textFileStore(name: string, extensions: string[], defaultText: s
         path.set(pathValue as string);
       }
     } catch(e) {
+      reportErrorToSentry(e);
       toasts.error(e as string);
     }
 
@@ -84,6 +86,7 @@ export function textFileStore(name: string, extensions: string[], defaultText: s
       toasts.success(`Saved to ${pathValue}`);
     }
     catch(e) {
+      reportErrorToSentry(e);
       toasts.error(e as string);
     }
 
@@ -108,6 +111,7 @@ export function textFileStore(name: string, extensions: string[], defaultText: s
       }
 
     } catch(e) {
+      reportErrorToSentry(e);
       toasts.error(e as string);
     }
 

--- a/tauri-app/src/routes/orders/+page.svelte
+++ b/tauri-app/src/routes/orders/+page.svelte
@@ -22,6 +22,7 @@
     DropdownItem,
     Spinner,
   } from 'flowbite-svelte';
+  import { reportErrorToSentry } from '$lib/services/sentry';
 
   $: $subgraphUrl, $ordersList?.fetchFirst();
   let openOrderRemoveModal = false;
@@ -32,8 +33,9 @@
     isSubmitting = true;
     try {
       await orderRemove(id);
-      // eslint-disable-next-line no-empty
-    } catch (e) {}
+    } catch (e) {
+      reportErrorToSentry(e);
+    }
     isSubmitting = false;
   }
   async function executeWalletconnect() {
@@ -44,8 +46,7 @@
       toasts.success("Transaction sent successfully!");
       await tx.wait(1);
     } catch (e) {
-      // eslint-disable-next-line no-console
-      console.log(e);
+      reportErrorToSentry(e);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       if (typeof e === "object" && (e as any)?.reason) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/tauri-app/src/routes/orders/[id]/+page.svelte
+++ b/tauri-app/src/routes/orders/[id]/+page.svelte
@@ -22,6 +22,7 @@
   import { ethersExecute } from '$lib/services/ethersTx';
   import { orderbookAddress } from '$lib/stores/settings';
   import { toasts } from '$lib/stores/toasts';
+  import { reportErrorToSentry } from '$lib/services/sentry';
 
   let openOrderRemoveModal = false;
   let isSubmitting = false;
@@ -75,8 +76,9 @@
     isSubmitting = true;
     try {
       await orderRemove(order.id);
-      // eslint-disable-next-line no-empty
-    } catch (e) {}
+    } catch (e) {
+      reportErrorToSentry(e);
+    }
     isSubmitting = false;
   }
 
@@ -88,8 +90,7 @@
       toasts.success("Transaction sent successfully!");
       await tx.wait(1);
     } catch (e) {
-      // eslint-disable-next-line no-console
-      console.log(e);
+      reportErrorToSentry(e);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       if (typeof e === "object" && (e as any)?.reason) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/tauri-app/src/routes/orders/add/+page.svelte
+++ b/tauri-app/src/routes/orders/add/+page.svelte
@@ -24,6 +24,7 @@
   import { orderAdd, orderAddCalldata } from '$lib/services/order';
   import { ethersExecute } from '$lib/services/ethersTx';
   import { formatEthersTransactionError } from '$lib/utils/transaction';
+  import { SentrySeverityLevel, reportErrorToSentry } from '$lib/services/sentry';
 
   let isSubmitting = false;
   let isCharting = false;
@@ -64,8 +65,9 @@
     try {
       mergedConfigSource = await mergeDotrainConfigWithSettings($dotrainFile.text);
       mergedConfig = await convertConfigstringToConfig(mergedConfigSource);
-      // eslint-disable-next-line no-empty
-    } catch(e) {}
+    } catch(e) {
+      reportErrorToSentry(e, SentrySeverityLevel.Info);
+    }
   }
 
   async function chart() {
@@ -73,6 +75,7 @@
     try {
       chartData = await makeChartData($dotrainFile.text, $settingsText);
     } catch(e) {
+      reportErrorToSentry(e);
       toasts.error(e as string);
     }
     isCharting = false;
@@ -84,8 +87,9 @@
       if(!deployment) throw Error("Select a deployment to add order");
 
       await orderAdd($dotrainFile.text, deployment);
-      // eslint-disable-next-line no-empty
-    } catch (e) {}
+    } catch (e) {
+      reportErrorToSentry(e);
+    }
     isSubmitting = false;
   }
   async function executeWalletconnect() {
@@ -99,6 +103,7 @@
       toasts.success("Transaction sent successfully!");
       await tx.wait(1);
     } catch (e) {
+      reportErrorToSentry(e);
       toasts.error(formatEthersTransactionError(e));
     }
     isSubmitting = false;


### PR DESCRIPTION
- Anytime we manually catch a UI error, report it to sentry (at the "error" log level by default)
- For errors that are likely be common (i.e. as the result of incorrect user input, or as expected parts of the app logic) report to sentry at the "info" log level. I believe this is a better approach as some "real" errors may get reported, while the expected ones can be ignored via the sentry web interface.