### PR TITLE
ERC20 Entity for Subgraph

### DIFF
--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -1,7 +1,7 @@
 type Vault @entity {
   id: Bytes!
   "The token that this vault is for"
-  token: Bytes!
+  token: ERC20!
   "The owner of this vault"
   owner: Bytes!
   "The vaultId of this vault"
@@ -33,8 +33,6 @@ interface VaultBalanceChange {
 
 type Deposit implements Event & VaultBalanceChange @entity(immutable: true) {
   id: Bytes!
-  "The token that was deposited"
-  token: Bytes!
 
   # For VaultBalanceChange
   "The vault that was deposited into"
@@ -54,8 +52,6 @@ type Deposit implements Event & VaultBalanceChange @entity(immutable: true) {
 
 type Withdrawal implements Event & VaultBalanceChange @entity(immutable: true) {
   id: Bytes!
-  "The token that was withdrawn"
-  token: Bytes!
   "The amount that was being targeted to be withdrawn"
   targetAmount: BigInt!
 
@@ -199,4 +195,16 @@ interface Event {
   transaction: Transaction!
   "msg.sender for the event"
   sender: Bytes!
+}
+
+type ERC20 @entity(immutable: true) {
+  id: Bytes!
+  "The address of the ERC20 token"
+  address: Bytes!
+  "The name of the ERC20 token"
+  name: String
+  "The symbol of the ERC20 token"
+  symbol: String
+  "The number of decimals of the ERC20 token"
+  decimals: BigInt
 }

--- a/subgraph/src/deposit.ts
+++ b/subgraph/src/deposit.ts
@@ -8,6 +8,7 @@ import {
   vaultEntityId,
 } from "./vault";
 import { Deposit } from "../generated/OrderBook/OrderBook";
+import { getERC20Entity } from "./erc20";
 
 export function handleDeposit(event: Deposit): void {
   let oldVaultBalance: BigInt = handleVaultBalanceChange(
@@ -31,7 +32,6 @@ export function createDepositEntity(
     event.params.vaultId,
     event.params.token
   );
-  deposit.token = event.params.token;
   deposit.transaction = createTransactionEntity(event);
   deposit.oldVaultBalance = oldVaultBalance;
   deposit.newVaultBalance = oldVaultBalance.plus(event.params.amount);

--- a/subgraph/src/erc20.ts
+++ b/subgraph/src/erc20.ts
@@ -1,0 +1,30 @@
+import { Address, BigInt, Bytes } from "@graphprotocol/graph-ts";
+import { ERC20 as ERC20Entity } from "../generated/schema";
+import { ERC20 } from "../generated/OrderBook/ERC20";
+
+export function makeERC20EntityId(address: Bytes): Bytes {
+  return address;
+}
+
+export function createERC20Entity(address: Bytes): void {
+  let erc20 = ERC20.bind(Address.fromBytes(address));
+  let entity = new ERC20Entity(makeERC20EntityId(address));
+  entity.address = address;
+  entity.name = erc20.try_name().reverted ? null : erc20.name();
+  entity.symbol = erc20.try_symbol().reverted ? null : erc20.symbol();
+  entity.decimals = erc20.try_decimals().reverted
+    ? null
+    : BigInt.fromI32(erc20.decimals());
+  entity.save();
+}
+
+export function getERC20Entity(address: Bytes): Bytes {
+  let id = makeERC20EntityId(address);
+  let entity = ERC20Entity.load(makeERC20EntityId(address));
+  if (entity == null) {
+    createERC20Entity(address);
+    return id;
+  } else {
+    return id;
+  }
+}

--- a/subgraph/src/vault.ts
+++ b/subgraph/src/vault.ts
@@ -1,9 +1,6 @@
 import { Bytes, BigInt } from "@graphprotocol/graph-ts";
-import { Withdraw, Deposit } from "../generated/OrderBook/OrderBook";
 import { Vault } from "../generated/schema";
-import { createDepositEntity } from "./deposit";
-import { createWithdrawalEntity } from "./withdraw";
-import { eventId } from "./interfaces/event";
+import { getERC20Entity } from "./erc20";
 
 export function vaultEntityId(
   owner: Bytes,
@@ -27,7 +24,7 @@ export function handleVaultBalanceChange(
   if (vault == null) {
     vault = new Vault(vaultEntityId(owner, vaultId, token));
     vault.vaultId = vaultId;
-    vault.token = token;
+    vault.token = getERC20Entity(token);
     vault.owner = owner;
     vault.balance = BigInt.fromI32(0);
   }

--- a/subgraph/src/withdraw.ts
+++ b/subgraph/src/withdraw.ts
@@ -33,7 +33,6 @@ export function createWithdrawalEntity(
     event.params.vaultId,
     event.params.token
   );
-  withdraw.token = event.params.token;
   withdraw.transaction = createTransactionEntity(event);
   withdraw.oldVaultBalance = oldVaultBalance;
   withdraw.newVaultBalance = oldVaultBalance.minus(event.params.amount);

--- a/subgraph/subgraph.yaml
+++ b/subgraph/subgraph.yaml
@@ -20,6 +20,9 @@ dataSources:
       abis:
         - name: OrderBook
           file: "../out/OrderBook.sol/OrderBook.json"
+        - name: ERC20
+          file: "../out/ERC20.sol/ERC20.json"
+
       eventHandlers:
         - event: Deposit(address,address,uint256,uint256)
           handler: handleDeposit

--- a/subgraph/tests/deposit-entity.test.ts
+++ b/subgraph/tests/deposit-entity.test.ts
@@ -10,6 +10,7 @@ import { BigInt, Address } from "@graphprotocol/graph-ts";
 import { createDepositEntity } from "../src/deposit";
 import { createDepositEvent } from "./event-mocks.test";
 import { vaultEntityId } from "../src/vault";
+import { createMockERC20Functions } from "./erc20.test";
 
 describe("Deposits", () => {
   afterEach(() => {
@@ -18,6 +19,10 @@ describe("Deposits", () => {
   });
 
   test("createDepositEntity()", () => {
+    createMockERC20Functions(
+      Address.fromString("0x0987654321098765432109876543210987654321")
+    );
+
     let event = createDepositEvent(
       Address.fromString("0x1234567890123456789012345678901234567890"),
       Address.fromString("0x0987654321098765432109876543210987654321"),
@@ -52,12 +57,6 @@ describe("Deposits", () => {
       id.toHexString(),
       "vault",
       vaultId.toHexString()
-    );
-    assert.fieldEquals(
-      "Deposit",
-      id.toHexString(),
-      "token",
-      "0x0987654321098765432109876543210987654321"
     );
     assert.fieldEquals(
       "Deposit",

--- a/subgraph/tests/erc20.test.ts
+++ b/subgraph/tests/erc20.test.ts
@@ -1,0 +1,43 @@
+import {
+  test,
+  assert,
+  clearStore,
+  describe,
+  afterEach,
+  clearInBlockStore,
+  createMockedFunction,
+} from "matchstick-as";
+import { BigInt, Address, ethereum, Bytes } from "@graphprotocol/graph-ts";
+import { createDepositEntity } from "../src/deposit";
+import { createDepositEvent } from "./event-mocks.test";
+import { vaultEntityId } from "../src/vault";
+import { createERC20Entity } from "../src/erc20";
+
+describe("Deposits", () => {
+  afterEach(() => {
+    clearStore();
+    clearInBlockStore();
+  });
+
+  test("createERC20Entity()", () => {
+    let address = Address.fromString(
+      "0x1234567890123456789012345678901234567890"
+    );
+    createMockERC20Functions(address);
+    createERC20Entity(Bytes.fromByteArray(address));
+
+    assert.entityCount("ERC20", 1);
+  });
+});
+
+export function createMockERC20Functions(address: Address): void {
+  createMockedFunction(address, "name", "name():(string)")
+    .withArgs([])
+    .returns([ethereum.Value.fromString("Test")]);
+  createMockedFunction(address, "symbol", "symbol():(string)")
+    .withArgs([])
+    .returns([ethereum.Value.fromString("TST")]);
+  createMockedFunction(address, "decimals", "decimals():(uint8)")
+    .withArgs([])
+    .returns([ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(18))]);
+}

--- a/subgraph/tests/handlers/handle-deposit.test.ts
+++ b/subgraph/tests/handlers/handle-deposit.test.ts
@@ -12,6 +12,7 @@ import { handleDeposit } from "../../src/handlers";
 import { vaultEntityId } from "../../src/vault";
 import { Deposit, Vault } from "../../generated/schema";
 import { eventId } from "../../src/interfaces/event";
+import { createMockERC20Functions } from "../erc20.test";
 
 describe("Handle deposit", () => {
   afterEach(() => {
@@ -20,6 +21,10 @@ describe("Handle deposit", () => {
   });
 
   test("handleDeposit()", () => {
+    createMockERC20Functions(
+      Address.fromString("0x1234567890123456789012345678901234567890")
+    );
+
     let event = createDepositEvent(
       Address.fromString("0x0987654321098765432109876543210987654321"),
       Address.fromString("0x1234567890123456789012345678901234567890"),
@@ -55,7 +60,6 @@ describe("Handle deposit", () => {
       return;
     }
     assert.bytesEquals(deposit.sender, event.params.sender);
-    assert.bytesEquals(deposit.token, event.params.token);
     assert.bigIntEquals(deposit.amount, BigInt.fromI32(100));
     assert.bigIntEquals(deposit.oldVaultBalance, BigInt.fromI32(0));
     assert.bigIntEquals(deposit.newVaultBalance, BigInt.fromI32(100));
@@ -96,13 +100,16 @@ describe("Handle deposit", () => {
       return;
     }
     assert.bytesEquals(deposit.sender, event.params.sender);
-    assert.bytesEquals(deposit.token, event.params.token);
     assert.bigIntEquals(deposit.amount, BigInt.fromI32(200));
     assert.bigIntEquals(deposit.oldVaultBalance, BigInt.fromI32(100));
     assert.bigIntEquals(deposit.newVaultBalance, BigInt.fromI32(300));
     assert.bigIntEquals(deposit.timestamp, event.block.timestamp);
 
     // make another deposit, different token, same vaultId
+    createMockERC20Functions(
+      Address.fromString("0x0987654321098765432109876543210987654321")
+    );
+
     event = createDepositEvent(
       Address.fromString("0x0987654321098765432109876543210987654321"),
       Address.fromString("0x0987654321098765432109876543210987654321"),
@@ -137,7 +144,6 @@ describe("Handle deposit", () => {
       return;
     }
     assert.bytesEquals(deposit.sender, event.params.sender);
-    assert.bytesEquals(deposit.token, event.params.token);
     assert.bigIntEquals(deposit.amount, BigInt.fromI32(300));
     assert.bigIntEquals(deposit.oldVaultBalance, BigInt.fromI32(0));
     assert.bigIntEquals(deposit.newVaultBalance, BigInt.fromI32(300));

--- a/subgraph/tests/handlers/handle-takeorder.test.ts
+++ b/subgraph/tests/handlers/handle-takeorder.test.ts
@@ -7,14 +7,9 @@ import {
   assert,
 } from "matchstick-as";
 import { Bytes, BigInt, Address } from "@graphprotocol/graph-ts";
-import {
-  Evaluable,
-  IO,
-  createAddOrderEvent,
-  createTakeOrderEvent,
-} from "../event-mocks.test";
-import { handleAddOrder } from "../../src/order";
+import { Evaluable, IO, createTakeOrderEvent } from "../event-mocks.test";
 import { handleTakeOrder } from "../../src/takeorder";
+import { createMockERC20Functions } from "../erc20.test";
 
 describe("Add and remove orders", () => {
   afterEach(() => {
@@ -23,6 +18,13 @@ describe("Add and remove orders", () => {
   });
 
   test("handleTakeOrder()", () => {
+    createMockERC20Functions(
+      Address.fromString("0x3333333333333333333333333333333333333333")
+    );
+    createMockERC20Functions(
+      Address.fromString("0x4444444444444444444444444444444444444444")
+    );
+
     let event = createTakeOrderEvent(
       Address.fromString("0x1111111111111111111111111111111111111111"),
       Address.fromString("0x2222222222222222222222222222222222222222"),

--- a/subgraph/tests/handlers/handle-withdraw.test.ts
+++ b/subgraph/tests/handlers/handle-withdraw.test.ts
@@ -5,7 +5,6 @@ import {
   describe,
   afterEach,
   clearInBlockStore,
-  log,
 } from "matchstick-as";
 import { BigInt, Address } from "@graphprotocol/graph-ts";
 import { createDepositEvent, createWithdrawEvent } from "../event-mocks.test";
@@ -13,6 +12,7 @@ import { handleDeposit, handleWithdraw } from "../../src/handlers";
 import { vaultEntityId } from "../../src/vault";
 import { Withdrawal, Vault } from "../../generated/schema";
 import { eventId } from "../../src/interfaces/event";
+import { createMockERC20Functions } from "../erc20.test";
 
 describe("Handle withdraw", () => {
   afterEach(() => {
@@ -21,6 +21,10 @@ describe("Handle withdraw", () => {
   });
 
   test("handleWithdraw()", () => {
+    createMockERC20Functions(
+      Address.fromString("0x1234567890123456789012345678901234567890")
+    );
+
     // first we make a deposit
     let depositEvent = createDepositEvent(
       Address.fromString("0x0987654321098765432109876543210987654321"),
@@ -66,7 +70,6 @@ describe("Handle withdraw", () => {
       return;
     }
     assert.bytesEquals(withdraw.sender, event.params.sender);
-    assert.bytesEquals(withdraw.token, event.params.token);
     assert.bigIntEquals(withdraw.amount, BigInt.fromI32(100));
     assert.bigIntEquals(withdraw.oldVaultBalance, BigInt.fromI32(1000));
     assert.bigIntEquals(withdraw.newVaultBalance, BigInt.fromI32(900));
@@ -107,11 +110,14 @@ describe("Handle withdraw", () => {
       return;
     }
     assert.bytesEquals(withdraw.sender, event.params.sender);
-    assert.bytesEquals(withdraw.token, event.params.token);
     assert.bigIntEquals(withdraw.amount, BigInt.fromI32(200));
     assert.bigIntEquals(withdraw.oldVaultBalance, BigInt.fromI32(900));
     assert.bigIntEquals(withdraw.newVaultBalance, BigInt.fromI32(700));
     assert.bigIntEquals(withdraw.timestamp, event.block.timestamp);
+
+    createMockERC20Functions(
+      Address.fromString("0x0987654321098765432109876543210987654321")
+    );
 
     // deposit different token, same vaultId
     depositEvent = createDepositEvent(
@@ -159,7 +165,6 @@ describe("Handle withdraw", () => {
       return;
     }
     assert.bytesEquals(withdraw.sender, event.params.sender);
-    assert.bytesEquals(withdraw.token, event.params.token);
     assert.bigIntEquals(withdraw.amount, BigInt.fromI32(200));
     assert.bigIntEquals(withdraw.oldVaultBalance, BigInt.fromI32(300));
     assert.bigIntEquals(withdraw.newVaultBalance, BigInt.fromI32(100));

--- a/subgraph/tests/takeorder.test.ts
+++ b/subgraph/tests/takeorder.test.ts
@@ -10,6 +10,7 @@ import { BigInt, Address, Bytes, ethereum } from "@graphprotocol/graph-ts";
 import { Evaluable, IO, createTakeOrderEvent } from "./event-mocks.test";
 import { createTakeOrderEntity } from "../src/takeorder";
 import { eventId } from "../src/interfaces/event";
+import { createMockERC20Functions } from "./erc20.test";
 
 describe("Deposits", () => {
   afterEach(() => {
@@ -18,6 +19,14 @@ describe("Deposits", () => {
   });
 
   test("createTakeOrderEvent()", () => {
+    createMockERC20Functions(
+      Address.fromString("0x3333333333333333333333333333333333333333")
+    );
+
+    createMockERC20Functions(
+      Address.fromString("0x4444444444444444444444444444444444444444")
+    );
+
     let event = createTakeOrderEvent(
       Address.fromString("0x1111111111111111111111111111111111111111"),
       Address.fromString("0x2222222222222222222222222222222222222222"),
@@ -88,6 +97,14 @@ describe("Deposits", () => {
   });
 
   test("createTakeOrderEntity()", () => {
+    createMockERC20Functions(
+      Address.fromString("0x3333333333333333333333333333333333333333")
+    );
+
+    createMockERC20Functions(
+      Address.fromString("0x4444444444444444444444444444444444444444")
+    );
+
     let event = createTakeOrderEvent(
       Address.fromString("0x1111111111111111111111111111111111111111"),
       Address.fromString("0x2222222222222222222222222222222222222222"),

--- a/subgraph/tests/trade.test.ts
+++ b/subgraph/tests/trade.test.ts
@@ -20,6 +20,7 @@ import { eventId } from "../src/interfaces/event";
 import { createTradeEntity, makeTradeId } from "../src/trade";
 import { TradeVaultBalanceChange } from "../generated/schema";
 import { tradeVaultBalanceChangeId } from "../src/tradevaultbalancechange";
+import { createMockERC20Functions } from "./erc20.test";
 
 describe("Deposits", () => {
   afterEach(() => {
@@ -49,6 +50,13 @@ describe("Deposits", () => {
   });
 
   test("createTradeEntity()", () => {
+    createMockERC20Functions(
+      Address.fromString("0x3333333333333333333333333333333333333333")
+    );
+    createMockERC20Functions(
+      Address.fromString("0x4444444444444444444444444444444444444444")
+    );
+
     let event = createTakeOrderEvent(
       Address.fromString("0x1111111111111111111111111111111111111111"),
       Address.fromString("0x2222222222222222222222222222222222222222"),

--- a/subgraph/tests/tradevaultbalancechange.test.ts
+++ b/subgraph/tests/tradevaultbalancechange.test.ts
@@ -18,6 +18,7 @@ import {
 import { VaultBalanceChangeType, vaultEntityId } from "../src/vault";
 import { orderHashFromTakeOrderEvent } from "../src/takeorder";
 import { makeTradeId } from "../src/trade";
+import { createMockERC20Functions } from "./erc20.test";
 
 describe("Deposits", () => {
   afterEach(() => {
@@ -48,6 +49,13 @@ describe("Deposits", () => {
   });
 
   test("createTradeVaultBalanceChangeEntity()", () => {
+    createMockERC20Functions(
+      Address.fromString("0x3333333333333333333333333333333333333333")
+    );
+    createMockERC20Functions(
+      Address.fromString("0x4444444444444444444444444444444444444444")
+    );
+
     let owner = Address.fromString(
       "0x1111111111111111111111111111111111111111"
     );

--- a/subgraph/tests/vault.test.ts
+++ b/subgraph/tests/vault.test.ts
@@ -9,6 +9,7 @@ import {
 import { handleVaultBalanceChange, vaultEntityId } from "../src/vault";
 import { Bytes, BigInt, Address } from "@graphprotocol/graph-ts";
 import { createDepositEvent, createWithdrawEvent } from "./event-mocks.test";
+import { createMockERC20Functions } from "./erc20.test";
 
 describe("Vault balance changes", () => {
   afterEach(() => {
@@ -17,6 +18,10 @@ describe("Vault balance changes", () => {
   });
 
   test("handleVaultBalanceChange()", () => {
+    createMockERC20Functions(
+      Address.fromString("0x1234567890123456789012345678901234567890")
+    );
+
     handleVaultBalanceChange(
       BigInt.fromI32(1),
       Bytes.fromHexString("0x1234567890123456789012345678901234567890"),
@@ -59,6 +64,10 @@ describe("Vault balance changes", () => {
   });
 
   test("handleVaultDeposit()", () => {
+    createMockERC20Functions(
+      Address.fromString("0x1234567890123456789012345678901234567890")
+    );
+
     let event = createDepositEvent(
       Address.fromString("0x0987654321098765432109876543210987654321"),
       Address.fromString("0x1234567890123456789012345678901234567890"),
@@ -107,6 +116,10 @@ describe("Vault balance changes", () => {
   });
 
   test("handleVaultWithdraw()", () => {
+    createMockERC20Functions(
+      Address.fromString("0x1234567890123456789012345678901234567890")
+    );
+
     // first we need to deposit
     let depositEvent = createDepositEvent(
       Address.fromString("0x0987654321098765432109876543210987654321"),
@@ -175,6 +188,10 @@ describe("Vault balance changes", () => {
   test("If vault does not exist, create it", () => {
     assert.entityCount("Vault", 0);
 
+    createMockERC20Functions(
+      Address.fromString("0x1234567890123456789012345678901234567890")
+    );
+
     let event = createDepositEvent(
       Address.fromString("0x0987654321098765432109876543210987654321"),
       Address.fromString("0x1234567890123456789012345678901234567890"),
@@ -222,6 +239,10 @@ describe("Vault balance changes", () => {
     );
   });
   test("handleVaultBalanceChange returns 0 if vault doesn't exist yet", () => {
+    createMockERC20Functions(
+      Address.fromString("0x1234567890123456789012345678901234567890")
+    );
+
     let oldBalance = handleVaultBalanceChange(
       BigInt.fromI32(1),
       Bytes.fromHexString("0x1234567890123456789012345678901234567890"),
@@ -234,6 +255,10 @@ describe("Vault balance changes", () => {
   });
 
   test("handleVaultBalanceChange returns old balance if vault exists", () => {
+    createMockERC20Functions(
+      Address.fromString("0x1234567890123456789012345678901234567890")
+    );
+
     handleVaultBalanceChange(
       BigInt.fromI32(1),
       Bytes.fromHexString("0x1234567890123456789012345678901234567890"),

--- a/subgraph/tests/withdrawal-entity.test.ts
+++ b/subgraph/tests/withdrawal-entity.test.ts
@@ -10,6 +10,7 @@ import { BigInt, Address } from "@graphprotocol/graph-ts";
 import { createWithdrawalEntity } from "../src/withdraw";
 import { createWithdrawEvent } from "./event-mocks.test";
 import { vaultEntityId } from "../src/vault";
+import { createMockERC20Functions } from "./erc20.test";
 
 describe("Withdrawals", () => {
   afterEach(() => {
@@ -18,6 +19,10 @@ describe("Withdrawals", () => {
   });
 
   test("createWithdrawalEntity()", () => {
+    createMockERC20Functions(
+      Address.fromString("0x0987654321098765432109876543210987654321")
+    );
+
     let event = createWithdrawEvent(
       Address.fromString("0x1234567890123456789012345678901234567890"),
       Address.fromString("0x0987654321098765432109876543210987654321"),
@@ -60,12 +65,6 @@ describe("Withdrawals", () => {
       id.toHexString(),
       "vault",
       vaultId.toHexString()
-    );
-    assert.fieldEquals(
-      "Withdrawal",
-      id.toHexString(),
-      "token",
-      "0x0987654321098765432109876543210987654321"
     );
     assert.fieldEquals(
       "Withdrawal",


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

Pinging an RPC many times to pull token details doesn't really make sense when the name/symbol/decimals can be grabbed once, the first time the token appears in the subgraph.

## Solution

Added an ERC20 entity to Vault. Removed the token field from all other entities, as the Vault is always the logical reference from anywhere else.

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
