### PR TITLE
ci: revert -- releases should not be draft

### DIFF
--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -63,4 +63,3 @@ jobs:
           tagName: app-v__VERSION__-${{ github.sha }} # the action automatically replaces \_\_VERSION\_\_ with the app version
           releaseName: "App v__VERSION__-${{ github.sha }}"
           releaseBody: "See the assets to download this version and install."
-          releaseDraft: true


### PR DESCRIPTION
As part of #457 I had CI publish draft releases off the feature branch. Forgot to remove the draft setting before the PR was merged into main.