### PR TITLE
Remove build steps from yaml testing packages

### DIFF
--- a/.github/workflows/test-ui-components.yaml
+++ b/.github/workflows/test-ui-components.yaml
@@ -15,18 +15,6 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/magic-nix-cache-action@main
 
-      - run: nix develop -c rainix-sol-prelude
-        working-directory: lib/rain.interpreter
-      - run: nix develop -c rainix-rs-prelude
-        working-directory: lib/rain.interpreter
-      - run: nix develop -c rainix-sol-prelude
-        working-directory: lib/rain.interpreter/lib/rain.metadata
-      - run: nix develop -c rainix-rs-prelude
-        working-directory: lib/rain.interpreter/lib/rain.metadata
-      - run: nix develop -c rainix-sol-prelude
-      - run: nix develop -c rainix-rs-prelude
-      - run: nix develop -c raindex-prelude
-      - run: nix develop -c npm run build
       - run: nix develop -c bash -c "cd packages/ui-components && npm run test"
 
   lint:
@@ -42,16 +30,4 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/magic-nix-cache-action@main
 
-      - run: nix develop -c rainix-sol-prelude
-        working-directory: lib/rain.interpreter
-      - run: nix develop -c rainix-rs-prelude
-        working-directory: lib/rain.interpreter
-      - run: nix develop -c rainix-sol-prelude
-        working-directory: lib/rain.interpreter/lib/rain.metadata
-      - run: nix develop -c rainix-rs-prelude
-        working-directory: lib/rain.interpreter/lib/rain.metadata
-      - run: nix develop -c rainix-sol-prelude
-      - run: nix develop -c rainix-rs-prelude
-      - run: nix develop -c raindex-prelude
-      - run: nix develop -c npm run build
       - run: nix develop -c bash -c "cd packages/ui-components && npm run svelte-lint-format-check"

--- a/.github/workflows/test-webapp.yaml
+++ b/.github/workflows/test-webapp.yaml
@@ -15,6 +15,18 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/magic-nix-cache-action@main
 
+      - run: nix develop -c rainix-sol-prelude
+        working-directory: lib/rain.interpreter
+      - run: nix develop -c rainix-rs-prelude
+        working-directory: lib/rain.interpreter
+      - run: nix develop -c rainix-sol-prelude
+        working-directory: lib/rain.interpreter/lib/rain.metadata
+      - run: nix develop -c rainix-rs-prelude
+        working-directory: lib/rain.interpreter/lib/rain.metadata
+      - run: nix develop -c rainix-sol-prelude
+      - run: nix develop -c rainix-rs-prelude
+      - run: nix develop -c raindex-prelude
+      - run: nix develop -c npm run build
       - run: nix develop -c bash -c "cd packages/webapp && npm run test"
 
   lint:
@@ -29,5 +41,17 @@ jobs:
 
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/magic-nix-cache-action@main
-      
+
+      - run: nix develop -c rainix-sol-prelude
+        working-directory: lib/rain.interpreter
+      - run: nix develop -c rainix-rs-prelude
+        working-directory: lib/rain.interpreter
+      - run: nix develop -c rainix-sol-prelude
+        working-directory: lib/rain.interpreter/lib/rain.metadata
+      - run: nix develop -c rainix-rs-prelude
+        working-directory: lib/rain.interpreter/lib/rain.metadata
+      - run: nix develop -c rainix-sol-prelude
+      - run: nix develop -c rainix-rs-prelude
+      - run: nix develop -c raindex-prelude
+      - run: nix develop -c npm run build
       - run: nix develop -c bash -c "cd packages/webapp && npm run svelte-lint-format-check"

--- a/.github/workflows/test-webapp.yaml
+++ b/.github/workflows/test-webapp.yaml
@@ -15,18 +15,6 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/magic-nix-cache-action@main
 
-      - run: nix develop -c rainix-sol-prelude
-        working-directory: lib/rain.interpreter
-      - run: nix develop -c rainix-rs-prelude
-        working-directory: lib/rain.interpreter
-      - run: nix develop -c rainix-sol-prelude
-        working-directory: lib/rain.interpreter/lib/rain.metadata
-      - run: nix develop -c rainix-rs-prelude
-        working-directory: lib/rain.interpreter/lib/rain.metadata
-      - run: nix develop -c rainix-sol-prelude
-      - run: nix develop -c rainix-rs-prelude
-      - run: nix develop -c raindex-prelude
-      - run: nix develop -c npm run build
       - run: nix develop -c bash -c "cd packages/webapp && npm run test"
 
   lint:
@@ -41,17 +29,5 @@ jobs:
 
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/magic-nix-cache-action@main
-
-      - run: nix develop -c rainix-sol-prelude
-        working-directory: lib/rain.interpreter
-      - run: nix develop -c rainix-rs-prelude
-        working-directory: lib/rain.interpreter
-      - run: nix develop -c rainix-sol-prelude
-        working-directory: lib/rain.interpreter/lib/rain.metadata
-      - run: nix develop -c rainix-rs-prelude
-        working-directory: lib/rain.interpreter/lib/rain.metadata
-      - run: nix develop -c rainix-sol-prelude
-      - run: nix develop -c rainix-rs-prelude
-      - run: nix develop -c raindex-prelude
-      - run: nix develop -c npm run build
+      
       - run: nix develop -c bash -c "cd packages/webapp && npm run svelte-lint-format-check"


### PR DESCRIPTION
This pull request includes changes to the GitHub workflows for testing UI components and the web application. The changes simplify the workflows by removing redundant `nix develop` commands and consolidating the remaining commands.

Simplification of GitHub workflows:

* [`.github/workflows/test-ui-components.yaml`](diffhunk://#diff-280e1469aa93d7329387754e1402da34164af0730358d09a6f18581fa856948aL18-L29): Removed multiple redundant `nix develop` commands and consolidated the remaining commands to streamline the workflow. [[1]](diffhunk://#diff-280e1469aa93d7329387754e1402da34164af0730358d09a6f18581fa856948aL18-L29) [[2]](diffhunk://#diff-280e1469aa93d7329387754e1402da34164af0730358d09a6f18581fa856948aL45-L56)

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [x] included screenshots (if this involves a front-end change)
