### PR TITLE
Subgraph: fix for trade entity

### DIFF
--- a/subgraph/src/trade.ts
+++ b/subgraph/src/trade.ts
@@ -1,6 +1,7 @@
 import { Bytes, ethereum, crypto } from "@graphprotocol/graph-ts";
 import { Trade, TradeVaultBalanceChange } from "../generated/schema";
 import { eventId } from "./interfaces/event";
+import { makeOrderId } from "./order";
 
 export function makeTradeId(event: ethereum.Event, orderHash: Bytes): Bytes {
   let bytes = eventId(event).concat(orderHash);
@@ -15,7 +16,7 @@ export function createTradeEntity(
 ): void {
   let trade = new Trade(makeTradeId(event, orderHash));
   trade.orderbook = event.address;
-  trade.order = orderHash;
+  trade.order = makeOrderId(event.address, orderHash);
   trade.inputVaultBalanceChange = inputVaultBalanceChange.id;
   trade.outputVaultBalanceChange = outputVaultBalanceChange.id;
   trade.tradeEvent = eventId(event);

--- a/subgraph/tests/trade.test.ts
+++ b/subgraph/tests/trade.test.ts
@@ -21,6 +21,7 @@ import { createTradeEntity, makeTradeId } from "../src/trade";
 import { TradeVaultBalanceChange } from "../generated/schema";
 import { tradeVaultBalanceChangeId } from "../src/tradevaultbalancechange";
 import { createMockERC20Functions } from "./erc20.test";
+import { makeOrderId } from "../src/order";
 
 describe("Deposits", () => {
   afterEach(() => {
@@ -122,6 +123,7 @@ describe("Deposits", () => {
     );
 
     let id = makeTradeId(event, orderHash).toHexString();
+    let orderId = makeOrderId(event.address, orderHash).toHexString();
 
     assert.entityCount("Trade", 1);
     assert.fieldEquals(
@@ -130,5 +132,19 @@ describe("Deposits", () => {
       "timestamp",
       event.block.timestamp.toString()
     );
+
+    assert.fieldEquals(
+      "Trade",
+      id,
+      "inputVaultBalanceChange",
+      inputVaultBalanceChange.id.toHexString()
+    );
+    assert.fieldEquals(
+      "Trade",
+      id,
+      "outputVaultBalanceChange",
+      outputVaultBalanceChange.id.toHexString()
+    );
+    assert.fieldEquals("Trade", id, "order", orderId);
   });
 });


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

We had an issue where Order entities were not showing their associated trades.

## Solution

The id being used to link Trades to Orders was wrong. I updated the id to be the same used for Order ids.

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
