### PR TITLE
add and remove order events fix

### DIFF
--- a/subgraph/src/order.ts
+++ b/subgraph/src/order.ts
@@ -68,7 +68,7 @@ export function createAddOrderEntity(event: AddOrderV2): void {
   let addOrder = new AddOrder(event.transaction.hash);
   addOrder.id = eventId(event);
   addOrder.orderbook = event.address;
-  addOrder.order = event.params.orderHash;
+  addOrder.order = makeOrderId(event.address, event.params.orderHash);
   addOrder.sender = event.params.sender;
   addOrder.transaction = createTransactionEntity(event);
   addOrder.save();
@@ -78,7 +78,7 @@ export function createRemoveOrderEntity(event: RemoveOrderV2): void {
   let removeOrder = new RemoveOrder(event.transaction.hash);
   removeOrder.id = eventId(event);
   removeOrder.orderbook = event.address;
-  removeOrder.order = event.params.orderHash;
+  removeOrder.order = makeOrderId(event.address, event.params.orderHash);
   removeOrder.sender = event.params.sender;
   removeOrder.transaction = createTransactionEntity(event);
   removeOrder.save();

--- a/subgraph/tests/order.test.ts
+++ b/subgraph/tests/order.test.ts
@@ -205,11 +205,13 @@ describe("Add and remove orders", () => {
 
     let id = eventId(event);
 
+    let orderid = makeOrderId(event.address, event.params.orderHash);
+
     assert.fieldEquals(
       "AddOrder",
       id.toHexString(),
       "order",
-      "0x0987654321098765432109876543210987654321"
+      orderid.toHexString()
     );
 
     assert.fieldEquals(
@@ -260,11 +262,13 @@ describe("Add and remove orders", () => {
 
     let id = eventId(event);
 
+    let orderid = makeOrderId(event.address, event.params.orderHash);
+
     assert.fieldEquals(
       "RemoveOrder",
       id.toHexString(),
       "order",
-      "0x0987654321098765432109876543210987654321"
+      orderid.toHexString()
     );
 
     assert.fieldEquals(


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

AddOrder and RemoveOrder entitties aren't being linked correctly to the order entities, due to the construction of the id being linked on.

## Solution

Fixed this.

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
