### PR TITLE
add hacky fix for io ratio in tables

### DIFF
--- a/tauri-app/src/routes/orders/[id]/+page.svelte
+++ b/tauri-app/src/routes/orders/[id]/+page.svelte
@@ -180,7 +180,8 @@
               {item.output_token.symbol}
             </TableBodyCell>
             <TableBodyCell tdClass="break-all py-2">
-              {item.ioratio}
+              <!-- {item.ioratio} -->
+              {Number(item.output_display) / Number(item.input_display)}
               {item.input_token.symbol}/{item.output_token.symbol}
             </TableBodyCell>
           </svelte:fragment>

--- a/tauri-app/src/routes/orders/[id]/+page.svelte
+++ b/tauri-app/src/routes/orders/[id]/+page.svelte
@@ -182,7 +182,7 @@
             <TableBodyCell tdClass="break-all py-2">
               <!-- {item.ioratio} -->
               {Number(item.output_display) / Number(item.input_display)}
-              {item.input_token.symbol}/{item.output_token.symbol}
+              {item.output_token.symbol}/{item.input_token.symbol}
             </TableBodyCell>
           </svelte:fragment>
         </AppTable>

--- a/tauri-app/src/routes/orders/[id]/+page.svelte
+++ b/tauri-app/src/routes/orders/[id]/+page.svelte
@@ -178,7 +178,7 @@
             </TableBodyCell>
             <TableBodyCell tdClass="break-all py-2">
               <!-- {item.ioratio} -->
-              {Number(item.output_display) / Number(item.input_display)}
+              {BigInt(item.output_display) / BigInt(item.input_display)}
               {item.output_token.symbol}/{item.input_token.symbol}
             </TableBodyCell>
           </svelte:fragment>


### PR DESCRIPTION
![image](https://github.com/rainlanguage/rain.orderbook/assets/1431991/baf1def4-0142-4475-a822-07e33e316b6b)

updates the table to render the raitos and symbols the right way round.