### PR TITLE
fix tauri command batch order quote bug

### DIFF
--- a/tauri-app/src-tauri/src/commands/order_quote.rs
+++ b/tauri-app/src-tauri/src/commands/order_quote.rs
@@ -1,7 +1,7 @@
 use crate::error::CommandResult;
 use alloy::primitives::{Address, U256};
 use alloy_ethers_typecast::transaction::ReadableClient;
-use rain_orderbook_bindings::IOrderBookV4::Quote;
+use rain_orderbook_bindings::IOrderBookV4::{OrderV3, Quote};
 use rain_orderbook_common::fuzz::{RainEvalResults, RainEvalResultsTable};
 use rain_orderbook_quote::{
     BatchQuoteTarget, NewQuoteDebugger, OrderQuoteValue, QuoteDebugger, QuoteTarget,
@@ -41,28 +41,48 @@ pub async fn batch_order_quotes(
     for order in &orders {
         let mut pairs: Vec<Pair> = Vec::new();
         let mut quote_targets: Vec<QuoteTarget> = Vec::new();
+        let order_struct: OrderV3 = order.clone().try_into()?;
         let orderbook = Address::from_str(&order.orderbook.id.0)?;
 
-        for (input_index, input) in order.inputs.iter().enumerate() {
-            for (output_index, output) in order.outputs.iter().enumerate() {
+        for (input_index, input) in order_struct.validInputs.iter().enumerate() {
+            for (output_index, output) in order_struct.validOutputs.iter().enumerate() {
                 let pair_name = format!(
                     "{}/{}",
-                    input.token.symbol.as_deref().unwrap_or("UNKNOWN"),
-                    output.token.symbol.as_deref().unwrap_or("UNKNOWN"),
+                    order
+                        .inputs
+                        .iter()
+                        .find_map(|v| {
+                            Address::from_str(&v.token.address.0).ok().and_then(|add| {
+                                add.eq(&input.token).then_some(
+                                    v.token.symbol.clone().unwrap_or("UNKNOWN".to_string()),
+                                )
+                            })
+                        })
+                        .unwrap_or("UNKNOWN".to_string()),
+                    order
+                        .outputs
+                        .iter()
+                        .find_map(|v| {
+                            Address::from_str(&v.token.address.0).ok().and_then(|add| {
+                                add.eq(&output.token).then_some(
+                                    v.token.symbol.clone().unwrap_or("UNKNOWN".to_string()),
+                                )
+                            })
+                        })
+                        .unwrap_or("UNKNOWN".to_string())
                 );
 
-                let quote = order.clone().try_into()?;
                 let quote_target = QuoteTarget {
                     orderbook,
                     quote_config: Quote {
-                        order: quote,
+                        order: order_struct.clone(),
                         inputIOIndex: U256::from(input_index),
                         outputIOIndex: U256::from(output_index),
                         signedContext: vec![],
                     },
                 };
 
-                if input.token.address.0 != output.token.address.0 {
+                if input.token != output.token {
                     pairs.push(Pair {
                         pair_name,
                         input_index: input_index as u32,
@@ -156,10 +176,11 @@ mod tests {
     use alloy::{
         hex::encode_prefixed,
         primitives::{utils::parse_ether, B256},
+        providers::Provider,
         sol_types::{SolCall, SolValue},
     };
     use rain_orderbook_common::{add_order::AddOrderArgs, dotrain_order::DotrainOrder};
-    use rain_orderbook_test_fixtures::LocalEvm;
+    use rain_orderbook_test_fixtures::{ContractTxHandler, LocalEvm};
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_debug_order_quote() {
@@ -261,7 +282,7 @@ amount price: 16 52;
             add_events: vec![],
             meta: None,
             timestamp_added: BigInt(0.to_string()),
-            trades: vec![]
+            trades: vec![],
         };
 
         let input_io_index = 0;
@@ -287,12 +308,16 @@ amount price: 16 52;
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_batch_order_quotes_block() {
-        let local_evm = LocalEvm::new_with_tokens(2).await;
+        let mut local_evm = LocalEvm::new().await;
 
-        let orderbook = &local_evm.orderbook;
         let token1_holder = local_evm.signer_wallets[0].default_signer().address();
-        let token1 = local_evm.tokens[0].clone();
-        let token2 = local_evm.tokens[1].clone();
+        let token1 = local_evm
+            .deploy_new_token("Token1", "Token1", 18, U256::MAX, token1_holder)
+            .await;
+        let token2 = local_evm
+            .deploy_new_token("Token2", "Token2", 18, U256::MAX, token1_holder)
+            .await;
+        let orderbook = &local_evm.orderbook;
 
         let dotrain = format!(
             r#"
@@ -324,9 +349,12 @@ orderbook:
 orders:
     some-key:
         inputs:
+            - token: t1
             - token: t2
         outputs:
             - token: t1
+              vault-id: 0x01
+            - token: t2
               vault-id: 0x01
 scenarios:
     some-key:
@@ -336,7 +364,7 @@ deployments:
         order: some-key
 ---
 #calculate-io
-amount price: 16 52;
+amount price: context<3 0>() context<4 0>();
 #handle-add-order
 :;
 #handle-io
@@ -359,13 +387,14 @@ amount price: 16 52;
             .unwrap()
             .abi_encode();
 
+        // deploy order and deposit in token 1 vault
         let order = encode_prefixed(
             local_evm
                 .add_order_and_deposit(
                     &calldata,
                     token1_holder,
                     *token1.address(),
-                    parse_ether("1000").unwrap(),
+                    U256::MAX,
                     U256::from(1),
                 )
                 .await
@@ -373,8 +402,39 @@ amount price: 16 52;
                 .order
                 .abi_encode(),
         );
+        // deposit in token2 vault
+        token2
+            .approve(*local_evm.orderbook.address(), U256::MAX)
+            .do_send(&local_evm)
+            .await
+            .unwrap();
+        local_evm
+            .orderbook
+            .deposit2(*token2.address(), U256::from(1), U256::MAX, vec![])
+            .do_send(&local_evm)
+            .await
+            .unwrap();
 
-        let inputs = vec![Vault {
+        let v1 = Vault {
+            id: Bytes(B256::random().to_string()),
+            token: Erc20 {
+                id: Bytes(token1.address().to_string()),
+                address: Bytes(token1.address().to_string()),
+                name: Some("Token1".to_string()),
+                symbol: Some("Token1".to_string()),
+                decimals: Some(BigInt(18.to_string())),
+            },
+            balance: BigInt("123".to_string()),
+            vault_id: BigInt(B256::random().to_string()),
+            owner: Bytes(local_evm.anvil.addresses()[0].to_string()),
+            orderbook: Orderbook {
+                id: Bytes(orderbook.address().to_string()),
+            },
+            orders_as_input: vec![],
+            orders_as_output: vec![],
+            balance_changes: vec![],
+        };
+        let v2 = Vault {
             id: Bytes(B256::random().to_string()),
             token: Erc20 {
                 id: Bytes(token2.address().to_string()),
@@ -392,27 +452,11 @@ amount price: 16 52;
             orders_as_input: vec![],
             orders_as_output: vec![],
             balance_changes: vec![],
-        }];
+        };
 
-        let outputs = vec![Vault {
-            id: Bytes(B256::random().to_string()),
-            token: Erc20 {
-                id: Bytes(token1.address().to_string()),
-                address: Bytes(token1.address().to_string()),
-                name: Some("Token1".to_string()),
-                symbol: Some("token1".to_string()),
-                decimals: Some(BigInt(18.to_string())),
-            },
-            balance: BigInt("123".to_string()),
-            vault_id: BigInt(B256::random().to_string()),
-            owner: Bytes(local_evm.anvil.addresses()[0].to_string()),
-            orderbook: Orderbook {
-                id: Bytes(orderbook.address().to_string()),
-            },
-            orders_as_input: vec![],
-            orders_as_output: vec![],
-            balance_changes: vec![],
-        }];
+        // does not follow the actuall original order's io
+        let inputs = vec![v2.clone(), v1.clone()];
+        let outputs = vec![v1.clone(), v2.clone()];
 
         let order = Order {
             id: Bytes(B256::random().to_string()),
@@ -428,7 +472,7 @@ amount price: 16 52;
             add_events: vec![],
             meta: None,
             timestamp_added: BigInt(0.to_string()),
-            trades: vec![]
+            trades: vec![],
         };
 
         let rpc_url = local_evm.url();
@@ -437,9 +481,39 @@ amount price: 16 52;
             .await
             .unwrap();
 
-        let quote = result[0].data.unwrap();
-
-        assert_eq!(quote.max_output, parse_ether("16").unwrap());
-        assert_eq!(quote.ratio, parse_ether("52").unwrap());
+        let t1_u256 = U256::from_str(&token1.address().to_string()).unwrap();
+        let t2_u256 = U256::from_str(&token2.address().to_string()).unwrap();
+        let block_number = U256::from(local_evm.provider.get_block_number().await.unwrap());
+        let expected = vec![
+            BatchOrderQuotesResponse {
+                pair: Pair {
+                    pair_name: "Token1/Token2".to_string(),
+                    input_index: 0,
+                    output_index: 1,
+                },
+                block_number,
+                data: Some(OrderQuoteValue {
+                    max_output: t1_u256,
+                    ratio: t2_u256,
+                }),
+                success: true,
+                error: None,
+            },
+            BatchOrderQuotesResponse {
+                pair: Pair {
+                    pair_name: "Token2/Token1".to_string(),
+                    input_index: 1,
+                    output_index: 0,
+                },
+                block_number,
+                data: Some(OrderQuoteValue {
+                    max_output: t2_u256,
+                    ratio: t1_u256,
+                }),
+                success: true,
+                error: None,
+            },
+        ];
+        assert_eq!(result, expected);
     }
 }


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation
resolves #853 
there is a bug that order of the retunred batch order quotes are incorrect, this PR fixes that
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
use decoded `order_bytes` of the returned sg `Order` struct to iterarte over `IO` to have correct indexes
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
