### PR TITLE
Making subgraph schema support multiple orderbooks

### DIFF
--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -1,5 +1,31 @@
+type Orderbook @entity {
+  id: Bytes!
+  "All orders in the orderbook"
+  orders: [Order!]! @derivedFrom(field: "orderbook")
+  "All trades in the orderbook"
+  trades: [Trade!]! @derivedFrom(field: "orderbook")
+  "All vaults in the orderbook"
+  vaults: [Vault!]! @derivedFrom(field: "orderbook")
+  "All vault balance changes in the orderbook"
+  vaultBalanceChanges: [VaultBalanceChange!]! @derivedFrom(field: "orderbook")
+  "All deposit events in the orderbook"
+  deposits: [Deposit!]! @derivedFrom(field: "orderbook")
+  "All withdrawal events in the orderbook"
+  withdrawals: [Withdrawal!]! @derivedFrom(field: "orderbook")
+  "All add order events in the orderbook"
+  addOrders: [AddOrder!]! @derivedFrom(field: "orderbook")
+  "All remove order events in the orderbook"
+  removeOrders: [RemoveOrder!]! @derivedFrom(field: "orderbook")
+  "All take order events in the orderbook"
+  takeOrders: [TakeOrder!]! @derivedFrom(field: "orderbook")
+  "All trade events in the orderbook"
+  tradeEvents: [TradeEvent!]! @derivedFrom(field: "orderbook")
+}
+
 type Vault @entity {
   id: Bytes!
+  "The orderbook this vault is in"
+  orderbook: Orderbook!
   "The token that this vault is for"
   token: ERC20!
   "The owner of this vault"
@@ -17,6 +43,8 @@ type Vault @entity {
 }
 
 interface VaultBalanceChange {
+  "The orderbook this balance change is for"
+  orderbook: Orderbook!
   "The vault that was affected"
   vault: Vault!
   "The amount changed - this is signed"
@@ -35,6 +63,8 @@ type Deposit implements Event & VaultBalanceChange @entity(immutable: true) {
   id: Bytes!
 
   # For VaultBalanceChange
+  "The orderbook this balance change is for"
+  orderbook: Orderbook!
   "The vault that was deposited into"
   vault: Vault!
   "The amount that was deposited"
@@ -56,6 +86,8 @@ type Withdrawal implements Event & VaultBalanceChange @entity(immutable: true) {
   targetAmount: BigInt!
 
   # For VaultBalanceChange
+  "The orderbook this balance change is for"
+  orderbook: Orderbook!
   "The vault that was withdrawn from"
   vault: Vault!
   "The amount that was actually withdrawn - this will be negative"
@@ -73,6 +105,8 @@ type Withdrawal implements Event & VaultBalanceChange @entity(immutable: true) {
 
 type TradeVaultBalanceChange implements VaultBalanceChange @entity(immutable: true) {
   id: Bytes!
+  "The orderbook this balance change is for"
+  orderbook: Orderbook!
   "The trade that this balance change is for"
   trade: Trade!
   "The vault that was affected"
@@ -91,6 +125,8 @@ type TradeVaultBalanceChange implements VaultBalanceChange @entity(immutable: tr
 
 type Order @entity {
   id: Bytes!
+  "The orderbook this order is in"
+  orderbook: Orderbook!
   "Whether this order is active or not"
   active: Boolean!
   "The hash of the order"
@@ -121,6 +157,8 @@ type AddOrder implements Event @entity(immutable: true) {
   id: Bytes!
   "The order that was added"
   order: Order!
+  "The orderbook this add order event is in"
+  orderbook: Orderbook!
 
   # For Event
   transaction: Transaction!
@@ -132,6 +170,8 @@ type RemoveOrder implements Event @entity(immutable: true) {
   id: Bytes!
   "The order that was removed"
   order: Order!
+  "The orderbook this remove order event is in"
+  orderbook: Orderbook!
 
   # For Event
   transaction: Transaction!
@@ -141,6 +181,8 @@ type RemoveOrder implements Event @entity(immutable: true) {
 
 type Trade @entity(immutable: true) {
   id: Bytes!
+  "The orderbook this trade is for"
+  orderbook: Orderbook!
   "The order that was traded"
   order: Order!
   "Input vault balance change"
@@ -164,6 +206,8 @@ type TakeOrder implements TradeEvent @entity(immutable: true) {
   takeOrderConfigBytes: Bytes!
 
   # For TradeEvent
+  "The orderbook this trade event is for"
+  orderbook: Orderbook!
   "The trades that occured in this event"
   trades: [Trade!]! @derivedFrom(field: "tradeEvent")
   transaction: Transaction!
@@ -173,6 +217,8 @@ type TakeOrder implements TradeEvent @entity(immutable: true) {
 
 interface TradeEvent implements Event {
   id: Bytes!
+  "The orderbook this trade event is for"
+  orderbook: Orderbook!
   "The trades that occured in this event"
   trades: [Trade!]! @derivedFrom(field: "tradeEvent")
 

--- a/subgraph/src/deposit.ts
+++ b/subgraph/src/deposit.ts
@@ -20,6 +20,7 @@ export function createDepositEntity(
   oldVaultBalance: BigInt
 ): void {
   let deposit = new DepositEntity(eventId(event));
+  deposit.orderbook = event.address;
   deposit.amount = event.params.amount;
   deposit.sender = event.params.sender;
   deposit.vault = vaultEntityId(

--- a/subgraph/src/deposit.ts
+++ b/subgraph/src/deposit.ts
@@ -4,8 +4,10 @@ import { eventId } from "./interfaces/event";
 import { createTransactionEntity } from "./transaction";
 import { handleVaultBalanceChange, vaultEntityId } from "./vault";
 import { Deposit } from "../generated/OrderBook/OrderBook";
+import { createOrderbookEntity } from "./orderbook";
 
 export function handleDeposit(event: Deposit): void {
+  createOrderbookEntity(event);
   let oldVaultBalance: BigInt = handleVaultBalanceChange(
     event.address,
     event.params.vaultId,

--- a/subgraph/src/deposit.ts
+++ b/subgraph/src/deposit.ts
@@ -7,6 +7,7 @@ import { Deposit } from "../generated/OrderBook/OrderBook";
 
 export function handleDeposit(event: Deposit): void {
   let oldVaultBalance: BigInt = handleVaultBalanceChange(
+    event.address,
     event.params.vaultId,
     event.params.token,
     event.params.amount,
@@ -22,6 +23,7 @@ export function createDepositEntity(
   deposit.amount = event.params.amount;
   deposit.sender = event.params.sender;
   deposit.vault = vaultEntityId(
+    event.address,
     event.params.sender,
     event.params.vaultId,
     event.params.token

--- a/subgraph/src/interfaces/event.ts
+++ b/subgraph/src/interfaces/event.ts
@@ -6,5 +6,5 @@ export function eventId(event: ethereum.Event): Bytes {
       Bytes.fromByteArray(Bytes.fromBigInt(event.logIndex))
     )
   );
-  return crypto.keccak256(bytes);
+  return Bytes.fromByteArray(crypto.keccak256(bytes));
 }

--- a/subgraph/src/interfaces/event.ts
+++ b/subgraph/src/interfaces/event.ts
@@ -1,7 +1,10 @@
-import { Bytes, ethereum } from "@graphprotocol/graph-ts";
+import { Bytes, ethereum, crypto } from "@graphprotocol/graph-ts";
 
 export function eventId(event: ethereum.Event): Bytes {
-  return event.transaction.hash.concat(
-    Bytes.fromByteArray(Bytes.fromBigInt(event.logIndex))
+  let bytes = event.address.concat(
+    event.transaction.hash.concat(
+      Bytes.fromByteArray(Bytes.fromBigInt(event.logIndex))
+    )
   );
+  return crypto.keccak256(bytes);
 }

--- a/subgraph/src/meta.ts
+++ b/subgraph/src/meta.ts
@@ -6,7 +6,10 @@ import { makeOrderId } from "./order";
 export function handleMeta(event: MetaV1): void {
   // The order should already exist by the time the MetaV1 event is handled
   let order = Order.load(
-    makeOrderId(Bytes.fromByteArray(Bytes.fromBigInt(event.params.subject)))
+    makeOrderId(
+      event.address,
+      Bytes.fromByteArray(Bytes.fromBigInt(event.params.subject))
+    )
   );
   if (order != null) {
     order.meta = event.params.meta;

--- a/subgraph/src/meta.ts
+++ b/subgraph/src/meta.ts
@@ -2,8 +2,11 @@ import { Bytes } from "@graphprotocol/graph-ts";
 import { MetaV1 } from "../generated/OrderBook/OrderBook";
 import { Order } from "../generated/schema";
 import { makeOrderId } from "./order";
+import { createOrderbookEntity } from "./orderbook";
 
 export function handleMeta(event: MetaV1): void {
+  createOrderbookEntity(event);
+
   // The order should already exist by the time the MetaV1 event is handled
   let order = Order.load(
     makeOrderId(

--- a/subgraph/src/order.ts
+++ b/subgraph/src/order.ts
@@ -1,4 +1,4 @@
-import { Bytes, ethereum } from "@graphprotocol/graph-ts";
+import { Bytes, ethereum, crypto } from "@graphprotocol/graph-ts";
 import { AddOrderV2, RemoveOrderV2 } from "../generated/OrderBook/OrderBook";
 import { AddOrder, Order, RemoveOrder } from "../generated/schema";
 import { getVault } from "./vault";
@@ -19,12 +19,13 @@ export function handleRemoveOrder(event: RemoveOrderV2): void {
   createRemoveOrderEntity(event);
 }
 
-export function makeOrderId(orderHash: Bytes): Bytes {
-  return orderHash;
+export function makeOrderId(orderbook: Bytes, orderHash: Bytes): Bytes {
+  let bytes = orderbook.concat(orderHash);
+  return crypto.keccak256(bytes);
 }
 
 export function createOrderEntity(event: AddOrderV2): void {
-  let order = new Order(makeOrderId(event.params.orderHash));
+  let order = new Order(makeOrderId(event.address, event.params.orderHash));
   order.active = true;
   order.orderHash = event.params.orderHash;
   order.owner = event.params.sender;
@@ -37,7 +38,7 @@ export function createOrderEntity(event: AddOrderV2): void {
     let input = event.params.order.validInputs[i];
     let vaultId = input.vaultId;
     let token = input.token;
-    let vault = getVault(sender, vaultId, token).id;
+    let vault = getVault(event.address, sender, vaultId, token).id;
     inputs.push(vault);
   }
 
@@ -47,7 +48,7 @@ export function createOrderEntity(event: AddOrderV2): void {
     let output = event.params.order.validOutputs[i];
     let vaultId = output.vaultId;
     let token = output.token;
-    let vault = getVault(sender, vaultId, token).id;
+    let vault = getVault(event.address, sender, vaultId, token).id;
     outputs.push(vault);
   }
 

--- a/subgraph/src/order.ts
+++ b/subgraph/src/order.ts
@@ -11,7 +11,7 @@ export function handleAddOrder(event: AddOrderV2): void {
 }
 
 export function handleRemoveOrder(event: RemoveOrderV2): void {
-  let order = Order.load(event.params.orderHash);
+  let order = Order.load(makeOrderId(event.address, event.params.orderHash));
   if (order != null) {
     order.active = false;
     order.save();
@@ -21,11 +21,12 @@ export function handleRemoveOrder(event: RemoveOrderV2): void {
 
 export function makeOrderId(orderbook: Bytes, orderHash: Bytes): Bytes {
   let bytes = orderbook.concat(orderHash);
-  return crypto.keccak256(bytes);
+  return Bytes.fromByteArray(crypto.keccak256(bytes));
 }
 
 export function createOrderEntity(event: AddOrderV2): void {
   let order = new Order(makeOrderId(event.address, event.params.orderHash));
+  order.orderbook = event.address;
   order.active = true;
   order.orderHash = event.params.orderHash;
   order.owner = event.params.sender;
@@ -63,6 +64,7 @@ export function createOrderEntity(event: AddOrderV2): void {
 export function createAddOrderEntity(event: AddOrderV2): void {
   let addOrder = new AddOrder(event.transaction.hash);
   addOrder.id = eventId(event);
+  addOrder.orderbook = event.address;
   addOrder.order = event.params.orderHash;
   addOrder.sender = event.params.sender;
   addOrder.transaction = createTransactionEntity(event);
@@ -72,6 +74,7 @@ export function createAddOrderEntity(event: AddOrderV2): void {
 export function createRemoveOrderEntity(event: RemoveOrderV2): void {
   let removeOrder = new RemoveOrder(event.transaction.hash);
   removeOrder.id = eventId(event);
+  removeOrder.orderbook = event.address;
   removeOrder.order = event.params.orderHash;
   removeOrder.sender = event.params.sender;
   removeOrder.transaction = createTransactionEntity(event);

--- a/subgraph/src/order.ts
+++ b/subgraph/src/order.ts
@@ -4,13 +4,16 @@ import { AddOrder, Order, RemoveOrder } from "../generated/schema";
 import { getVault } from "./vault";
 import { eventId } from "./interfaces/event";
 import { createTransactionEntity } from "./transaction";
+import { createOrderbookEntity } from "./orderbook";
 
 export function handleAddOrder(event: AddOrderV2): void {
+  createOrderbookEntity(event);
   createOrderEntity(event);
   createAddOrderEntity(event);
 }
 
 export function handleRemoveOrder(event: RemoveOrderV2): void {
+  createOrderbookEntity(event);
   let order = Order.load(makeOrderId(event.address, event.params.orderHash));
   if (order != null) {
     order.active = false;

--- a/subgraph/src/orderbook.ts
+++ b/subgraph/src/orderbook.ts
@@ -1,0 +1,7 @@
+import { ethereum } from "@graphprotocol/graph-ts";
+import { Orderbook } from "../generated/schema";
+
+export function createOrderbookEntity(event: ethereum.Event): void {
+  let orderbook = new Orderbook(event.address);
+  orderbook.save();
+}

--- a/subgraph/src/takeorder.ts
+++ b/subgraph/src/takeorder.ts
@@ -82,6 +82,7 @@ export function handleTakeOrder(event: TakeOrderV2): void {
 
 export function createTakeOrderEntity(event: TakeOrderV2): void {
   let takeOrder = new TakeOrder(eventId(event));
+  takeOrder.orderbook = event.address;
   takeOrder.inputAmount = event.params.input;
   takeOrder.outputAmount = event.params.output;
   takeOrder.sender = event.params.sender;

--- a/subgraph/src/takeorder.ts
+++ b/subgraph/src/takeorder.ts
@@ -24,6 +24,7 @@ export function handleTakeOrder(event: TakeOrderV2): void {
     order.validOutputs[event.params.config.outputIOIndex.toU32()];
 
   let oldOutputVaultBalance = handleVaultBalanceChange(
+    event.address,
     orderOutput.vaultId,
     orderOutput.token,
     // input for the taker is a debit for the vault
@@ -34,7 +35,12 @@ export function handleTakeOrder(event: TakeOrderV2): void {
   let outputVaultBalanceChange = createTradeVaultBalanceChangeEntity(
     event,
     orderHash,
-    vaultEntityId(order.owner, orderOutput.vaultId, orderOutput.token),
+    vaultEntityId(
+      event.address,
+      order.owner,
+      orderOutput.vaultId,
+      orderOutput.token
+    ),
     oldOutputVaultBalance,
     event.params.input.neg() // change is negative
   );
@@ -43,6 +49,7 @@ export function handleTakeOrder(event: TakeOrderV2): void {
   let orderInput = order.validInputs[event.params.config.inputIOIndex.toU32()];
 
   let oldInputVaultBalance = handleVaultBalanceChange(
+    event.address,
     orderInput.vaultId,
     orderInput.token,
     // output for the taker is a credit for the vault
@@ -53,7 +60,12 @@ export function handleTakeOrder(event: TakeOrderV2): void {
   let inputVaultBalanceChange = createTradeVaultBalanceChangeEntity(
     event,
     orderHash,
-    vaultEntityId(order.owner, orderInput.vaultId, orderInput.token),
+    vaultEntityId(
+      event.address,
+      order.owner,
+      orderInput.vaultId,
+      orderInput.token
+    ),
     oldInputVaultBalance,
     event.params.output
   );

--- a/subgraph/src/takeorder.ts
+++ b/subgraph/src/takeorder.ts
@@ -7,6 +7,7 @@ import { handleVaultBalanceChange, vaultEntityId } from "./vault";
 import { createTradeVaultBalanceChangeEntity } from "./tradevaultbalancechange";
 import { createTradeEntity } from "./trade";
 import { crypto } from "@graphprotocol/graph-ts";
+import { createOrderbookEntity } from "./orderbook";
 
 export function orderHashFromTakeOrderEvent(event: TakeOrderV2): Bytes {
   let orderHash = crypto.keccak256(
@@ -16,6 +17,8 @@ export function orderHashFromTakeOrderEvent(event: TakeOrderV2): Bytes {
 }
 
 export function handleTakeOrder(event: TakeOrderV2): void {
+  createOrderbookEntity(event);
+
   let order = event.params.config.order;
   let orderHash = orderHashFromTakeOrderEvent(event);
 

--- a/subgraph/src/trade.ts
+++ b/subgraph/src/trade.ts
@@ -4,7 +4,7 @@ import { eventId } from "./interfaces/event";
 
 export function makeTradeId(event: ethereum.Event, orderHash: Bytes): Bytes {
   let bytes = eventId(event).concat(orderHash);
-  return crypto.keccak256(bytes);
+  return Bytes.fromByteArray(crypto.keccak256(bytes));
 }
 
 export function createTradeEntity(
@@ -14,6 +14,7 @@ export function createTradeEntity(
   outputVaultBalanceChange: TradeVaultBalanceChange
 ): void {
   let trade = new Trade(makeTradeId(event, orderHash));
+  trade.orderbook = event.address;
   trade.order = orderHash;
   trade.inputVaultBalanceChange = inputVaultBalanceChange.id;
   trade.outputVaultBalanceChange = outputVaultBalanceChange.id;

--- a/subgraph/src/trade.ts
+++ b/subgraph/src/trade.ts
@@ -1,9 +1,10 @@
-import { Bytes, ethereum } from "@graphprotocol/graph-ts";
+import { Bytes, ethereum, crypto } from "@graphprotocol/graph-ts";
 import { Trade, TradeVaultBalanceChange } from "../generated/schema";
 import { eventId } from "./interfaces/event";
 
 export function makeTradeId(event: ethereum.Event, orderHash: Bytes): Bytes {
-  return eventId(event).concat(orderHash);
+  let bytes = eventId(event).concat(orderHash);
+  return crypto.keccak256(bytes);
 }
 
 export function createTradeEntity(

--- a/subgraph/src/tradevaultbalancechange.ts
+++ b/subgraph/src/tradevaultbalancechange.ts
@@ -8,7 +8,7 @@ export function tradeVaultBalanceChangeId(
   vaultEntityId: Bytes
 ): Bytes {
   let bytes = eventId(event).concat(vaultEntityId);
-  return crypto.keccak256(bytes);
+  return Bytes.fromByteArray(crypto.keccak256(bytes));
 }
 
 export function createTradeVaultBalanceChangeEntity(
@@ -21,6 +21,7 @@ export function createTradeVaultBalanceChangeEntity(
   let tradeVaultBalanceChange = new TradeVaultBalanceChange(
     tradeVaultBalanceChangeId(event, vaultEntityId)
   );
+  tradeVaultBalanceChange.orderbook = event.address;
   tradeVaultBalanceChange.amount = amount;
   tradeVaultBalanceChange.oldVaultBalance = oldVaultBalance;
   tradeVaultBalanceChange.newVaultBalance = oldVaultBalance.plus(amount);

--- a/subgraph/src/tradevaultbalancechange.ts
+++ b/subgraph/src/tradevaultbalancechange.ts
@@ -1,4 +1,4 @@
-import { BigInt, Bytes, ethereum } from "@graphprotocol/graph-ts";
+import { BigInt, Bytes, ethereum, crypto } from "@graphprotocol/graph-ts";
 import { TradeVaultBalanceChange } from "../generated/schema";
 import { eventId } from "./interfaces/event";
 import { makeTradeId } from "./trade";
@@ -7,7 +7,8 @@ export function tradeVaultBalanceChangeId(
   event: ethereum.Event,
   vaultEntityId: Bytes
 ): Bytes {
-  return vaultEntityId.concat(eventId(event));
+  let bytes = eventId(event).concat(vaultEntityId);
+  return crypto.keccak256(bytes);
 }
 
 export function createTradeVaultBalanceChangeEntity(

--- a/subgraph/src/vault.ts
+++ b/subgraph/src/vault.ts
@@ -11,7 +11,7 @@ export function vaultEntityId(
   let bytes = orderbook.concat(
     owner.concat(token.concat(Bytes.fromByteArray(Bytes.fromBigInt(vaultId))))
   );
-  return crypto.keccak256(bytes);
+  return Bytes.fromByteArray(crypto.keccak256(bytes));
 }
 
 export function createEmptyVault(
@@ -21,6 +21,7 @@ export function createEmptyVault(
   token: Bytes
 ): Vault {
   let vault = new Vault(vaultEntityId(orderbook, owner, vaultId, token));
+  vault.orderbook = orderbook;
   vault.vaultId = vaultId;
   vault.token = getERC20Entity(token);
   vault.owner = owner;

--- a/subgraph/src/vault.ts
+++ b/subgraph/src/vault.ts
@@ -1,23 +1,26 @@
-import { Bytes, BigInt } from "@graphprotocol/graph-ts";
+import { Bytes, BigInt, crypto } from "@graphprotocol/graph-ts";
 import { Vault } from "../generated/schema";
 import { getERC20Entity } from "./erc20";
 
 export function vaultEntityId(
+  orderbook: Bytes,
   owner: Bytes,
   vaultId: BigInt,
   token: Bytes
 ): Bytes {
-  return owner.concat(
-    token.concat(Bytes.fromByteArray(Bytes.fromBigInt(vaultId)))
+  let bytes = orderbook.concat(
+    owner.concat(token.concat(Bytes.fromByteArray(Bytes.fromBigInt(vaultId))))
   );
+  return crypto.keccak256(bytes);
 }
 
 export function createEmptyVault(
+  orderbook: Bytes,
   owner: Bytes,
   vaultId: BigInt,
   token: Bytes
 ): Vault {
-  let vault = new Vault(vaultEntityId(owner, vaultId, token));
+  let vault = new Vault(vaultEntityId(orderbook, owner, vaultId, token));
   vault.vaultId = vaultId;
   vault.token = getERC20Entity(token);
   vault.owner = owner;
@@ -26,21 +29,27 @@ export function createEmptyVault(
   return vault;
 }
 
-export function getVault(owner: Bytes, vaultId: BigInt, token: Bytes): Vault {
-  let vault = Vault.load(vaultEntityId(owner, vaultId, token));
+export function getVault(
+  orderbook: Bytes,
+  owner: Bytes,
+  vaultId: BigInt,
+  token: Bytes
+): Vault {
+  let vault = Vault.load(vaultEntityId(orderbook, owner, vaultId, token));
   if (vault == null) {
-    vault = createEmptyVault(owner, vaultId, token);
+    vault = createEmptyVault(orderbook, owner, vaultId, token);
   }
   return vault;
 }
 
 export function handleVaultBalanceChange(
+  orderbook: Bytes,
   vaultId: BigInt,
   token: Bytes,
   amount: BigInt,
   owner: Bytes
 ): BigInt {
-  let vault = getVault(owner, vaultId, token);
+  let vault = getVault(orderbook, owner, vaultId, token);
   let oldVaultBalance = vault.balance;
   vault.balance = vault.balance.plus(amount);
   vault.save();

--- a/subgraph/src/withdraw.ts
+++ b/subgraph/src/withdraw.ts
@@ -7,6 +7,7 @@ import { handleVaultBalanceChange, vaultEntityId } from "./vault";
 
 export function handleWithdraw(event: Withdraw): void {
   let oldVaultBalance: BigInt = handleVaultBalanceChange(
+    event.address,
     event.params.vaultId,
     event.params.token,
     event.params.amount.neg(),
@@ -24,6 +25,7 @@ export function createWithdrawalEntity(
   withdraw.targetAmount = event.params.targetAmount;
   withdraw.sender = event.params.sender;
   withdraw.vault = vaultEntityId(
+    event.address,
     event.params.sender,
     event.params.vaultId,
     event.params.token

--- a/subgraph/src/withdraw.ts
+++ b/subgraph/src/withdraw.ts
@@ -21,6 +21,7 @@ export function createWithdrawalEntity(
   oldVaultBalance: BigInt
 ): void {
   let withdraw = new Withdrawal(eventId(event));
+  withdraw.orderbook = event.address;
   withdraw.amount = event.params.amount.neg();
   withdraw.targetAmount = event.params.targetAmount;
   withdraw.sender = event.params.sender;

--- a/subgraph/src/withdraw.ts
+++ b/subgraph/src/withdraw.ts
@@ -4,8 +4,10 @@ import { Withdrawal } from "../generated/schema";
 import { eventId } from "./interfaces/event";
 import { createTransactionEntity } from "./transaction";
 import { handleVaultBalanceChange, vaultEntityId } from "./vault";
+import { createOrderbookEntity } from "./orderbook";
 
 export function handleWithdraw(event: Withdraw): void {
+  createOrderbookEntity(event);
   let oldVaultBalance: BigInt = handleVaultBalanceChange(
     event.address,
     event.params.vaultId,

--- a/subgraph/tests/deposit-entity.test.ts
+++ b/subgraph/tests/deposit-entity.test.ts
@@ -6,7 +6,7 @@ import {
   afterEach,
   clearInBlockStore,
 } from "matchstick-as";
-import { BigInt, Address } from "@graphprotocol/graph-ts";
+import { BigInt, Address, crypto } from "@graphprotocol/graph-ts";
 import { createDepositEntity } from "../src/deposit";
 import { createDepositEvent } from "./event-mocks.test";
 import { vaultEntityId } from "../src/vault";
@@ -32,8 +32,13 @@ describe("Deposits", () => {
     let newVaultBalance = BigInt.fromI32(0);
     createDepositEntity(event, newVaultBalance);
 
-    let id = event.transaction.hash.concatI32(event.logIndex.toI32());
+    let id = crypto.keccak256(
+      event.address.concat(
+        event.transaction.hash.concatI32(event.logIndex.toI32())
+      )
+    );
     let vaultId = vaultEntityId(
+      event.address,
       Address.fromString("0x1234567890123456789012345678901234567890"),
       BigInt.fromI32(1),
       Address.fromString("0x0987654321098765432109876543210987654321")

--- a/subgraph/tests/handlers/handle-addorder.test.ts
+++ b/subgraph/tests/handlers/handle-addorder.test.ts
@@ -55,6 +55,15 @@ describe("Add and remove orders", () => {
 
     handleAddOrder(event);
 
+    // we should have an orderbook entity
+    assert.entityCount("Orderbook", 1);
+    assert.fieldEquals(
+      "Orderbook",
+      event.address.toHexString(),
+      "id",
+      event.address.toHexString()
+    );
+
     let id = makeOrderId(
       event.address,
       Bytes.fromHexString("0x0987654321098765432109876543210987654321")

--- a/subgraph/tests/handlers/handle-addorder.test.ts
+++ b/subgraph/tests/handlers/handle-addorder.test.ts
@@ -8,7 +8,7 @@ import {
 } from "matchstick-as";
 import { Bytes, BigInt, Address } from "@graphprotocol/graph-ts";
 import { Evaluable, IO, createAddOrderEvent } from "../event-mocks.test";
-import { handleAddOrder } from "../../src/order";
+import { handleAddOrder, makeOrderId } from "../../src/order";
 import { vaultEntityId } from "../../src/vault";
 import { createMockERC20Functions } from "../erc20.test";
 
@@ -55,40 +55,40 @@ describe("Add and remove orders", () => {
 
     handleAddOrder(event);
 
-    assert.entityCount("Order", 1);
-    assert.fieldEquals(
-      "Order",
-      "0x0987654321098765432109876543210987654321",
-      "active",
-      "true"
+    let id = makeOrderId(
+      event.address,
+      Bytes.fromHexString("0x0987654321098765432109876543210987654321")
     );
+
+    assert.entityCount("Order", 1);
+    assert.fieldEquals("Order", id.toHexString(), "active", "true");
     assert.fieldEquals(
       "Order",
-      "0x0987654321098765432109876543210987654321",
+      id.toHexString(),
       "orderHash",
       "0x0987654321098765432109876543210987654321"
     );
     assert.fieldEquals(
       "Order",
-      "0x0987654321098765432109876543210987654321",
+      id.toHexString(),
       "owner",
       "0x1234567890123456789012345678901234567890"
     );
     assert.fieldEquals(
       "Order",
-      "0x0987654321098765432109876543210987654321",
+      id.toHexString(),
       "nonce",
       "0x1234567890123456789012345678901234567890"
     );
     assert.fieldEquals(
       "Order",
-      "0x0987654321098765432109876543210987654321",
+      id.toHexString(),
       "orderBytes",
       "0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000123456789012345678901234567890123456789000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000014000000000000000000000000000000000000000000000000000000000000001c012345678901234567890123456789012345678900000000000000000000000000000000000000000000000001234567890123456789012345678901234567890000000000000000000000000098765432109876543210987654321098765432100000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000014123456789012345678901234567890123456789000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000000000001234567890123456789012345678901234567890000000000000000000000000000000000000000000000000000000000000001200000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001000000000000000000000000098765432109876543210987654321098765432100000000000000000000000000000000000000000000000000000000000000120000000000000000000000000000000000000000000000000000000000000001"
     );
     assert.fieldEquals(
       "Order",
-      "0x0987654321098765432109876543210987654321",
+      id.toHexString(),
       "timestampAdded",
       event.block.timestamp.toString()
     );
@@ -96,10 +96,20 @@ describe("Add and remove orders", () => {
     // we should also have two new empty vaults
     assert.entityCount("Vault", 2);
 
-    let inputVaultId = vaultEntityId(owner, input.vaultId, input.token);
+    let inputVaultId = vaultEntityId(
+      event.address,
+      owner,
+      input.vaultId,
+      input.token
+    );
     assert.fieldEquals("Vault", inputVaultId.toHexString(), "balance", "0");
 
-    let outputVaultId = vaultEntityId(owner, output.vaultId, output.token);
+    let outputVaultId = vaultEntityId(
+      event.address,
+      owner,
+      output.vaultId,
+      output.token
+    );
     assert.fieldEquals("Vault", outputVaultId.toHexString(), "balance", "0");
   });
 });

--- a/subgraph/tests/handlers/handle-deposit.test.ts
+++ b/subgraph/tests/handlers/handle-deposit.test.ts
@@ -34,6 +34,15 @@ describe("Handle deposit", () => {
 
     handleDeposit(event);
 
+    // we should have an orderbook entity
+    assert.entityCount("Orderbook", 1);
+    assert.fieldEquals(
+      "Orderbook",
+      event.address.toHexString(),
+      "id",
+      event.address.toHexString()
+    );
+
     // check vault entity
     let vault = Vault.load(
       vaultEntityId(

--- a/subgraph/tests/handlers/handle-deposit.test.ts
+++ b/subgraph/tests/handlers/handle-deposit.test.ts
@@ -37,6 +37,7 @@ describe("Handle deposit", () => {
     // check vault entity
     let vault = Vault.load(
       vaultEntityId(
+        event.address,
         event.params.sender,
         event.params.vaultId,
         event.params.token
@@ -78,6 +79,7 @@ describe("Handle deposit", () => {
     // check vault entity
     vault = Vault.load(
       vaultEntityId(
+        event.address,
         event.params.sender,
         event.params.vaultId,
         event.params.token
@@ -122,6 +124,7 @@ describe("Handle deposit", () => {
     // check vault entity
     vault = Vault.load(
       vaultEntityId(
+        event.address,
         event.params.sender,
         event.params.vaultId,
         event.params.token

--- a/subgraph/tests/handlers/handle-meta.test.ts
+++ b/subgraph/tests/handlers/handle-meta.test.ts
@@ -13,7 +13,7 @@ import {
   createAddOrderEvent,
   createMetaEvent,
 } from "../event-mocks.test";
-import { handleAddOrder } from "../../src/order";
+import { handleAddOrder, makeOrderId } from "../../src/order";
 import { handleMeta } from "../../src/handlers";
 import { createMockERC20Functions } from "../erc20.test";
 
@@ -87,10 +87,12 @@ describe("Add and remove orders", () => {
 
     handleMeta(metaEvent);
 
+    let id = makeOrderId(metaEvent.address, orderHash);
+
     // meta field on order should be updated
     assert.fieldEquals(
       "Order",
-      orderHash.toHexString(),
+      id.toHexString(),
       "meta",
       "0x1234567890abcdef1234567890abcdef12345678"
     );

--- a/subgraph/tests/handlers/handle-meta.test.ts
+++ b/subgraph/tests/handlers/handle-meta.test.ts
@@ -87,6 +87,15 @@ describe("Add and remove orders", () => {
 
     handleMeta(metaEvent);
 
+    // we should have an orderbook entity
+    assert.entityCount("Orderbook", 1);
+    assert.fieldEquals(
+      "Orderbook",
+      event.address.toHexString(),
+      "id",
+      event.address.toHexString()
+    );
+
     let id = makeOrderId(metaEvent.address, orderHash);
 
     // meta field on order should be updated

--- a/subgraph/tests/handlers/handle-removeorder.test.ts
+++ b/subgraph/tests/handlers/handle-removeorder.test.ts
@@ -99,6 +99,15 @@ describe("Add and remove orders", () => {
 
     handleRemoveOrder(removeEvent);
 
+    // we should have an orderbook entity
+    assert.entityCount("Orderbook", 1);
+    assert.fieldEquals(
+      "Orderbook",
+      event.address.toHexString(),
+      "id",
+      event.address.toHexString()
+    );
+
     assert.entityCount("Order", 1);
 
     let id = makeOrderId(

--- a/subgraph/tests/handlers/handle-removeorder.test.ts
+++ b/subgraph/tests/handlers/handle-removeorder.test.ts
@@ -13,7 +13,11 @@ import {
   createAddOrderEvent,
   createRemoveOrderEvent,
 } from "../event-mocks.test";
-import { handleAddOrder, handleRemoveOrder } from "../../src/order";
+import {
+  handleAddOrder,
+  handleRemoveOrder,
+  makeOrderId,
+} from "../../src/order";
 import { createMockERC20Functions } from "../erc20.test";
 
 describe("Add and remove orders", () => {
@@ -56,6 +60,10 @@ describe("Add and remove orders", () => {
       )
     );
 
+    event.address = Address.fromString(
+      "0x1234567890123456789012345678901234567890"
+    );
+
     handleAddOrder(event);
 
     // Now we can remove the order
@@ -85,14 +93,25 @@ describe("Add and remove orders", () => {
       )
     );
 
+    removeEvent.address = Address.fromString(
+      "0x1234567890123456789012345678901234567890"
+    );
+
     handleRemoveOrder(removeEvent);
 
     assert.entityCount("Order", 1);
+
+    let id = makeOrderId(
+      removeEvent.address,
+      Bytes.fromHexString("0x0987654321098765432109876543210987654321")
+    );
+
     assert.fieldEquals(
       "Order",
-      "0x0987654321098765432109876543210987654321",
+      id.toHexString(),
       "active",
-      "false"
+      "false",
+      "Order should be inactive after removeOrder event"
     );
 
     // if we add the order again, it should be active
@@ -102,9 +121,10 @@ describe("Add and remove orders", () => {
 
     assert.fieldEquals(
       "Order",
-      "0x0987654321098765432109876543210987654321",
+      id.toHexString(),
       "active",
-      "true"
+      "true",
+      "Order should be active after second addOrder event"
     );
 
     // if we remove the order again, it should be inactive
@@ -115,9 +135,10 @@ describe("Add and remove orders", () => {
 
     assert.fieldEquals(
       "Order",
-      "0x0987654321098765432109876543210987654321",
+      id.toHexString(),
       "active",
-      "false"
+      "false",
+      "Order should be inactive after second removeOrder event"
     );
   });
 });

--- a/subgraph/tests/handlers/handle-takeorder.test.ts
+++ b/subgraph/tests/handlers/handle-takeorder.test.ts
@@ -64,5 +64,14 @@ describe("Add and remove orders", () => {
     assert.entityCount("Vault", 2);
     assert.entityCount("TradeVaultBalanceChange", 2);
     assert.entityCount("Trade", 1);
+
+    // we should have an orderbook entity
+    assert.entityCount("Orderbook", 1);
+    assert.fieldEquals(
+      "Orderbook",
+      event.address.toHexString(),
+      "id",
+      event.address.toHexString()
+    );
   });
 });

--- a/subgraph/tests/handlers/handle-withdraw.test.ts
+++ b/subgraph/tests/handlers/handle-withdraw.test.ts
@@ -48,6 +48,7 @@ describe("Handle withdraw", () => {
     // check vault entity
     let vault = Vault.load(
       vaultEntityId(
+        event.address,
         event.params.sender,
         event.params.vaultId,
         event.params.token
@@ -88,6 +89,7 @@ describe("Handle withdraw", () => {
     // check vault entity
     vault = Vault.load(
       vaultEntityId(
+        event.address,
         event.params.sender,
         event.params.vaultId,
         event.params.token
@@ -143,6 +145,7 @@ describe("Handle withdraw", () => {
     // check vault entity
     vault = Vault.load(
       vaultEntityId(
+        event.address,
         event.params.sender,
         event.params.vaultId,
         event.params.token

--- a/subgraph/tests/handlers/handle-withdraw.test.ts
+++ b/subgraph/tests/handlers/handle-withdraw.test.ts
@@ -45,6 +45,15 @@ describe("Handle withdraw", () => {
 
     handleWithdraw(event);
 
+    // we should have an orderbook entity
+    assert.entityCount("Orderbook", 1);
+    assert.fieldEquals(
+      "Orderbook",
+      event.address.toHexString(),
+      "id",
+      event.address.toHexString()
+    );
+
     // check vault entity
     let vault = Vault.load(
       vaultEntityId(

--- a/subgraph/tests/order.test.ts
+++ b/subgraph/tests/order.test.ts
@@ -17,6 +17,7 @@ import {
   createAddOrderEntity,
   createOrderEntity,
   createRemoveOrderEntity,
+  makeOrderId,
 } from "../src/order";
 import { eventId } from "../src/interfaces/event";
 import { Order } from "../generated/schema";
@@ -131,42 +132,41 @@ describe("Add and remove orders", () => {
       )
     );
 
+    let id = makeOrderId(
+      event.address,
+      Bytes.fromHexString("0x0987654321098765432109876543210987654321")
+    );
+
     createOrderEntity(event);
 
     assert.entityCount("Order", 1);
+    assert.fieldEquals("Order", id.toHexString(), "active", "true");
     assert.fieldEquals(
       "Order",
-      "0x0987654321098765432109876543210987654321",
-      "active",
-      "true"
-    );
-    assert.fieldEquals(
-      "Order",
-      "0x0987654321098765432109876543210987654321",
+      id.toHexString(),
       "orderHash",
       "0x0987654321098765432109876543210987654321"
     );
     assert.fieldEquals(
       "Order",
-      "0x0987654321098765432109876543210987654321",
+      id.toHexString(),
       "owner",
       "0x1234567890123456789012345678901234567890"
     );
     assert.fieldEquals(
       "Order",
-      "0x0987654321098765432109876543210987654321",
+      id.toHexString(),
       "nonce",
       "0x1234567890123456789012345678901234567890"
     );
     assert.fieldEquals(
       "Order",
-      "0x0987654321098765432109876543210987654321",
+      id.toHexString(),
       "timestampAdded",
       event.block.timestamp.toString()
     );
-    let order = Order.load(
-      Bytes.fromHexString("0x0987654321098765432109876543210987654321")
-    )!;
+
+    let order = Order.load(id)!;
     let inputs = order.inputs;
     assert.i32Equals(inputs.length, 1, "inputs length");
     let outputs = order.outputs;

--- a/subgraph/tests/trade.test.ts
+++ b/subgraph/tests/trade.test.ts
@@ -39,12 +39,14 @@ describe("Deposits", () => {
       "0x3333333333333333333333333333333333333333"
     );
 
-    let tradeId = eventId(event).concat(orderHash);
+    let tradeId = Bytes.fromByteArray(
+      crypto.keccak256(eventId(event).concat(orderHash))
+    );
 
     assert.bytesEquals(
       tradeId,
       Bytes.fromHexString(
-        "0x1111111111111111111111111111111111111111111111111111111111111111020000003333333333333333333333333333333333333333"
+        "0x6e82bd6b67d3ab900f932bb0bd3cc4fb2c96e4a9e8cf0d4476271bea34bf226b"
       )
     );
   });
@@ -92,6 +94,7 @@ describe("Deposits", () => {
       tradeVaultBalanceChangeId(
         event,
         vaultEntityId(
+          event.address,
           Address.fromString("0x1111111111111111111111111111111111111111"),
           BigInt.fromU32(1),
           Address.fromString("0x3333333333333333333333333333333333333333")
@@ -103,6 +106,7 @@ describe("Deposits", () => {
       tradeVaultBalanceChangeId(
         event,
         vaultEntityId(
+          event.address,
           Address.fromString("0x1111111111111111111111111111111111111111"),
           BigInt.fromU32(1),
           Address.fromString("0x4444444444444444444444444444444444444444")

--- a/subgraph/tests/tradevaultbalancechange.test.ts
+++ b/subgraph/tests/tradevaultbalancechange.test.ts
@@ -7,7 +7,7 @@ import {
   newMockEvent,
   assert,
 } from "matchstick-as";
-import { BigInt, Address, Bytes } from "@graphprotocol/graph-ts";
+import { BigInt, Address, Bytes, crypto } from "@graphprotocol/graph-ts";
 import { Evaluable, IO, createTakeOrderEvent } from "./event-mocks.test";
 import { eventId } from "../src/interfaces/event";
 import {
@@ -35,14 +35,14 @@ describe("Deposits", () => {
       "0x1234567890abcdef1234567890abcdef12345678"
     );
 
-    let tradeVaultBalanceChangeId = vaultEntityId.concat(eventId(event));
+    let tradeVaultBalanceChangeId = Bytes.fromByteArray(
+      crypto.keccak256(eventId(event).concat(vaultEntityId))
+    );
 
     assert.bytesEquals(
       tradeVaultBalanceChangeId,
       Bytes.fromHexString(
-        "0x1234567890abcdef1234567890abcdef123456781234567890abcdef" +
-          "1234567890abcdef1234567890abcdef1234567890abcdef" +
-          "02000000"
+        "0x417b9a4b4f93565a22e3d13b93f7f467b0e84ef8dddcb52a718298e4e17df26f"
       )
     );
   });
@@ -88,6 +88,7 @@ describe("Deposits", () => {
     let oldVaultBalance = BigInt.fromI32(10);
 
     let _vaultEntityId = vaultEntityId(
+      event.address,
       owner,
       BigInt.fromI32(1),
       Address.fromString("0x3333333333333333333333333333333333333333")

--- a/subgraph/tests/vault.test.ts
+++ b/subgraph/tests/vault.test.ts
@@ -23,6 +23,7 @@ describe("Vault balance changes", () => {
     );
 
     handleVaultBalanceChange(
+      Address.fromString("0x0987654321098765432109876543210987654321"),
       BigInt.fromI32(1),
       Bytes.fromHexString("0x1234567890123456789012345678901234567890"),
       BigInt.fromI32(100),
@@ -30,6 +31,7 @@ describe("Vault balance changes", () => {
     );
 
     let vaultId = vaultEntityId(
+      Bytes.fromHexString("0x0987654321098765432109876543210987654321"),
       Address.fromString("0x0987654321098765432109876543210987654321"),
       BigInt.fromI32(1),
       Address.fromString("0x1234567890123456789012345678901234567890")
@@ -74,6 +76,7 @@ describe("Vault balance changes", () => {
       BigInt.fromI32(100)
     );
     handleVaultBalanceChange(
+      event.address,
       event.params.vaultId,
       event.params.token,
       event.params.amount,
@@ -81,6 +84,7 @@ describe("Vault balance changes", () => {
     );
 
     let vaultId = vaultEntityId(
+      event.address,
       Address.fromString("0x0987654321098765432109876543210987654321"),
       BigInt.fromI32(1),
       Address.fromString("0x1234567890123456789012345678901234567890")
@@ -127,6 +131,7 @@ describe("Vault balance changes", () => {
     );
 
     handleVaultBalanceChange(
+      depositEvent.address,
       depositEvent.params.vaultId,
       depositEvent.params.token,
       depositEvent.params.amount,
@@ -142,6 +147,7 @@ describe("Vault balance changes", () => {
       BigInt.fromI32(100)
     );
     handleVaultBalanceChange(
+      event.address,
       event.params.vaultId,
       event.params.token,
       event.params.amount.neg(),
@@ -149,6 +155,7 @@ describe("Vault balance changes", () => {
     );
 
     let vaultId = vaultEntityId(
+      event.address,
       Address.fromString("0x0987654321098765432109876543210987654321"),
       BigInt.fromI32(1),
       Address.fromString("0x1234567890123456789012345678901234567890")
@@ -196,6 +203,7 @@ describe("Vault balance changes", () => {
     );
 
     handleVaultBalanceChange(
+      event.address,
       event.params.vaultId,
       event.params.token,
       event.params.amount,
@@ -203,6 +211,7 @@ describe("Vault balance changes", () => {
     );
 
     let vaultId = vaultEntityId(
+      event.address,
       Address.fromString("0x0987654321098765432109876543210987654321"),
       BigInt.fromI32(1),
       Address.fromString("0x1234567890123456789012345678901234567890")
@@ -240,6 +249,7 @@ describe("Vault balance changes", () => {
     );
 
     let oldBalance = handleVaultBalanceChange(
+      Address.fromString("0x0987654321098765432109876543210987654321"),
       BigInt.fromI32(1),
       Bytes.fromHexString("0x1234567890123456789012345678901234567890"),
       BigInt.fromI32(100),
@@ -255,6 +265,7 @@ describe("Vault balance changes", () => {
     );
 
     handleVaultBalanceChange(
+      Address.fromString("0x0987654321098765432109876543210987654321"),
       BigInt.fromI32(1),
       Bytes.fromHexString("0x1234567890123456789012345678901234567890"),
       BigInt.fromI32(100),
@@ -262,6 +273,7 @@ describe("Vault balance changes", () => {
     );
 
     let oldBalance = handleVaultBalanceChange(
+      Address.fromString("0x0987654321098765432109876543210987654321"),
       BigInt.fromI32(1),
       Bytes.fromHexString("0x1234567890123456789012345678901234567890"),
       BigInt.fromI32(100),

--- a/subgraph/tests/withdrawal-entity.test.ts
+++ b/subgraph/tests/withdrawal-entity.test.ts
@@ -6,7 +6,7 @@ import {
   afterEach,
   clearInBlockStore,
 } from "matchstick-as";
-import { BigInt, Address } from "@graphprotocol/graph-ts";
+import { BigInt, Address, crypto } from "@graphprotocol/graph-ts";
 import { createWithdrawalEntity } from "../src/withdraw";
 import { createWithdrawEvent } from "./event-mocks.test";
 import { vaultEntityId } from "../src/vault";
@@ -34,8 +34,13 @@ describe("Withdrawals", () => {
     let oldVaultBalance = BigInt.fromI32(300);
     createWithdrawalEntity(event, oldVaultBalance);
 
-    let id = event.transaction.hash.concatI32(event.logIndex.toI32());
+    let id = crypto.keccak256(
+      event.address.concat(
+        event.transaction.hash.concatI32(event.logIndex.toI32())
+      )
+    );
     let vaultId = vaultEntityId(
+      event.address,
       Address.fromString("0x1234567890123456789012345678901234567890"),
       BigInt.fromI32(1),
       Address.fromString("0x0987654321098765432109876543210987654321")


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

We want our subgraph to support multiple orderbooks.

## Solution

Namespace the ids for most entities with the address of the orderbook they're associated with. Add an `orderbook` field to those entities and `derivedFrom` fields on a new `Orderbook` entity so the relationship can be queried in both directions.

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
