### PR TITLE
Order status filter

### DIFF
--- a/crates/cli/src/commands/order/list.rs
+++ b/crates/cli/src/commands/order/list.rs
@@ -120,6 +120,7 @@ mod tests {
             },
             filter_args: CliFilterArgs {
                 owners: vec!["addr1".to_string()],
+                active: Some(true),
             },
         };
 
@@ -146,6 +147,7 @@ mod tests {
             },
             filter_args: CliFilterArgs {
                 owners: vec!["addr1".to_string()],
+                active: Some(true),
             },
         };
 
@@ -172,6 +174,7 @@ mod tests {
             },
             filter_args: CliFilterArgs {
                 owners: vec!["addr1".to_string()],
+                active: Some(true),
             },
         };
 

--- a/crates/cli/src/commands/vault/list.rs
+++ b/crates/cli/src/commands/vault/list.rs
@@ -119,6 +119,7 @@ mod tests {
             },
             filter_args: CliFilterArgs {
                 owners: vec!["addr1".to_string()],
+                active: Some(true),
             },
         };
 
@@ -145,6 +146,7 @@ mod tests {
             },
             filter_args: CliFilterArgs {
                 owners: vec!["addr1".to_string()],
+                active: Some(true),
             },
         };
 
@@ -165,6 +167,7 @@ mod tests {
             },
             filter_args: CliFilterArgs {
                 owners: vec!["addr1".to_string()],
+                active: Some(true),
             },
         };
 

--- a/crates/cli/src/subgraph.rs
+++ b/crates/cli/src/subgraph.rs
@@ -69,12 +69,16 @@ pub struct CliFilterArgs {
         value_delimiter = ','
     )]
     pub owners: Vec<String>,
+
+    #[arg(long, help = "Filter orders by active status", default_value = "true")]
+    pub active: Option<bool>,
 }
 
 impl From<CliFilterArgs> for OrdersListFilterArgs {
     fn from(val: CliFilterArgs) -> Self {
         Self {
             owners: val.owners.into_iter().map(Bytes).collect(),
+            active: val.active,
         }
     }
 }

--- a/crates/subgraph/src/orderbook_client.rs
+++ b/crates/subgraph/src/orderbook_client.rs
@@ -74,16 +74,19 @@ impl OrderbookSubgraphClient {
     ) -> Result<Vec<Order>, OrderbookSubgraphClientError> {
         let pagination_variables = Self::parse_pagination_args(pagination_args);
 
+        let filters = if !filter_args.owners.is_empty() || filter_args.active.is_some() {
+            Some(OrdersListQueryFilters {
+                owner_in: filter_args.owners,
+                active: filter_args.active,
+            })
+        } else {
+            None
+        };
+
         let variables = OrdersListQueryVariables {
             first: pagination_variables.first,
             skip: pagination_variables.skip,
-            filters: if filter_args.owners.is_empty() {
-                None
-            } else {
-                Some(OrdersListQueryFilters {
-                    owner_in: filter_args.owners,
-                })
-            },
+            filters,
         };
 
         let data = self
@@ -100,7 +103,10 @@ impl OrderbookSubgraphClient {
         loop {
             let page_data = self
                 .orders_list(
-                    OrdersListFilterArgs { owners: vec![] },
+                    OrdersListFilterArgs {
+                        owners: vec![],
+                        active: None,
+                    },
                     PaginationArgs {
                         page,
                         page_size: ALL_PAGES_QUERY_PAGE_SIZE,

--- a/crates/subgraph/src/types/common.rs
+++ b/crates/subgraph/src/types/common.rs
@@ -11,6 +11,7 @@ pub struct IdQueryVariables<'a> {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OrdersListFilterArgs {
     pub owners: Vec<Bytes>,
+    pub active: Option<bool>,
 }
 
 #[derive(cynic::QueryVariables, Debug, Clone)]
@@ -24,8 +25,10 @@ pub struct PaginationQueryVariables {
 #[cynic(graphql_type = "Order_filter")]
 #[typeshare]
 pub struct OrdersListQueryFilters {
-    #[cynic(rename = "owner_in")]
+    #[cynic(rename = "owner_in", skip_serializing_if = "Vec::is_empty")]
     pub owner_in: Vec<Bytes>,
+    #[cynic(rename = "active", skip_serializing_if = "Option::is_none")]
+    pub active: Option<bool>,
 }
 
 #[derive(cynic::QueryVariables, Debug, Clone)]

--- a/tauri-app/src/lib/components/ListViewOrderbookSelector.svelte
+++ b/tauri-app/src/lib/components/ListViewOrderbookSelector.svelte
@@ -3,6 +3,7 @@
   import DropdownActiveNetwork from './DropdownActiveNetwork.svelte';
   import DropdownActiveOrderbook from './DropdownActiveOrderbook.svelte';
   import DropdownOrderListWatchlist from './dropdown/DropdownOrderListWatchlist.svelte';
+  import DropdownOrderStatus from './dropdown/DropdownOrderStatus.svelte';
   import { settings } from '$lib/stores/settings';
   import { Alert } from 'flowbite-svelte';
 </script>
@@ -13,6 +14,7 @@
       >No networks added to <a class="underline" href="/settings">settings</a></Alert
     >
   {:else}
+    <DropdownOrderStatus />
     <DropdownOrderListWatchlist />
     <DropdownActiveNetwork />
     <DropdownActiveOrderbook />

--- a/tauri-app/src/lib/components/dropdown/DropdownCheckbox.svelte
+++ b/tauri-app/src/lib/components/dropdown/DropdownCheckbox.svelte
@@ -10,7 +10,9 @@
   export let value: Record<string, string> = {};
   export let label: string = 'Select items';
   export let allLabel: string = 'All items';
+  export let showAllLabel: boolean = true;
   export let emptyMessage: string = 'No items available';
+  export let onlyTitle: boolean = false;
 
   $: selectedCount = Object.keys(value).length;
   $: allSelected = selectedCount === Object.keys(options).length;
@@ -57,7 +59,7 @@
   <Dropdown class="w-full min-w-72 py-0" data-testid="dropdown-checkbox">
     {#if isEmpty(options)}
       <div class="ml-2 w-full rounded-lg p-3">{emptyMessage}</div>
-    {:else if Object.keys(options).length > 1}
+    {:else if Object.keys(options).length > 1 && showAllLabel}
       <Checkbox
         data-testid="dropdown-checkbox-option"
         class="w-full rounded-lg p-3 hover:bg-gray-100 dark:hover:bg-gray-600"
@@ -77,7 +79,9 @@
       >
         <div class="ml-2">
           <div class="text-sm font-medium">{key}</div>
-          <div class="text-xs text-gray-500">{optionValue}</div>
+          {#if !onlyTitle}
+            <div class="text-xs text-gray-500">{optionValue}</div>
+          {/if}
         </div>
       </Checkbox>
     {/each}

--- a/tauri-app/src/lib/components/dropdown/DropdownOrderStatus.svelte
+++ b/tauri-app/src/lib/components/dropdown/DropdownOrderStatus.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  import DropdownCheckbox from './DropdownCheckbox.svelte';
+  import { activeOrderStatus } from '$lib/stores/settings';
+
+  const orderStatusOptions = {
+    Active: 'active',
+    Inactive: 'inactive',
+  };
+
+  function handleStatusChange(event: CustomEvent<Record<string, string>>) {
+    let status: boolean | undefined = undefined;
+    let items = Object.keys(event.detail);
+
+    if (items.length === 0 || items.length === 2) {
+      status = undefined;
+    } else if (items.includes('Active')) {
+      status = true;
+    } else if (items.includes('Inactive')) {
+      status = false;
+    }
+
+    activeOrderStatus.set(status);
+  }
+</script>
+
+<DropdownCheckbox
+  options={orderStatusOptions}
+  on:change={handleStatusChange}
+  label="Status"
+  showAllLabel={false}
+  onlyTitle={true}
+/>

--- a/tauri-app/src/lib/components/tables/OrdersListTable.svelte
+++ b/tauri-app/src/lib/components/tables/OrdersListTable.svelte
@@ -21,13 +21,18 @@
   import { subgraphUrl } from '$lib/stores/settings';
   import { formatTimestampSecondsAsLocal } from '$lib/utils/time';
   import { handleOrderRemoveModal } from '$lib/services/modal';
-  import { activeWatchlist } from '$lib/stores/settings';
+  import { activeWatchlist, activeOrderStatus } from '$lib/stores/settings';
   import { get } from 'svelte/store';
 
   $: query = createInfiniteQuery({
-    queryKey: [QKEY_ORDERS, $activeWatchlist],
+    queryKey: [QKEY_ORDERS, $activeWatchlist, $activeOrderStatus],
     queryFn: ({ pageParam }) => {
-      return ordersList($subgraphUrl, Object.values(get(activeWatchlist)), pageParam);
+      return ordersList(
+        $subgraphUrl,
+        Object.values(get(activeWatchlist)),
+        $activeOrderStatus,
+        pageParam,
+      );
     },
     initialPageParam: 0,
     getNextPageParam(lastPage, _allPages, lastPageParam) {

--- a/tauri-app/src/lib/queries/ordersList.ts
+++ b/tauri-app/src/lib/queries/ordersList.ts
@@ -16,6 +16,7 @@ export type OrdersListArgs = {
 export const ordersList = async (
   url: string | undefined,
   owners: string[] = [],
+  active: boolean | undefined = undefined,
   pageParam: number,
   pageSize: number = DEFAULT_PAGE_SIZE,
 ) => {
@@ -26,6 +27,7 @@ export const ordersList = async (
     subgraphArgs: { url },
     filterArgs: {
       owners,
+      active,
     },
     paginationArgs: { page: pageParam + 1, page_size: pageSize },
   } as OrdersListArgs);
@@ -54,10 +56,10 @@ if (import.meta.vitest) {
     });
 
     // check for a result with no URL
-    expect(await ordersList(undefined, [], 0)).toEqual([]);
+    expect(await ordersList(undefined, [], undefined, 0)).toEqual([]);
 
     // check for a result with a URL
-    expect(await ordersList('http://localhost:8000', [], 0)).toEqual([
+    expect(await ordersList('http://localhost:8000', [], undefined, 0)).toEqual([
       {
         id: '1',
         order_bytes: '0x123',

--- a/tauri-app/src/lib/stores/settings.ts
+++ b/tauri-app/src/lib/stores/settings.ts
@@ -198,3 +198,17 @@ export async function resetActiveNetworkRef() {
     activeNetworkRef.set(undefined);
   }
 }
+
+export const activeOrderStatus = cachedWritableStore<boolean | undefined>(
+  'settings.activeOrderStatus',
+  undefined,
+  (value) => JSON.stringify(value),
+  (str) => {
+    try {
+      const parsed = JSON.parse(str);
+      return typeof parsed === 'boolean' ? parsed : undefined;
+    } catch {
+      return undefined;
+    }
+  },
+);


### PR DESCRIPTION
Solves: #833 

## 🛑  CHAINED PR - DO NOT MERGE BEFORE #832 🛑 

<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

When listing all of the orders, active and inactive ones comes together, making the page cluttered if the user is only interested in a single status. See issue: https://github.com/rainlanguage/rain.orderbook/issues/833

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Added a new status filter for selecting active or inactive.

- None selection -> all of the orders
- All selection -> all of the orders
- Active selection -> only active ones
- Inactive selection -> only inactive ones

![Screenshot 2024-09-07 at 10 01 28](https://github.com/user-attachments/assets/21759916-2c00-4bf8-9333-de25f185e4bb)
![Screenshot 2024-09-07 at 10 01 36](https://github.com/user-attachments/assets/7207d1f9-5af3-4435-b083-9ad7d7c0e260)
![Screenshot 2024-09-07 at 10 01 40](https://github.com/user-attachments/assets/5cde8afb-c724-4ece-96f6-4c81de347dcc)

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [ ] unit-tested any new functionality
- [x] linked any relevant issues or PRs
