### PR TITLE
Order list refetching on remove order

### DIFF
--- a/tauri-app/src/lib/components/detail/OrderDetail.svelte
+++ b/tauri-app/src/lib/components/detail/OrderDetail.svelte
@@ -39,7 +39,12 @@
       <BadgeActive active={data.order.active} large />
     </div>
     {#if data.order && $walletAddressMatchesOrBlank(data.order.owner) && data.order.active}
-      <Button color="dark" on:click={() => handleOrderRemoveModal(data.order)}>Remove</Button>
+      <Button
+        color="dark"
+        on:click={() => handleOrderRemoveModal(data.order, $orderDetailQuery.refetch)}
+      >
+        Remove
+      </Button>
     {/if}
   </svelte:fragment>
   <svelte:fragment slot="card" let:data>

--- a/tauri-app/src/lib/components/detail/OrderDetail.test.ts
+++ b/tauri-app/src/lib/components/detail/OrderDetail.test.ts
@@ -194,6 +194,6 @@ test('shows remove button if owner wallet matches and order is active, opens cor
   screen.getByText('Remove').click();
 
   await waitFor(() => {
-    expect(handleOrderRemoveModal).toHaveBeenCalledWith(mockData.order);
+    expect(handleOrderRemoveModal).toHaveBeenCalledWith(mockData.order, expect.any(Function));
   });
 });

--- a/tauri-app/src/lib/components/modal/ModalOrderRemove.svelte
+++ b/tauri-app/src/lib/components/modal/ModalOrderRemove.svelte
@@ -7,15 +7,19 @@
   import { reportErrorToSentry } from '$lib/services/sentry';
   import { formatEthersTransactionError } from '$lib/utils/transaction';
   import type { Order as OrderDetailOrder } from '$lib/typeshare/subgraphTypes';
+  import { createEventDispatcher } from 'svelte';
 
   let openOrderRemoveModal = true;
   export let order: OrderDetailOrder;
   let isSubmitting = false;
 
+  const dispatch = createEventDispatcher();
+
   async function executeLedger() {
     isSubmitting = true;
     try {
       await orderRemove(order.id);
+      dispatch('orderRemoved');
     } catch (e) {
       reportErrorToSentry(e);
     }
@@ -28,6 +32,7 @@
       const tx = await ethersExecute(calldata, $orderbookAddress!);
       toasts.success('Transaction sent successfully!');
       await tx.wait(1);
+      dispatch('orderRemoved');
     } catch (e) {
       reportErrorToSentry(e);
       toasts.error(formatEthersTransactionError(e));

--- a/tauri-app/src/lib/components/modal/ModalOrderRemove.svelte
+++ b/tauri-app/src/lib/components/modal/ModalOrderRemove.svelte
@@ -7,19 +7,17 @@
   import { reportErrorToSentry } from '$lib/services/sentry';
   import { formatEthersTransactionError } from '$lib/utils/transaction';
   import type { Order as OrderDetailOrder } from '$lib/typeshare/subgraphTypes';
-  import { createEventDispatcher } from 'svelte';
 
   let openOrderRemoveModal = true;
   export let order: OrderDetailOrder;
   let isSubmitting = false;
-
-  const dispatch = createEventDispatcher();
+  export let onOrderRemoved: (() => void) | undefined;
 
   async function executeLedger() {
     isSubmitting = true;
     try {
       await orderRemove(order.id);
-      dispatch('orderRemoved');
+      if (onOrderRemoved) onOrderRemoved();
     } catch (e) {
       reportErrorToSentry(e);
     }
@@ -32,7 +30,7 @@
       const tx = await ethersExecute(calldata, $orderbookAddress!);
       toasts.success('Transaction sent successfully!');
       await tx.wait(1);
-      dispatch('orderRemoved');
+      if (onOrderRemoved) onOrderRemoved();
     } catch (e) {
       reportErrorToSentry(e);
       toasts.error(formatEthersTransactionError(e));

--- a/tauri-app/src/lib/components/modal/ModalOrderRemove.svelte
+++ b/tauri-app/src/lib/components/modal/ModalOrderRemove.svelte
@@ -11,13 +11,13 @@
   let openOrderRemoveModal = true;
   export let order: OrderDetailOrder;
   let isSubmitting = false;
-  export let onOrderRemoved: (() => void) | undefined;
+  export let onOrderRemoved: () => void;
 
   async function executeLedger() {
     isSubmitting = true;
     try {
       await orderRemove(order.id);
-      if (onOrderRemoved) onOrderRemoved();
+      onOrderRemoved();
     } catch (e) {
       reportErrorToSentry(e);
     }
@@ -30,7 +30,7 @@
       const tx = await ethersExecute(calldata, $orderbookAddress!);
       toasts.success('Transaction sent successfully!');
       await tx.wait(1);
-      if (onOrderRemoved) onOrderRemoved();
+      onOrderRemoved();
     } catch (e) {
       reportErrorToSentry(e);
       toasts.error(formatEthersTransactionError(e));

--- a/tauri-app/src/lib/components/tables/OrdersListTable.svelte
+++ b/tauri-app/src/lib/components/tables/OrdersListTable.svelte
@@ -125,7 +125,7 @@
           <DropdownItem
             on:click={(e) => {
               e.stopPropagation();
-              handleOrderRemoveModal(item);
+              handleOrderRemoveModal(item, $query.refetch);
             }}>Remove</DropdownItem
           >
         </Dropdown>

--- a/tauri-app/src/lib/components/tables/OrdersListTable.test.ts
+++ b/tauri-app/src/lib/components/tables/OrdersListTable.test.ts
@@ -265,6 +265,6 @@ test('clicking the remove option in the dropdown menu opens the remove modal', a
   });
 
   await waitFor(() => {
-    expect(handleOrderRemoveModal).toHaveBeenCalledWith(mockOrders[0]);
+    expect(handleOrderRemoveModal).toHaveBeenCalledWith(mockOrders[0], expect.any(Function));
   });
 });

--- a/tauri-app/src/lib/services/modal.ts
+++ b/tauri-app/src/lib/services/modal.ts
@@ -23,7 +23,7 @@ export const handleWithdrawModal = (vault: Vault) => {
 
 export const handleOrderRemoveModal = (
   order: OrderDetailOrder | OrderListOrder,
-  onOrderRemoved?: () => void,
+  onOrderRemoved: () => void,
 ) => {
   new ModalOrderRemove({ target: document.body, props: { order, onOrderRemoved } });
 };

--- a/tauri-app/src/lib/services/modal.ts
+++ b/tauri-app/src/lib/services/modal.ts
@@ -21,8 +21,15 @@ export const handleWithdrawModal = (vault: Vault) => {
   new ModalVaultWithdraw({ target: document.body, props: { open: true, vault } });
 };
 
-export const handleOrderRemoveModal = (order: OrderDetailOrder | OrderListOrder) => {
-  new ModalOrderRemove({ target: document.body, props: { order } });
+export const handleOrderRemoveModal = (
+  order: OrderDetailOrder | OrderListOrder,
+  callback?: () => void,
+) => {
+  const modal = new ModalOrderRemove({ target: document.body, props: { order } });
+  modal.$on('orderRemoved', () => {
+    if (callback) callback();
+  });
+  return modal;
 };
 
 export const handleDebugTradeModal = (txHash: string, rpcUrl: string) => {

--- a/tauri-app/src/lib/services/modal.ts
+++ b/tauri-app/src/lib/services/modal.ts
@@ -23,13 +23,9 @@ export const handleWithdrawModal = (vault: Vault) => {
 
 export const handleOrderRemoveModal = (
   order: OrderDetailOrder | OrderListOrder,
-  callback?: () => void,
+  onOrderRemoved?: () => void,
 ) => {
-  const modal = new ModalOrderRemove({ target: document.body, props: { order } });
-  modal.$on('orderRemoved', () => {
-    if (callback) callback();
-  });
-  return modal;
+  new ModalOrderRemove({ target: document.body, props: { order, onOrderRemoved } });
 };
 
 export const handleDebugTradeModal = (txHash: string, rpcUrl: string) => {


### PR DESCRIPTION
Closes #851

<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

See issue: #851

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

- Dispatched `orderRemoved` event after a successful transaction.
- On event listener add a custom callback function to be called
- Call `query.refetch` using the callback to get the new list of orders - removed order will be inactive

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [ ] unit-tested any new functionality
- [x] linked any relevant issues or PRs
