### PR TITLE
feat(tauri/ui): bottom margin to account for 'alpha warning' block

### DIFF
--- a/tauri-app/src/routes/+layout.svelte
+++ b/tauri-app/src/routes/+layout.svelte
@@ -28,7 +28,7 @@
 
 <WindowDraggableArea />
 
-<div class="flex min-h-screen w-full justify-start bg-white dark:bg-gray-900">
+<div class="flex min-h-screen w-full justify-start bg-white dark:bg-gray-900 mb-10">
   <Sidebar hasRequiredSettings={$hasRequiredSettings} />
 
   <main class="ml-64 h-full w-full grow overflow-x-auto p-8">


### PR DESCRIPTION
Resolves #440

Add some bottom margin to account for the "this product is early alpha" block, on all pages:

Previously:
![image](https://github.com/rainlanguage/rain.orderbook/assets/159270/84e2c0e2-4e5b-4644-aea8-ef683237a22d)


With this PR:
![image](https://github.com/rainlanguage/rain.orderbook/assets/159270/c3cb84dc-589f-44d6-9a9f-68a6e328d0bf)
