### PR TITLE
sg bug

### DIFF
--- a/subgraph/src/clear.ts
+++ b/subgraph/src/clear.ts
@@ -35,7 +35,7 @@ export function makeClearBountyId(
   vaultEntityId: Bytes
 ): Bytes {
   return Bytes.fromByteArray(
-    crypto.keccak256(eventId(event).concat(vaultEntityId))
+    crypto.keccak256(vaultEntityId.concat(eventId(event)))
   );
 }
 

--- a/subgraph/tests/tradevaultbalancechange.test.ts
+++ b/subgraph/tests/tradevaultbalancechange.test.ts
@@ -8,7 +8,12 @@ import {
   assert,
 } from "matchstick-as";
 import { BigInt, Address, Bytes, crypto } from "@graphprotocol/graph-ts";
-import { Evaluable, IO, createTakeOrderEvent } from "./event-mocks.test";
+import {
+  Evaluable,
+  IO,
+  createAfterClearEvent,
+  createTakeOrderEvent,
+} from "./event-mocks.test";
 import { eventId } from "../src/interfaces/event";
 import {
   createTradeVaultBalanceChangeEntity,
@@ -18,6 +23,7 @@ import { vaultEntityId } from "../src/vault";
 import { orderHashFromTakeOrderEvent } from "../src/takeorder";
 import { makeTradeId } from "../src/trade";
 import { createMockERC20Functions } from "./erc20.test";
+import { makeClearBountyId } from "../src/clear";
 
 describe("Deposits", () => {
   afterEach(() => {
@@ -135,5 +141,29 @@ describe("Deposits", () => {
       "transaction",
       event.transaction.hash.toHex()
     );
+  });
+
+  test("TradeVaultBalanceChangeEntity id should not be equal to ClearBounty id", () => {
+    const alice = Address.fromString(
+      "0x850c40aBf6e325231ba2DeD1356d1f2c267e63Ce"
+    );
+    let aliceOutputAmount = BigInt.fromString("10");
+    let bobOutputAmount = BigInt.fromString("20");
+    let aliceInputAmount = BigInt.fromString("15");
+    let bobInputAmount = BigInt.fromString("10");
+    let vaultEntityId = Bytes.fromHexString(
+      "0x1234567890abcdef1234567890abcdef12345678"
+    );
+    let event = createAfterClearEvent(
+      alice,
+      aliceOutputAmount,
+      bobOutputAmount,
+      aliceInputAmount,
+      bobInputAmount
+    );
+    const id1 = tradeVaultBalanceChangeId(event, vaultEntityId);
+    const id2 = makeClearBountyId(event, vaultEntityId);
+
+    assert.assertTrue(id1 !== id2);
   });
 });


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation
fixes #1073 
this bug happens when a sender tries to clear2() his own order against another and pass in the same vaultid for the bounty as the vaultid of his order that is being cleared, this causes 2 sg entities that generate id, generate the same id as they both have similar fn logic,
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
change the logic for id generation of clearBounty
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)
