### PR TITLE
Update IO ratio UI in trades list

### DIFF
--- a/tauri-app/src/lib/components/tables/OrderTradesListTable.svelte
+++ b/tauri-app/src/lib/components/tables/OrderTradesListTable.svelte
@@ -36,8 +36,7 @@
     <TableHeadCell padding="p-0">Transaction Hash</TableHeadCell>
     <TableHeadCell padding="p-0">Input</TableHeadCell>
     <TableHeadCell padding="p-0">Output</TableHeadCell>
-    <TableHeadCell padding="p-0">Input/Output Ratio</TableHeadCell>
-    <TableHeadCell padding="p-0">Output/Input Ratio</TableHeadCell>
+    <TableHeadCell padding="p-0">IO Ratio</TableHeadCell>
     <TableHeadCell padding="p-0"></TableHeadCell>
   </svelte:fragment>
 
@@ -65,7 +64,7 @@
       )}
       {item.outputVaultBalanceChange.vault.token.symbol}
     </TableBodyCell>
-    <TableBodyCell tdClass="break-all py-2" data-testid="input-output-ratio">
+    <TableBodyCell tdClass="break-all py-2" data-testid="io-ratio">
       {Math.abs(
         Number(
           formatUnits(
@@ -80,22 +79,22 @@
             ),
           ),
       )}
-    </TableBodyCell>
-    <TableBodyCell tdClass="break-all py-2" data-testid="output-input-ratio">
-      {Math.abs(
-        Number(
-          formatUnits(
-            BigInt(item.outputVaultBalanceChange.amount),
-            Number(item.outputVaultBalanceChange.vault.token.decimals ?? 0),
-          ),
-        ) /
+      <span class="text-gray-400">
+        ({Math.abs(
           Number(
             formatUnits(
-              BigInt(item.inputVaultBalanceChange.amount),
-              Number(item.inputVaultBalanceChange.vault.token.decimals ?? 0),
+              BigInt(item.outputVaultBalanceChange.amount),
+              Number(item.outputVaultBalanceChange.vault.token.decimals ?? 0),
             ),
-          ),
-      )}
+          ) /
+            Number(
+              formatUnits(
+                BigInt(item.inputVaultBalanceChange.amount),
+                Number(item.inputVaultBalanceChange.vault.token.decimals ?? 0),
+              ),
+            ),
+        )})
+      </span>
     </TableBodyCell>
     <TableBodyCell tdClass="py-2">
       <button

--- a/tauri-app/src/lib/components/tables/OrderTradesListTable.test.ts
+++ b/tauri-app/src/lib/components/tables/OrderTradesListTable.test.ts
@@ -190,8 +190,8 @@ test('renders table with correct data', async () => {
   });
 
   await waitFor(async () => {
-    const inputOutputRatios = screen.getAllByTestId('input-output-ratio');
-    const outputInputRatios = screen.getAllByTestId('output-input-ratio');
+    // get all the io ratios
+    const rows = screen.getAllByTestId('io-ratio');
 
     // checking the io ratios
     for (let i = 0; i < mockTakeOrdersList.length; i++) {
@@ -203,10 +203,10 @@ test('renders table with correct data', async () => {
         BigInt(mockTakeOrdersList[i].outputVaultBalanceChange.amount),
         Number(mockTakeOrdersList[i].outputVaultBalanceChange.vault.token.decimals),
       );
-      const expectedInputOutputRatio = Math.abs(Number(inputDisplay) / Number(outputDisplay));
-      const expectedOutputInputRatio = Math.abs(Number(outputDisplay) / Number(inputDisplay));
-      expect(inputOutputRatios[i]).toHaveTextContent(expectedInputOutputRatio.toString());
-      expect(outputInputRatios[i]).toHaveTextContent(expectedOutputInputRatio.toString());
+      const ioRatio = Number(inputDisplay) / Number(outputDisplay);
+      const oiRatio = Number(outputDisplay) / Number(inputDisplay);
+      expect(rows[i]).toHaveTextContent(ioRatio.toString());
+      expect(rows[i]).toHaveTextContent(oiRatio.toString());
     }
   });
 });


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

To have a unified IO ratio and inverse ratio display in the application.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

- Updated the table to have 1 column - IO ratio
- Displayed inverse ratio next to the io ratio value

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
