### PR TITLE
replacing the 'post-add-order' naming with 'handle-add-order'

### DIFF
--- a/crates/cli/src/commands/order/add.rs
+++ b/crates/cli/src/commands/order/add.rs
@@ -173,7 +173,7 @@ deployments:
 _ _: 0 0;
 #handle-io
 :;
-#post-add-order
+#handle-add-order
 :;"
         .to_string()
     }

--- a/crates/cli/src/commands/order/calldata.rs
+++ b/crates/cli/src/commands/order/calldata.rs
@@ -180,7 +180,7 @@ deployments:
 _ _: 0 0;
 #handle-io
 :;
-#post-add-order
+#handle-add-order
 :;",
             rpc_server.url("/rpc").as_str()
         );

--- a/crates/cli/src/commands/order/compose.rs
+++ b/crates/cli/src/commands/order/compose.rs
@@ -138,7 +138,7 @@ scenarios:
 _ _: 0 0;
 #handle-io
 :;
-#post-add-order
+#handle-add-order
 :;"
         .to_string()
     }

--- a/crates/cli/src/commands/order/orderbook_address.rs
+++ b/crates/cli/src/commands/order/orderbook_address.rs
@@ -170,7 +170,7 @@ deployments:
 _ _: 0 0;
 #handle-io
 :;
-#post-add-order
+#handle-add-order
 :;",
             orderbook_key
         )

--- a/crates/common/src/add_order.rs
+++ b/crates/common/src/add_order.rs
@@ -27,7 +27,7 @@ use std::collections::HashMap;
 use thiserror::Error;
 
 pub static ORDERBOOK_ORDER_ENTRYPOINTS: [&str; 2] = ["calculate-io", "handle-io"];
-pub static ORDERBOOK_ADDORDER_POST_TASK_ENTRYPOINTS: [&str; 1] = ["post-add-order"];
+pub static ORDERBOOK_ADDORDER_POST_TASK_ENTRYPOINTS: [&str; 1] = ["handle-add-order"];
 
 #[derive(Error, Debug)]
 pub enum AddOrderArgsError {
@@ -543,7 +543,7 @@ some front matter
 _ _: 0 0;
 #handle-io
 :;
-#post-add-order
+#handle-add-order
 _ _: 0 0;
 "#;
         let result = AddOrderArgs::new_from_deployment(dotrain.to_string(), deployment)
@@ -680,7 +680,7 @@ some front matter
 _ _: 0 0;
 #handle-io
 :;
-#post-add-order
+#handle-add-order
 _ _: 0 0;
 "#;
         let result = AddOrderArgs::new_from_deployment(dotrain.to_string(), deployment.clone())
@@ -689,6 +689,6 @@ _ _: 0 0;
 
         let post_action = result.compose_addorder_post_task().unwrap();
 
-        assert_eq!(post_action, "/* 0. post-add-order */ \n_ _: 0 0;");
+        assert_eq!(post_action, "/* 0. handle-add-order */ \n_ _: 0 0;");
     }
 }

--- a/crates/common/src/dotrain_order.rs
+++ b/crates/common/src/dotrain_order.rs
@@ -265,7 +265,7 @@ scenarios:
 _ _: 0 0;
 #handle-io
 :;
-#post-add-order
+#handle-add-order
 _ _: 1 2;
 "#,
             rpc_url = rain_orderbook_env::CI_DEPLOY_POLYGON_RPC_URL
@@ -280,7 +280,7 @@ _ _: 1 2;
 
         assert_eq!(
             rainlang,
-            r#"/* 0. post-add-order */ 
+            r#"/* 0. handle-add-order */ 
 _ _: 1 2;"#
         );
     }

--- a/crates/integration_tests/src/lib.rs
+++ b/crates/integration_tests/src/lib.rs
@@ -84,7 +84,7 @@ deployments:
 #calculate-io
 using-words-from 0xe80e7438ce6b1055c8e9CDE1b6336a4F9D53C666
 amount price: get("amount") 52;
-#post-add-order
+#handle-add-order
 :set("amount" 100);
 #handle-io
 :;
@@ -236,7 +236,7 @@ deployments:
 amount price: get("amount") 52;
 #handle-io
 :;
-#post-add-order
+#handle-add-order
 :ensure(0 "should fail");
 "#,
             rpc_url = anvil.endpoint()

--- a/test-js/common/test.test.ts
+++ b/test-js/common/test.test.ts
@@ -69,7 +69,7 @@ deployments:
 _ _: 0 0;
 #handle-io
 :;
-#post-add-order
+#handle-add-order
 :;
 `;
 
@@ -123,7 +123,7 @@ deployers:
 _ _: 0 0;
 #handle-io
 :;
-#post-add-order
+#handle-add-order
 :;
 `;
       await getAddOrderCalldata(dotrain, "some-deployment");


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

We want to change the naming of the post add order task to `handle-add-order`

## Solution

Did a find and replace

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
