### PR TITLE
Add inverse io ratio to trades list table

### DIFF
--- a/tauri-app/src/lib/components/tables/OrderTradesListTable.svelte
+++ b/tauri-app/src/lib/components/tables/OrderTradesListTable.svelte
@@ -36,7 +36,8 @@
     <TableHeadCell padding="p-0">Transaction Hash</TableHeadCell>
     <TableHeadCell padding="p-0">Input</TableHeadCell>
     <TableHeadCell padding="p-0">Output</TableHeadCell>
-    <TableHeadCell padding="p-0">IO Ratio</TableHeadCell>
+    <TableHeadCell padding="p-0">Input/Output Ratio</TableHeadCell>
+    <TableHeadCell padding="p-0">Output/Input Ratio</TableHeadCell>
     <TableHeadCell padding="p-0"></TableHeadCell>
   </svelte:fragment>
 
@@ -64,7 +65,7 @@
       )}
       {item.outputVaultBalanceChange.vault.token.symbol}
     </TableBodyCell>
-    <TableBodyCell tdClass="break-all py-2" data-testid="io-ratio">
+    <TableBodyCell tdClass="break-all py-2" data-testid="input-output-ratio">
       {Math.abs(
         Number(
           formatUnits(
@@ -79,8 +80,22 @@
             ),
           ),
       )}
-      {item.inputVaultBalanceChange.vault.token.symbol}/{item.outputVaultBalanceChange.vault.token
-        .symbol}
+    </TableBodyCell>
+    <TableBodyCell tdClass="break-all py-2" data-testid="output-input-ratio">
+      {Math.abs(
+        Number(
+          formatUnits(
+            BigInt(item.outputVaultBalanceChange.amount),
+            Number(item.outputVaultBalanceChange.vault.token.decimals ?? 0),
+          ),
+        ) /
+          Number(
+            formatUnits(
+              BigInt(item.inputVaultBalanceChange.amount),
+              Number(item.inputVaultBalanceChange.vault.token.decimals ?? 0),
+            ),
+          ),
+      )}
     </TableBodyCell>
     <TableBodyCell tdClass="py-2">
       <button

--- a/tauri-app/src/lib/components/tables/OrderTradesListTable.test.ts
+++ b/tauri-app/src/lib/components/tables/OrderTradesListTable.test.ts
@@ -190,8 +190,8 @@ test('renders table with correct data', async () => {
   });
 
   await waitFor(async () => {
-    // get all the io ratios
-    const rows = screen.getAllByTestId('io-ratio');
+    const inputOutputRatios = screen.getAllByTestId('input-output-ratio');
+    const outputInputRatios = screen.getAllByTestId('output-input-ratio');
 
     // checking the io ratios
     for (let i = 0; i < mockTakeOrdersList.length; i++) {
@@ -203,8 +203,10 @@ test('renders table with correct data', async () => {
         BigInt(mockTakeOrdersList[i].outputVaultBalanceChange.amount),
         Number(mockTakeOrdersList[i].outputVaultBalanceChange.vault.token.decimals),
       );
-      const expectedRatio = Number(inputDisplay) / Number(outputDisplay);
-      expect(rows[i]).toHaveTextContent(expectedRatio.toString());
+      const expectedInputOutputRatio = Math.abs(Number(inputDisplay) / Number(outputDisplay));
+      const expectedOutputInputRatio = Math.abs(Number(outputDisplay) / Number(inputDisplay));
+      expect(inputOutputRatios[i]).toHaveTextContent(expectedInputOutputRatio.toString());
+      expect(outputInputRatios[i]).toHaveTextContent(expectedOutputInputRatio.toString());
     }
   });
 });


### PR DESCRIPTION
Closes #864

<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

See issue: #864

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

- Added a new column for the table
- Updated the column naming to `input/output ratio` and `output/input ratio`
- Removed the token names from ratio values as they took up too much space on the table

<img width="1196" alt="Screenshot 2024-09-18 at 15 31 43" src="https://github.com/user-attachments/assets/44d2b893-7703-4dbd-9c93-ba77db0eecdc">

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
