### PR TITLE
filling context with 50x50 zeroes

### DIFF
--- a/crates/common/src/fuzz/mod.rs
+++ b/crates/common/src/fuzz/mod.rs
@@ -244,7 +244,7 @@ impl FuzzRunner {
 
                 // create a 50x50 grid of zero values for context - later we'll
                 // replace these with sane values based on Orderbook context
-                let context = vec![vec![U256::from(0); 50]; 50];
+                let context = vec![vec![U256::from(0); 5]; 5];
 
                 let args = ForkEvalArgs {
                     rainlang_string,

--- a/crates/common/src/fuzz/mod.rs
+++ b/crates/common/src/fuzz/mod.rs
@@ -242,7 +242,7 @@ impl FuzzRunner {
                     Some(final_bindings),
                 )?;
 
-                // create a 50x50 grid of zero values for context - later we'll
+                // create a 5x5 grid of zero values for context - later we'll
                 // replace these with sane values based on Orderbook context
                 let context = vec![vec![U256::from(0); 5]; 5];
 


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

Per #648 we have an issue where using any of the context words when simulating will give an array out of bounds panic.

## Solution

For now, filling the context grid with 50x50 zeroes. In the near future we'll attempt to fill with sane values.

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
