### PR TITLE
Adding vault balances to order details page

### DIFF
--- a/tauri-app/src/lib/components/ButtonVaultLink.svelte
+++ b/tauri-app/src/lib/components/ButtonVaultLink.svelte
@@ -2,25 +2,26 @@
   import { goto } from '$app/navigation';
   import type { Vault } from '$lib/typeshare/subgraphTypes';
   import { bigintStringToHex } from '$lib/utils/hex';
+  import { formatUnits } from 'viem';
 
   export let tokenVault: Vault;
 </script>
 
 <!-- svelte-ignore a11y-click-events-have-key-events -->
 <!-- svelte-ignore a11y-no-static-element-interactions -->
-<div
-  class="cursor-pointer hover:text-primary-600"
-  on:click={() => goto(`/vaults/${tokenVault.id}`)}
->
-  <div class="grid grid-cols-2 gap-x-2 break-normal">
-    <div>
-      {tokenVault.token.name} <span class="break-normal">({tokenVault.token.symbol})</span>
-    </div>
-    <div>
-      <span class="text-gray-500 dark:text-gray-400">ID</span>
-      <span class="mb-1 break-all">
-        {bigintStringToHex(tokenVault.vaultId)}
+<div class="cursor-pointer rounded-lg" on:click={() => goto(`/vaults/${tokenVault.id}`)}>
+  <div class="flex flex-col space-y-2">
+    <div class="flex items-center justify-between">
+      <span class="font-medium">{tokenVault.token.name} ({tokenVault.token.symbol})</span>
+      <span class="text-sm text-gray-500 dark:text-gray-400">
+        Balance: {formatUnits(
+          BigInt(tokenVault.balance),
+          parseInt(tokenVault.token.decimals || '18'),
+        )}
       </span>
+    </div>
+    <div class="text-sm text-gray-600 dark:text-gray-300">
+      ID: <span class="font-mono">{bigintStringToHex(tokenVault.vaultId)}</span>
     </div>
   </div>
 </div>

--- a/tauri-app/src/lib/components/detail/OrderDetail.svelte
+++ b/tauri-app/src/lib/components/detail/OrderDetail.svelte
@@ -68,18 +68,22 @@
       <CardProperty>
         <svelte:fragment slot="key">Input vaults</svelte:fragment>
         <svelte:fragment slot="value">
-          {#each data.order.inputs || [] as t}
-            <ButtonVaultLink tokenVault={t} />
-          {/each}
+          <div class="space-y-4">
+            {#each data.order.inputs || [] as t}
+              <ButtonVaultLink tokenVault={t} />
+            {/each}
+          </div>
         </svelte:fragment>
       </CardProperty>
 
       <CardProperty>
         <svelte:fragment slot="key">Output vaults</svelte:fragment>
         <svelte:fragment slot="value">
-          {#each data.order.outputs || [] as t}
-            <ButtonVaultLink tokenVault={t} />
-          {/each}
+          <div class="space-y-4">
+            {#each data.order.outputs || [] as t}
+              <ButtonVaultLink tokenVault={t} />
+            {/each}
+          </div>
         </svelte:fragment>
       </CardProperty>
     </div>

--- a/tauri-app/src/lib/components/detail/OrderDetail.test.ts
+++ b/tauri-app/src/lib/components/detail/OrderDetail.test.ts
@@ -7,6 +7,7 @@ import { mockIPC } from '@tauri-apps/api/mocks';
 import { mockOrderDetailsExtended } from '$lib/queries/orderDetail';
 import { handleOrderRemoveModal } from '$lib/services/modal';
 import { formatTimestampSecondsAsLocal } from '$lib/utils/time';
+import { formatUnits } from 'viem';
 
 const { mockWalletAddressMatchesOrBlankStore } = await vi.hoisted(
   () => import('$lib/mocks/wallets'),
@@ -138,8 +139,29 @@ test('shows the correct data when the query returns data with inputs and outputs
   });
 
   await waitFor(async () => {
-    expect(await screen.findAllByText('Token1')).toHaveLength(1);
-    expect(await screen.findAllByText('Token2')).toHaveLength(1);
+    // Check for input vaults
+    for (const input of mockData.order.inputs) {
+      expect(
+        await screen.findByText(`${input.token.name} (${input.token.symbol})`),
+      ).toBeInTheDocument();
+      expect(
+        await screen.findByText(
+          `Balance: ${formatUnits(BigInt(input.balance), parseInt(input.token.decimals || '18'))}`,
+        ),
+      ).toBeInTheDocument();
+    }
+
+    // Check for output vaults
+    for (const output of mockData.order.outputs) {
+      expect(
+        await screen.findByText(`${output.token.name} (${output.token.symbol})`),
+      ).toBeInTheDocument();
+      expect(
+        await screen.findByText(
+          `Balance: ${formatUnits(BigInt(output.balance), parseInt(output.token.decimals || '18'))}`,
+        ),
+      ).toBeInTheDocument();
+    }
   });
 });
 


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

See issue #814 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Added balance and updated UI.

### Vaults with a single token
![Screenshot 2024-09-10 at 10 27 24](https://github.com/user-attachments/assets/87fbfe11-d5ac-4afa-be26-e9b4a0c7a476)

### Vaults with multiple tokens (same for screenshot purposes)
![Screenshot 2024-09-10 at 10 26 44](https://github.com/user-attachments/assets/78281a20-f80f-40f9-99c6-6947dfbd3173)

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
