### PR TITLE
Further additions to charting and scenario debugging

### DIFF
--- a/crates/settings/src/chart.rs
+++ b/crates/settings/src/chart.rs
@@ -105,7 +105,7 @@ mod tests {
 
         let chart_string = ChartConfigSource {
             scenario: Some(scenario_name),
-            plots,
+            plots: Some(plots),
             metrics: None,
         };
 
@@ -200,6 +200,7 @@ mod tests {
             unit_prefix: Some("unit_prefix".to_string()),
             unit_suffix: Some("unit_suffix".to_string()),
             value: "value".to_string(),
+            precision: Some(2),
         }];
 
         let chart_string = ChartConfigSource {
@@ -215,7 +216,7 @@ mod tests {
             &chart.scenario,
             scenarios.get("scenario5").unwrap()
         ));
-        assert_eq!(chart.plots.unwrap().len(), 2);
+        assert_eq!(chart.clone().plots.unwrap().len(), 2);
 
         // both plots should have the name "Title"
         let mut plots = chart

--- a/crates/settings/src/chart.rs
+++ b/crates/settings/src/chart.rs
@@ -10,7 +10,7 @@ use typeshare::typeshare;
 pub struct Chart {
     #[typeshare(typescript(type = "Scenario"))]
     pub scenario: Arc<Scenario>,
-    pub plots: Vec<Plot>,
+    pub plots: Option<Vec<Plot>>,
     pub metrics: Option<Vec<Metric>>,
 }
 
@@ -23,6 +23,7 @@ pub struct Metric {
     pub unit_prefix: Option<String>,
     pub unit_suffix: Option<String>,
     pub value: String,
+    pub precision: Option<u8>,
 }
 
 #[derive(Error, Debug, PartialEq)]
@@ -52,21 +53,22 @@ impl ChartConfigSource {
                 .map(Arc::clone)?,
         };
 
+        // Convert `self.plots` from Option<HashMap<String, Plot>> to Option<Vec<Plot>>
+        let plots = self.plots.map(|plots_map| {
+            plots_map
+                .into_iter()
+                .map(|(name, mut plot)| {
+                    // If the plot does not have a title, use the name from the map
+                    plot.title.get_or_insert(name);
+                    plot
+                })
+                .collect::<Vec<Plot>>()
+        });
+
         Ok(Chart {
             scenario: scenario_ref,
             metrics: self.metrics,
-            plots: self
-                .plots
-                .into_iter()
-                .map(|(name, plot)| {
-                    // if the plot has a title, use it, otherwise use the name
-                    let title = plot.title.unwrap_or_else(|| name.clone());
-                    Plot {
-                        title: Some(title),
-                        ..plot
-                    }
-                })
-                .collect::<Vec<Plot>>(),
+            plots,
         })
     }
 }
@@ -128,7 +130,7 @@ mod tests {
 
         let chart_string = ChartConfigSource {
             scenario: None,
-            plots,
+            plots: Some(plots),
             metrics: None,
         };
 
@@ -151,7 +153,7 @@ mod tests {
 
         let chart_string = ChartConfigSource {
             scenario: Some("nonexistent_scenario".to_string()),
-            plots,
+            plots: Some(plots),
             metrics: None,
         };
 
@@ -168,7 +170,7 @@ mod tests {
 
         let chart_string = ChartConfigSource {
             scenario: None,
-            plots: HashMap::new(),
+            plots: None,
             metrics: None,
         };
 
@@ -202,7 +204,7 @@ mod tests {
 
         let chart_string = ChartConfigSource {
             scenario: Some(scenario_name),
-            plots,
+            plots: Some(plots),
             metrics: Some(metrics),
         };
 
@@ -213,11 +215,12 @@ mod tests {
             &chart.scenario,
             scenarios.get("scenario5").unwrap()
         ));
-        assert_eq!(chart.plots.len(), 2);
+        assert_eq!(chart.plots.unwrap().len(), 2);
 
         // both plots should have the name "Title"
         let mut plots = chart
             .plots
+            .unwrap()
             .iter()
             .map(|p| p.title.clone())
             .collect::<Vec<Option<String>>>();

--- a/crates/settings/src/config_source.rs
+++ b/crates/settings/src/config_source.rs
@@ -138,7 +138,7 @@ pub struct ScenarioConfigSource {
 #[serde(rename_all = "kebab-case")]
 pub struct ChartConfigSource {
     pub scenario: Option<ScenarioRef>,
-    pub plots: HashMap<String, Plot>,
+    pub plots: Option<HashMap<String, Plot>>,
     pub metrics: Option<Vec<Metric>>,
 }
 

--- a/tauri-app/src/lib/components/Charts.svelte
+++ b/tauri-app/src/lib/components/Charts.svelte
@@ -2,13 +2,14 @@
   import ObservableChart from '$lib/components/ObservableChart.svelte';
   import type { ChartData } from '$lib/typeshare/config';
   import { transformData } from '$lib/utils/chartData';
+  import { sortBy } from 'lodash';
   import MetricChart from './MetricChart.svelte';
   export let chartData: ChartData;
 </script>
 
 {#if chartData}
-  <div class="flex flex-col items-center">
-    {#each Object.entries(chartData.charts) as chart}
+  <div class="flex flex-col items-center gap-y-6">
+    {#each sortBy(Object.entries(chartData.charts), ['0']) as chart}
       {@const data = transformData(chartData.scenarios_data[chart[1].scenario.name])}
       <div class="w-full">
         <div class="flex flex-col justify-center gap-y-4">

--- a/tauri-app/src/lib/components/Charts.svelte
+++ b/tauri-app/src/lib/components/Charts.svelte
@@ -1,16 +1,16 @@
 <script lang="ts">
   import ObservableChart from '$lib/components/ObservableChart.svelte';
   import type { ChartData } from '$lib/typeshare/config';
-  import { transformData } from '$lib/utils/chartData';
+  import { transformDataForPlot } from '$lib/utils/chartData';
   import { sortBy } from 'lodash';
   import MetricChart from './MetricChart.svelte';
   export let chartData: ChartData;
 </script>
 
 {#if chartData}
-  <div class="flex flex-col items-center gap-y-6">
+  <div class="mt-8 flex flex-col items-center gap-y-6">
     {#each sortBy(Object.entries(chartData.charts), ['0']) as chart}
-      {@const data = transformData(chartData.scenarios_data[chart[1].scenario.name])}
+      {@const data = transformDataForPlot(chartData.scenarios_data[chart[1].scenario.name])}
       <div class="w-full">
         <div class="flex flex-col justify-center gap-y-4">
           <h2 class="text-2xl font-bold">{chart[0]}</h2>
@@ -30,4 +30,6 @@
       </div>
     {/each}
   </div>
+{:else}
+  No scenario data
 {/if}

--- a/tauri-app/src/lib/components/MetricChart.svelte
+++ b/tauri-app/src/lib/components/MetricChart.svelte
@@ -3,12 +3,16 @@
   import type { TransformedPlotData } from '$lib/utils/chartData';
   export let metric: Metric;
   export let data: TransformedPlotData[];
+
+  $: metricData = metric?.precision
+    ? parseFloat(data[0]?.[metric.value].toPrecision(metric.precision)).toString()
+    : data[0]?.[metric.value];
 </script>
 
 <div class="flex h-full w-full flex-col items-center justify-between border p-4">
   <span>{metric.label}</span>
   <span class="text-2xl"
-    >{metric?.['unit-prefix'] || ''}{data[0]?.[metric.value]}{metric?.['unit-suffix'] || ''}</span
+    >{metric?.['unit-prefix'] || ''}{metricData}{metric?.['unit-suffix'] || ''}</span
   >
   {#if metric?.description}
     <span class="text-sm">{metric.description}</span>

--- a/tauri-app/src/lib/components/ScenarioDebugTable.svelte
+++ b/tauri-app/src/lib/components/ScenarioDebugTable.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  import type { ChartData } from '$lib/typeshare/config';
+  import { transformData } from '$lib/utils/chartData';
+  import {
+    Table,
+    TableBody,
+    TableBodyCell,
+    TableBodyRow,
+    TableHead,
+    TableHeadCell,
+  } from 'flowbite-svelte';
+
+  export let chartData: ChartData;
+</script>
+
+{#if chartData}
+  <div class="flex w-full gap-x-4 overflow-x-scroll">
+    {#each Object.values(chartData.scenarios_data) as scenario}
+      {@const data = transformData(scenario)}
+      <div class="flex flex-col gap-y-2">
+        <span>{scenario.scenario}</span>
+        <Table divClass="cursor-pointer rounded-lg overflow-hidden dark:border-none border">
+          <TableHead>
+            <TableHeadCell>Stack item</TableHeadCell>
+            <TableHeadCell>Value</TableHeadCell>
+            <TableHeadCell>Hex</TableHeadCell>
+          </TableHead>
+          <TableBody>
+            {#each Object.entries(data[0]) as [key, value]}
+              <TableBodyRow>
+                <TableBodyCell>{key}</TableBodyCell>
+                <TableBodyCell>{value[0]}</TableBodyCell>
+                <TableBodyCell>{value[1]}</TableBodyCell>
+              </TableBodyRow>
+            {/each}
+          </TableBody>
+        </Table>
+      </div>
+    {/each}
+  </div>
+{:else}
+  No scenario data
+{/if}

--- a/tauri-app/src/lib/utils/asyncDebounce.ts
+++ b/tauri-app/src/lib/utils/asyncDebounce.ts
@@ -1,0 +1,206 @@
+import { debounce } from "lodash";
+import { get, writable } from "svelte/store";
+
+/**
+ * Creates a debounced asynchronous function that calls the original function
+ * only once after the last call within a specified wait time.
+ *
+ * @template T - The type of the arguments passed to the original function.
+ * @template R - The type of the result returned by the original function.
+ * @param {(...args: T) => Promise<R>} fn - The original function to be debounced.
+ * @param {number} wait - The wait time in milliseconds before invoking the debounced function.
+ * @param {(result: R) => void} onSuccess - The success callback function to be invoked with the result.
+ * @param {(error: unknown) => void} onError - The error callback function to be invoked with the error.
+ * @returns {(...args: T) => void} - The debounced function.
+ */
+export function createDebouncedAsyncFn<T extends unknown[], R>(
+    fn: (...args: T) => Promise<R>,
+    wait: number,
+    onSuccess: (result: R) => void,
+    onError: (error: unknown) => void
+): (...args: T) => void {
+    let currentArgs: T | undefined;
+
+    const executeFn = async (args: T) => {
+        const argsNotEqual = (args: T, currentArgs?: T) => JSON.stringify(currentArgs) !== JSON.stringify(args)
+        try {
+            const result = await fn(...args);
+            if (argsNotEqual(args, currentArgs)) return
+            onSuccess(result);
+        } catch (error) {
+            if (argsNotEqual(args, currentArgs)) return
+            onError(error);
+        }
+    };
+
+    const debouncedFn = debounce((...args: T) => {
+        return executeFn(args);
+    }, wait);
+
+    return (...args: T): void => {
+        currentArgs = args;
+        debouncedFn(...args);
+    };
+}
+
+
+/**
+ * Creates a debounced asynchronous function that calls the original function
+ * only once after the last call within a specified wait time.
+ *
+ * The function returns a debounced function along with writable stores for the result and error.
+ *
+ * @template T - The type of the arguments passed to the original function.
+ * @template R - The type of the result returned by the original function.
+ * @param {(...args: T) => Promise<R>} fn - The original function to be debounced.
+ * @param {number} wait - The wait time in milliseconds before invoking the debounced function.
+ * @returns {{ debouncedFn: (...args: T) => void, result: import('svelte/store').Writable<R | undefined>, error: import('svelte/store').Writable<unknown | undefined> }} - The debounced function and the result and error stores.
+ */
+export function useDebouncedFn<T extends unknown[], R>(fn: (...args: T) => Promise<R>, wait: number) {
+    const result = writable<R | undefined>(undefined);
+    const error = writable<unknown | undefined>(undefined);
+
+    const debouncedFn = createDebouncedAsyncFn<T, R>(
+        fn,
+        wait,
+        (res: R) => {
+            result.set(res);
+            error.set(undefined); // Reset error store on successful execution
+        },
+        (err: unknown) => {
+            error.set(err);
+            result.set(undefined); // Reset result store on error
+        }
+    );
+
+    return { debouncedFn, result, error };
+}
+
+if (import.meta.vitest) {
+    const { it, expect, vi } = import.meta.vitest
+
+    it('creates a debounced async function that only calls the original function once after the last call', async () => {
+        let callCount = 0;
+        const debouncedFn = createDebouncedAsyncFn(async () => {
+            callCount++;
+        }, 100, () => { }, () => { });
+
+        debouncedFn();
+
+        await new Promise((resolve) => setTimeout(resolve, 50));
+
+        debouncedFn();
+
+        await new Promise((resolve) => setTimeout(resolve, 150));
+
+        expect(callCount).toEqual(1);
+
+        debouncedFn();
+
+        await new Promise((resolve) => setTimeout(resolve, 50));
+
+        debouncedFn();
+
+        await new Promise((resolve) => setTimeout(resolve, 150));
+
+        expect(callCount).toEqual(2);
+    });
+
+    it('calls the onSuccess callback with the result of the original function', async () => {
+        const onSuccess = vi.fn();
+        const onError = vi.fn();
+
+        const debouncedFn = createDebouncedAsyncFn(async (value: number) => {
+            return value * 2;
+        }, 100, onSuccess, onError);
+
+        debouncedFn(5);
+
+        await new Promise((resolve) => setTimeout(resolve, 150)); // Wait for debounce and async function
+
+        expect(onSuccess).toHaveBeenCalledWith(10);
+    });
+
+    it('calls the onError callback if the original function throws an error', async () => {
+        const onSuccess = vi.fn();
+        const onError = vi.fn();
+
+        const debouncedFn = createDebouncedAsyncFn(async () => {
+            throw new Error('Test error');
+        }, 100, onSuccess, onError);
+
+        debouncedFn();
+
+        await new Promise((resolve) => setTimeout(resolve, 150)); // Wait for debounce and async function
+
+        expect(onError).toHaveBeenCalledWith(expect.any(Error));
+        expect(onError.mock.calls[0][0]).toHaveProperty('message', 'Test error');
+    });
+
+    it('passes the arguments to the original function', async () => {
+        const onSuccess = vi.fn();
+        const onError = vi.fn();
+
+        const debouncedFn = createDebouncedAsyncFn(async (value: number) => {
+            return value * 2;
+        }, 100, onSuccess, onError);
+
+        debouncedFn(5);
+
+        await new Promise((resolve) => setTimeout(resolve, 150)); // Wait for debounce and async function
+
+        expect(onSuccess).toHaveBeenCalledWith(10);
+    });
+
+    // tests for useDebouncedFn
+    it('creates a debounced async function that only calls the original function once after the last call', async () => {
+        let callCount = 0;
+        const { debouncedFn } = useDebouncedFn(async () => {
+            callCount++;
+        }, 100);
+
+        debouncedFn();
+
+        await new Promise((resolve) => setTimeout(resolve, 50));
+
+        debouncedFn();
+
+        await new Promise((resolve) => setTimeout(resolve, 150));
+
+        expect(callCount).toEqual(1);
+
+        debouncedFn();
+
+        await new Promise((resolve) => setTimeout(resolve, 50));
+
+        debouncedFn();
+
+        await new Promise((resolve) => setTimeout(resolve, 150));
+
+        expect(callCount).toEqual(2);
+    });
+
+    it('calls the onSuccess callback with the result of the original function', async () => {
+        const { debouncedFn, result } = useDebouncedFn(async (value: number) => {
+            return value * 2;
+        }, 100);
+
+        debouncedFn(5);
+
+        await new Promise((resolve) => setTimeout(resolve, 150)); // Wait for debounce and async function
+
+        expect(get(result)).toEqual(10);
+    });
+
+    it('calls the onError callback if the original function throws an error', async () => {
+        const { debouncedFn, error } = useDebouncedFn(async () => {
+            throw new Error('Test error');
+        }, 100);
+
+        debouncedFn();
+
+        await new Promise((resolve) => setTimeout(resolve, 150)); // Wait for debounce and async function
+
+        expect(get(error)).toHaveProperty('message', 'Test error');
+    });
+}


### PR DESCRIPTION
This adds
- optional plots under charts (so you can do metrics only)
- debug tables for any scenarios that have been charted
- rainlang is now generated automatically, on every document change but debounced for 500ms
- rainlang source for the scenarios is on tabs, not under a dropdown