### PR TITLE
Added block backtesting

### DIFF
--- a/crates/common/src/add_order.rs
+++ b/crates/common/src/add_order.rs
@@ -358,6 +358,7 @@ price: 2e18;
             name: "test-scenario".to_string(),
             bindings: HashMap::new(),
             runs: None,
+            blocks: None,
             deployer: deployer_arc.clone(),
         };
         let token1 = Token {

--- a/crates/settings/src/chart.rs
+++ b/crates/settings/src/chart.rs
@@ -88,6 +88,7 @@ mod tests {
             name: name.into(),
             bindings: HashMap::from([(String::from("key"), String::from("value"))]), // Example binding
             runs,
+            blocks: None, // TODO: Fix me
             deployer: mock_deployer(),
         };
         (name.to_string(), Arc::new(scenario))

--- a/crates/settings/src/deployment.rs
+++ b/crates/settings/src/deployment.rs
@@ -81,6 +81,7 @@ mod tests {
             bindings: HashMap::new(),
             deployer: mock_deployer(),
             runs: None,
+            blocks: None,
         };
         let order = Order {
             inputs: vec![],
@@ -109,6 +110,7 @@ mod tests {
             bindings: HashMap::new(),
             deployer: mock_deployer(),
             runs: None,
+            blocks: None,
         };
         let order = Order {
             inputs: vec![],

--- a/crates/settings/src/scenario.rs
+++ b/crates/settings/src/scenario.rs
@@ -1,6 +1,6 @@
 use crate::*;
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, num::ParseIntError, sync::Arc};
+use std::{collections::HashMap, num::ParseIntError, ops::Range, sync::Arc};
 use thiserror::Error;
 use typeshare::typeshare;
 
@@ -13,8 +13,8 @@ pub struct Scenario {
     #[typeshare(typescript(type = "number"))]
     pub runs: Option<u64>,
 
-    /// Blocks specifies the range of blocks (inclusive) which the scenario should run over. [start_block, end_block]
-    pub blocks: Option<Vec<u64>>,
+    /// Blocks specifies the range of blocks (exclusive) which the scenario should run over.
+    pub blocks: Option<Range<u64>>,
     #[typeshare(typescript(type = "Deployer"))]
     pub deployer: Arc<Deployer>,
 }

--- a/crates/settings/src/scenario.rs
+++ b/crates/settings/src/scenario.rs
@@ -12,6 +12,9 @@ pub struct Scenario {
     pub bindings: HashMap<String, String>,
     #[typeshare(typescript(type = "number"))]
     pub runs: Option<u64>,
+
+    /// Blocks specifies the range of blocks (inclusive) which the scenario should run over. [start_block, end_block]
+    pub blocks: Option<Vec<u64>>,
     #[typeshare(typescript(type = "Deployer"))]
     pub deployer: Arc<Deployer>,
 }
@@ -91,6 +94,7 @@ impl ScenarioConfigSource {
         let parent_scenario = Arc::new(Scenario {
             name: name.clone(),
             bindings: bindings.clone(),
+            blocks: None,
             runs: self.runs,
             deployer: deployer_ref.clone(),
         });

--- a/tauri-app/src/lib/components/ScenarioDebugTable.svelte
+++ b/tauri-app/src/lib/components/ScenarioDebugTable.svelte
@@ -21,6 +21,7 @@
         <span>{scenario.scenario}</span>
         <Table divClass="cursor-pointer rounded-lg overflow-hidden dark:border-none border">
           <TableHead>
+            <TableHeadCell>Block</TableHeadCell>
             <TableHeadCell>Stack item</TableHeadCell>
             <TableHeadCell>Value</TableHeadCell>
             <TableHeadCell>Hex</TableHeadCell>
@@ -31,6 +32,7 @@
                 <TableBodyCell>{key}</TableBodyCell>
                 <TableBodyCell>{value[0]}</TableBodyCell>
                 <TableBodyCell>{value[1]}</TableBodyCell>
+                <TableBodyCell>{value[2]}</TableBodyCell>
               </TableBodyRow>
             {/each}
           </TableBody>

--- a/tauri-app/src/lib/utils/chartData.ts
+++ b/tauri-app/src/lib/utils/chartData.ts
@@ -10,8 +10,13 @@ export const transformData = (fuzzResult: FuzzResultFlat): TransformedHexAndForm
   }
   return fuzzResult.data.map((row) => {
     const rowObject: TransformedHexAndFormattedData = {};
+
     fuzzResult.column_names.forEach((columnName, index) => {
-      rowObject[columnName] = [+formatUnits(hexToBigInt(row[index] as Hex), 18), row[index] as Hex];
+      if (columnName == 'block') {
+        rowObject[columnName] = row[0];
+      } else {
+        rowObject[columnName] = [+formatUnits(hexToBigInt(row[index] as Hex), 18), row[index] as Hex];
+      }
     });
     return rowObject;
   });
@@ -25,8 +30,11 @@ export const transformDataForPlot = (fuzzResult: FuzzResultFlat): TransformedPlo
   }
   return fuzzResult.data.map((row) => {
     const rowObject: TransformedPlotData = {};
+
     fuzzResult.column_names.forEach((columnName, index) => {
-      rowObject[columnName] = +formatUnits(hexToBigInt(row[index] as Hex), 18);
+      if (columnName != 'block') {
+        rowObject[columnName] = +formatUnits(hexToBigInt(row[index] as Hex), 18);
+      }
     });
     return rowObject;
   });
@@ -36,29 +44,34 @@ if (import.meta.vitest) {
   const { it, expect } = import.meta.vitest;
 
   it('data transforms correctly and errors are caught', () => {
-    const fuzzResult = {
+    const fuzzResultBlocks = {
       data: [
-        ['0xDE0B6B3A7640000', '0x29A2241AF62C0000'],
-        ['0x1BC16D674EC80000', '0x3782DACE9D900000'],
-        ['0x29A2241AF62C0000', '0x5678'],
-        ['0x1234', '0x5678'],
+        ['14334', '0xDE0B6B3A7640000', '0x29A2241AF62C0000'],
+        ['14334', '0x1BC16D674EC80000', '0x3782DACE9D900000'],
+        ['14335', '0x29A2241AF62C0000', '0x5678'],
+        ['14335', '0x1234', '0x5678'],
       ],
-      column_names: ['col1', 'col2'],
+      column_names: ['block', 'col1', 'col2'],
       scenario: 'test',
     };
 
-    const transformedData = transformData(fuzzResult);
+    const transformedBlockData = transformData(fuzzResult);
 
-    expect(transformedData.length).toEqual(4);
-    expect(transformedData[0].col1[0]).toEqual(1);
-    expect(transformedData[0].col2[0]).toEqual(3);
-    expect(transformedData[1].col1[0]).toEqual(2);
-    expect(transformedData[1].col2[0]).toEqual(4);
+    expect(transformedBlockData.length).toEqual(4);
+    expect(transformedBlockData[0].block).toEqual(14334);
+    expect(transformedBlockData[1].block).toEqual(14334);
+    expect(transformedBlockData[2].block).toEqual(14335);
+    expect(transformedBlockData[3].block).toEqual(14335);
 
-    expect(transformedData[0].col1[1]).toEqual('0xDE0B6B3A7640000');
-    expect(transformedData[0].col2[1]).toEqual('0x29A2241AF62C0000');
-    expect(transformedData[1].col1[1]).toEqual('0x1BC16D674EC80000');
-    expect(transformedData[1].col2[1]).toEqual('0x3782DACE9D900000');
+    expect(transformedBlockData[0].col1[0]).toEqual(1);
+    expect(transformedBlockData[0].col2[0]).toEqual(3);
+    expect(transformedBlockData[1].col1[0]).toEqual(2);
+    expect(transformedBlockData[1].col2[0]).toEqual(4);
+
+    expect(transformedBlockData[0].col1[1]).toEqual('0xDE0B6B3A7640000');
+    expect(transformedBlockData[0].col2[1]).toEqual('0x29A2241AF62C0000');
+    expect(transformedBlockData[1].col1[1]).toEqual('0x1BC16D674EC80000');
+    expect(transformedBlockData[1].col2[1]).toEqual('0x3782DACE9D900000');
 
     const fuzzResult3 = {
       data: [


### PR DESCRIPTION
## Motivation

As per issue #674, this PR implements backtesting.

## Solution

The PR includes changes to the main fuzzing code to iterate over and roll blocks from each fork, as well as UI changes to support the addition of block information alongside the other traces.

## Checks

By submitting this for review, I'm confirming I've done the following:
- [ x ] made this PR as small as possible
- [ WIP ] unit-tested any new functionality
- [ x ] linked any relevant issues or PRs
