### PR TITLE
Add zero check for division error on order quotes table

### DIFF
--- a/tauri-app/src/lib/components/detail/TanstackOrderQuote.svelte
+++ b/tauri-app/src/lib/components/detail/TanstackOrderQuote.svelte
@@ -103,7 +103,9 @@
               <TableBodyCell
                 >{formatUnits(BigInt(item.data.ratio), 18)}
                 <span class="text-gray-400"
-                  >({formatUnits(10n ** 36n / BigInt(item.data.ratio), 18)})</span
+                  >({BigInt(item.data.ratio) > 0n
+                    ? formatUnits(10n ** 36n / BigInt(item.data.ratio), 18)
+                    : '0'})</span
                 ></TableBodyCell
               >
               <TableBodyCell


### PR DESCRIPTION
Closes #875
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

See issue: #875

The quote IO ratio was 0 in the response and this was causing the division by zero error.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

- Add a zero check for the division operation

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
