### PR TITLE
Order meta for V4 subgraph

### DIFF
--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -103,6 +103,8 @@ type Order @entity {
   removeEvents: [RemoveOrder!]! @derivedFrom(field: "order")
   "Trades for this order"
   trades: [Trade!]! @derivedFrom(field: "order")
+  "Meta emitted for this order"
+  meta: Bytes
 }
 
 type AddOrder implements Event @entity(immutable: true) {

--- a/subgraph/src/handlers.ts
+++ b/subgraph/src/handlers.ts
@@ -1,6 +1,7 @@
 import {
   AddOrderV2,
   Deposit,
+  MetaV1,
   RemoveOrderV2,
   TakeOrderV2,
 } from "../generated/OrderBook/OrderBook";
@@ -11,6 +12,7 @@ import {
   handleAddOrder as _handleAddOrder,
   handleRemoveOrder as _handleRemoveOrder,
 } from "./order";
+import { handleMeta as _handleMeta } from "./meta";
 import { handleTakeOrder as _handleTakeOrder } from "./takeorder";
 
 export function handleDeposit(event: Deposit): void {
@@ -31,4 +33,8 @@ export function handleRemoveOrder(event: RemoveOrderV2): void {
 
 export function handleTakeOrder(event: TakeOrderV2): void {
   _handleTakeOrder(event);
+}
+
+export function handleMeta(event: MetaV1): void {
+  _handleMeta(event);
 }

--- a/subgraph/src/meta.ts
+++ b/subgraph/src/meta.ts
@@ -1,0 +1,15 @@
+import { Bytes } from "@graphprotocol/graph-ts";
+import { MetaV1 } from "../generated/OrderBook/OrderBook";
+import { Order } from "../generated/schema";
+import { makeOrderId } from "./order";
+
+export function handleMeta(event: MetaV1): void {
+  // The order should already exist by the time the MetaV1 event is handled
+  let order = Order.load(
+    makeOrderId(Bytes.fromByteArray(Bytes.fromBigInt(event.params.subject)))
+  );
+  if (order != null) {
+    order.meta = event.params.meta;
+    order.save();
+  }
+}

--- a/subgraph/src/order.ts
+++ b/subgraph/src/order.ts
@@ -19,8 +19,12 @@ export function handleRemoveOrder(event: RemoveOrderV2): void {
   createRemoveOrderEntity(event);
 }
 
+export function makeOrderId(orderHash: Bytes): Bytes {
+  return orderHash;
+}
+
 export function createOrderEntity(event: AddOrderV2): void {
-  let order = new Order(event.params.orderHash);
+  let order = new Order(makeOrderId(event.params.orderHash));
   order.active = true;
   order.orderHash = event.params.orderHash;
   order.owner = event.params.sender;

--- a/subgraph/subgraph.yaml
+++ b/subgraph/subgraph.yaml
@@ -31,4 +31,6 @@ dataSources:
           handler: handleRemoveOrder
         - event: TakeOrderV2(address,((address,(address,address,bytes),(address,uint8,uint256)[],(address,uint8,uint256)[],bytes32),uint256,uint256,(address,uint256[],bytes)[]),uint256,uint256)
           handler: handleTakeOrder
+        - event: MetaV1(address,uint256,bytes)
+          handler: handleMeta
       file: "./src/handlers.ts"

--- a/subgraph/tests/event-mocks.test.ts
+++ b/subgraph/tests/event-mocks.test.ts
@@ -9,6 +9,7 @@ import {
 import {
   AddOrderV2,
   Deposit,
+  MetaV1,
   RemoveOrderV2,
   TakeOrderV2,
 } from "../generated/OrderBook/OrderBook";
@@ -288,4 +289,37 @@ export function createTakeOrderEvent(
     new ethereum.EventParam("output", ethereum.Value.fromUnsignedBigInt(output))
   );
   return takeOrderEvent;
+}
+
+// event MetaV1(address sender, uint256 subject, bytes meta);
+export function createMetaEvent(
+  sender: Address,
+  subject: BigInt,
+  meta: Bytes
+): MetaV1 {
+  let mockEvent = newMockEvent();
+  let metaEvent = new MetaV1(
+    mockEvent.address,
+    mockEvent.logIndex,
+    mockEvent.transactionLogIndex,
+    mockEvent.logType,
+    mockEvent.block,
+    mockEvent.transaction,
+    mockEvent.parameters,
+    null
+  );
+  metaEvent.parameters = new Array();
+  metaEvent.parameters.push(
+    new ethereum.EventParam("sender", ethereum.Value.fromAddress(sender))
+  );
+  metaEvent.parameters.push(
+    new ethereum.EventParam(
+      "subject",
+      ethereum.Value.fromUnsignedBigInt(subject)
+    )
+  );
+  metaEvent.parameters.push(
+    new ethereum.EventParam("meta", ethereum.Value.fromBytes(meta))
+  );
+  return metaEvent;
 }

--- a/subgraph/tests/handlers/handle-meta.test.ts
+++ b/subgraph/tests/handlers/handle-meta.test.ts
@@ -1,0 +1,95 @@
+import {
+  test,
+  clearStore,
+  describe,
+  afterEach,
+  clearInBlockStore,
+  assert,
+  log,
+} from "matchstick-as";
+import { Bytes, BigInt, Address } from "@graphprotocol/graph-ts";
+import {
+  Evaluable,
+  IO,
+  createAddOrderEvent,
+  createMetaEvent,
+} from "../event-mocks.test";
+import { createOrderEntity, handleAddOrder } from "../../src/order";
+import { handleMeta } from "../../src/handlers";
+import { Order } from "../../generated/schema";
+
+describe("Add and remove orders", () => {
+  afterEach(() => {
+    clearStore();
+    clearInBlockStore();
+  });
+
+  test("handleMeta() should not error if there is no order", () => {
+    let event = createMetaEvent(
+      // sender
+      Address.fromString(
+        "0x1234567890abcdef1234567890abcdef12345678"
+      ) as Address,
+      // subject
+      BigInt.fromI32(1),
+      // meta
+      Bytes.fromHexString("0x1234567890abcdef1234567890abcdef12345678")
+    );
+
+    handleMeta(event);
+  });
+
+  test("handleMeta() should update the meta field of an order", () => {
+    let orderHash = Bytes.fromHexString(
+      "0x0987654321098765432109876543210987654321"
+    );
+    // first we need to create an order
+    let event = createAddOrderEvent(
+      Address.fromString("0x1234567890123456789012345678901234567890"),
+      orderHash,
+      [
+        new IO(
+          Address.fromString("0x1234567890123456789012345678901234567890"),
+          BigInt.fromI32(18),
+          BigInt.fromI32(1)
+        ),
+      ],
+      [
+        new IO(
+          Address.fromString("0x1234567890123456789012345678901234567890"),
+          BigInt.fromI32(18),
+          BigInt.fromI32(1)
+        ),
+      ],
+      Bytes.fromHexString("0x1234567890123456789012345678901234567890"),
+      new Evaluable(
+        Address.fromString("0x1234567890123456789012345678901234567890"),
+        Address.fromString("0x0987654321098765432109876543210987654321"),
+        Bytes.fromHexString("0x1234567890123456789012345678901234567890")
+      )
+    );
+
+    handleAddOrder(event);
+
+    let metaEvent = createMetaEvent(
+      // sender
+      Address.fromBytes(
+        Address.fromHexString("0x1234567890abcdef1234567890abcdef12345678")
+      ),
+      // subject
+      BigInt.fromByteArray(orderHash),
+      // meta
+      Bytes.fromHexString("0x1234567890abcdef1234567890abcdef12345678")
+    );
+
+    handleMeta(metaEvent);
+
+    // meta field on order should be updated
+    assert.fieldEquals(
+      "Order",
+      orderHash.toHexString(),
+      "meta",
+      "0x1234567890abcdef1234567890abcdef12345678"
+    );
+  });
+});


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

We currently use MetaV1 about an order to show the verified Rainlang. However we don't need to do any actual handling of the meta as we do it in Rust.

## Solution

Added a meta field to Order that is just Bytes.

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
