### PR TITLE
Implementing metaboards in OrderbookYaml

### DIFF
--- a/crates/settings/src/lib.rs
+++ b/crates/settings/src/lib.rs
@@ -6,6 +6,7 @@ pub mod deployer;
 pub mod deployment;
 pub mod gui;
 pub mod merge;
+pub mod metaboard;
 pub mod network;
 pub mod order;
 pub mod orderbook;

--- a/crates/settings/src/metaboard.rs
+++ b/crates/settings/src/metaboard.rs
@@ -1,25 +1,35 @@
-use crate::config::Metaboard;
 use crate::yaml::{require_hash, require_string, YamlError, YamlParsableHash};
+use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
     sync::{Arc, RwLock},
 };
 use strict_yaml_rust::StrictYaml;
+use typeshare::typeshare;
 use url::{ParseError, Url};
 
-#[derive(Clone, Debug)]
-pub struct YamlMetaboard(Metaboard);
+#[typeshare]
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "kebab-case")]
+#[serde(default)]
+pub struct Metaboard {
+    #[serde(skip)]
+    pub document: Arc<RwLock<StrictYaml>>,
+    pub key: String,
+    #[typeshare(typescript(type = "string"))]
+    pub url: Url,
+}
 
-impl YamlMetaboard {
+impl Metaboard {
     pub fn validate_url(value: &str) -> Result<Url, ParseError> {
         Url::parse(value)
     }
 }
 
-impl YamlParsableHash for YamlMetaboard {
+impl YamlParsableHash for Metaboard {
     fn parse_all_from_yaml(
         document: Arc<RwLock<StrictYaml>>,
-    ) -> Result<HashMap<String, YamlMetaboard>, YamlError> {
+    ) -> Result<HashMap<String, Metaboard>, YamlError> {
         let document_read = document.read().map_err(|_| YamlError::ReadLockError)?;
         let metaboards_hash = require_hash(
             &document_read,
@@ -32,7 +42,7 @@ impl YamlParsableHash for YamlMetaboard {
             .map(|(key_yaml, metaboard_yaml)| {
                 let metaboard_key = key_yaml.as_str().unwrap_or_default().to_string();
 
-                let url = YamlMetaboard::validate_url(&require_string(
+                let url = Metaboard::validate_url(&require_string(
                     metaboard_yaml,
                     None,
                     Some(format!(
@@ -40,21 +50,31 @@ impl YamlParsableHash for YamlMetaboard {
                     )),
                 )?)?;
 
-                Ok((metaboard_key, YamlMetaboard(url)))
+                let metaboard = Metaboard {
+                    document: document.clone(),
+                    key: metaboard_key.clone(),
+                    url,
+                };
+
+                Ok((metaboard_key, metaboard))
             })
             .collect()
     }
 }
 
-impl From<Metaboard> for YamlMetaboard {
-    fn from(value: Metaboard) -> Self {
-        YamlMetaboard(value)
+impl Default for Metaboard {
+    fn default() -> Self {
+        Self {
+            document: Arc::new(RwLock::new(StrictYaml::String("".to_string()))),
+            key: "".to_string(),
+            url: Url::parse("https://metaboard.com").unwrap(),
+        }
     }
 }
 
-impl From<YamlMetaboard> for Metaboard {
-    fn from(value: YamlMetaboard) -> Self {
-        value.0
+impl PartialEq for Metaboard {
+    fn eq(&self, other: &Self) -> bool {
+        self.key == other.key && self.url == other.url
     }
 }
 
@@ -68,7 +88,7 @@ mod test {
         let yaml = r#"
 test: test
 "#;
-        let error = YamlMetaboard::parse_all_from_yaml(get_document(yaml)).unwrap_err();
+        let error = Metaboard::parse_all_from_yaml(get_document(yaml)).unwrap_err();
         assert_eq!(
             error,
             YamlError::ParseError("missing field: metaboards".to_string())
@@ -79,7 +99,7 @@ metaboards:
     TestMetaboard:
         test: https://metaboard.com
 "#;
-        let error = YamlMetaboard::parse_all_from_yaml(get_document(yaml)).unwrap_err();
+        let error = Metaboard::parse_all_from_yaml(get_document(yaml)).unwrap_err();
         assert_eq!(
             error,
             YamlError::ParseError(
@@ -92,7 +112,7 @@ metaboards:
     TestMetaboard:
         - https://metaboard.com
 "#;
-        let error = YamlMetaboard::parse_all_from_yaml(get_document(yaml)).unwrap_err();
+        let error = Metaboard::parse_all_from_yaml(get_document(yaml)).unwrap_err();
         assert_eq!(
             error,
             YamlError::ParseError(
@@ -102,10 +122,9 @@ metaboards:
 
         let yaml = r#"
 metaboards:
-    TestMetaboard: https://metaboard.com
+    TestMetaboard: invalid-url
 "#;
-        let result = YamlMetaboard::parse_all_from_yaml(get_document(yaml)).unwrap();
-        assert_eq!(result.len(), 1);
-        assert!(result.contains_key("TestMetaboard"));
+        let res = Metaboard::parse_all_from_yaml(get_document(yaml));
+        assert!(res.is_err());
     }
 }

--- a/crates/settings/src/metaboard.rs
+++ b/crates/settings/src/metaboard.rs
@@ -1,0 +1,63 @@
+use crate::config::Metaboard;
+use crate::yaml::{require_hash, require_string, YamlError, YamlParsableHash};
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock},
+};
+use strict_yaml_rust::StrictYaml;
+use url::{ParseError, Url};
+
+// Wrapper type just for YAML parsing
+#[derive(Clone)]
+pub struct YamlMetaboard(Metaboard);
+
+impl YamlMetaboard {
+    pub fn metaboard(&self) -> &Metaboard {
+        &self.0
+    }
+
+    pub fn validate_url(value: &str) -> Result<Url, ParseError> {
+        Url::parse(value)
+    }
+}
+
+impl YamlParsableHash for YamlMetaboard {
+    fn parse_all_from_yaml(
+        document: Arc<RwLock<StrictYaml>>,
+    ) -> Result<HashMap<String, YamlMetaboard>, YamlError> {
+        let document_read = document.read().map_err(|_| YamlError::ReadLockError)?;
+        let metaboards_hash = require_hash(
+            &document_read,
+            Some("metaboards"),
+            Some("missing field: metaboards".to_string()),
+        )?;
+
+        metaboards_hash
+            .iter()
+            .map(|(key_yaml, metaboard_yaml)| {
+                let metaboard_key = key_yaml.as_str().unwrap_or_default().to_string();
+
+                let url = YamlMetaboard::validate_url(&require_string(
+                    metaboard_yaml,
+                    None,
+                    Some(format!(
+                        "metaboard value must be a string for key: {metaboard_key}"
+                    )),
+                )?)?;
+
+                Ok((metaboard_key, YamlMetaboard(url)))
+            })
+            .collect()
+    }
+}
+
+impl From<Metaboard> for YamlMetaboard {
+    fn from(value: Metaboard) -> Self {
+        YamlMetaboard(value)
+    }
+}
+impl From<YamlMetaboard> for Metaboard {
+    fn from(value: YamlMetaboard) -> Self {
+        value.0
+    }
+}

--- a/crates/settings/src/orderbook.rs
+++ b/crates/settings/src/orderbook.rs
@@ -6,6 +6,7 @@ use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::{Arc, RwLock};
 use strict_yaml_rust::StrictYaml;
+use subgraph::YamlSubgraph;
 use thiserror::Error;
 use typeshare::typeshare;
 use yaml::{optional_string, require_hash, require_string, YamlError, YamlParsableHash};
@@ -67,7 +68,8 @@ impl YamlParsableHash for Orderbook {
                     Some(subgraph_name) => subgraph_name,
                     None => orderbook_key.clone(),
                 };
-                let subgraph = Subgraph::parse_from_yaml(document.clone(), &subgraph_name)?;
+                let subgraph = YamlSubgraph::parse_from_yaml(document.clone(), &subgraph_name)?;
+                let subgraph = Arc::new(subgraph.into());
 
                 let label = optional_string(orderbook_yaml, "label");
 
@@ -76,7 +78,7 @@ impl YamlParsableHash for Orderbook {
                     key: orderbook_key.clone(),
                     address,
                     network: Arc::new(network),
-                    subgraph: Arc::new(subgraph),
+                    subgraph,
                     label,
                 };
 

--- a/crates/settings/src/orderbook.rs
+++ b/crates/settings/src/orderbook.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::{Arc, RwLock};
 use strict_yaml_rust::StrictYaml;
-use subgraph::YamlSubgraph;
+use subgraph::Subgraph;
 use thiserror::Error;
 use typeshare::typeshare;
 use yaml::{optional_string, require_hash, require_string, YamlError, YamlParsableHash};
@@ -68,8 +68,8 @@ impl YamlParsableHash for Orderbook {
                     Some(subgraph_name) => subgraph_name,
                     None => orderbook_key.clone(),
                 };
-                let subgraph = YamlSubgraph::parse_from_yaml(document.clone(), &subgraph_name)?;
-                let subgraph = Arc::new(subgraph.into());
+                let subgraph =
+                    Arc::new(Subgraph::parse_from_yaml(document.clone(), &subgraph_name)?);
 
                 let label = optional_string(orderbook_yaml, "label");
 
@@ -95,7 +95,7 @@ impl Default for Orderbook {
             key: "".to_string(),
             address: Address::ZERO,
             network: Arc::new(Network::default()),
-            subgraph: Arc::new(Subgraph::parse("https://subgraph.com").unwrap()),
+            subgraph: Arc::new(Subgraph::default()),
             label: None,
         }
     }

--- a/crates/settings/src/subgraph.rs
+++ b/crates/settings/src/subgraph.rs
@@ -5,12 +5,21 @@ use std::{
     sync::{Arc, RwLock},
 };
 use strict_yaml_rust::StrictYaml;
-use url::Url;
+use url::{ParseError, Url};
 
-impl YamlParsableHash for Subgraph {
+#[derive(Clone, Debug)]
+pub struct YamlSubgraph(Subgraph);
+
+impl YamlSubgraph {
+    pub fn validate_url(value: &str) -> Result<Url, ParseError> {
+        Url::parse(value)
+    }
+}
+
+impl YamlParsableHash for YamlSubgraph {
     fn parse_all_from_yaml(
         document: Arc<RwLock<StrictYaml>>,
-    ) -> Result<HashMap<String, Url>, YamlError> {
+    ) -> Result<HashMap<String, YamlSubgraph>, YamlError> {
         let document_read = document.read().map_err(|_| YamlError::ReadLockError)?;
         let subgraphs_hash = require_hash(
             &document_read,
@@ -23,7 +32,7 @@ impl YamlParsableHash for Subgraph {
             .map(|(key_yaml, subgraph_yaml)| {
                 let subgraph_key = key_yaml.as_str().unwrap_or_default().to_string();
 
-                let url = Url::parse(&require_string(
+                let url = YamlSubgraph::validate_url(&require_string(
                     subgraph_yaml,
                     None,
                     Some(format!(
@@ -31,9 +40,21 @@ impl YamlParsableHash for Subgraph {
                     )),
                 )?)?;
 
-                Ok((subgraph_key, url))
+                Ok((subgraph_key, YamlSubgraph(url)))
             })
             .collect()
+    }
+}
+
+impl From<Subgraph> for YamlSubgraph {
+    fn from(value: Subgraph) -> Self {
+        YamlSubgraph(value)
+    }
+}
+
+impl From<YamlSubgraph> for Subgraph {
+    fn from(value: YamlSubgraph) -> Self {
+        value.0
     }
 }
 
@@ -47,7 +68,7 @@ mod test {
         let yaml = r#"
 test: test
 "#;
-        let error = Subgraph::parse_all_from_yaml(get_document(yaml)).unwrap_err();
+        let error = YamlSubgraph::parse_all_from_yaml(get_document(yaml)).unwrap_err();
         assert_eq!(
             error,
             YamlError::ParseError("missing field: subgraphs".to_string())
@@ -58,7 +79,7 @@ subgraphs:
     TestSubgraph:
         test: https://subgraph.com
 "#;
-        let error = Subgraph::parse_all_from_yaml(get_document(yaml)).unwrap_err();
+        let error = YamlSubgraph::parse_all_from_yaml(get_document(yaml)).unwrap_err();
         assert_eq!(
             error,
             YamlError::ParseError(
@@ -71,12 +92,20 @@ subgraphs:
     TestSubgraph:
         - https://subgraph.com
 "#;
-        let error = Subgraph::parse_all_from_yaml(get_document(yaml)).unwrap_err();
+        let error = YamlSubgraph::parse_all_from_yaml(get_document(yaml)).unwrap_err();
         assert_eq!(
             error,
             YamlError::ParseError(
                 "subgraph value must be a string for key: TestSubgraph".to_string()
             )
         );
+
+        let yaml = r#"
+subgraphs:
+    TestSubgraph: https://subgraph.com
+"#;
+        let result = YamlSubgraph::parse_all_from_yaml(get_document(yaml)).unwrap();
+        assert_eq!(result.len(), 1);
+        assert!(result.contains_key("TestSubgraph"));
     }
 }

--- a/crates/settings/src/subgraph.rs
+++ b/crates/settings/src/subgraph.rs
@@ -1,25 +1,35 @@
-use crate::config::Subgraph;
 use crate::yaml::{require_hash, require_string, YamlError, YamlParsableHash};
+use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
     sync::{Arc, RwLock},
 };
 use strict_yaml_rust::StrictYaml;
+use typeshare::typeshare;
 use url::{ParseError, Url};
 
-#[derive(Clone, Debug)]
-pub struct YamlSubgraph(Subgraph);
+#[typeshare]
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "kebab-case")]
+#[serde(default)]
+pub struct Subgraph {
+    #[serde(skip)]
+    pub document: Arc<RwLock<StrictYaml>>,
+    pub key: String,
+    #[typeshare(typescript(type = "string"))]
+    pub url: Url,
+}
 
-impl YamlSubgraph {
+impl Subgraph {
     pub fn validate_url(value: &str) -> Result<Url, ParseError> {
         Url::parse(value)
     }
 }
 
-impl YamlParsableHash for YamlSubgraph {
+impl YamlParsableHash for Subgraph {
     fn parse_all_from_yaml(
         document: Arc<RwLock<StrictYaml>>,
-    ) -> Result<HashMap<String, YamlSubgraph>, YamlError> {
+    ) -> Result<HashMap<String, Subgraph>, YamlError> {
         let document_read = document.read().map_err(|_| YamlError::ReadLockError)?;
         let subgraphs_hash = require_hash(
             &document_read,
@@ -32,7 +42,7 @@ impl YamlParsableHash for YamlSubgraph {
             .map(|(key_yaml, subgraph_yaml)| {
                 let subgraph_key = key_yaml.as_str().unwrap_or_default().to_string();
 
-                let url = YamlSubgraph::validate_url(&require_string(
+                let url = Subgraph::validate_url(&require_string(
                     subgraph_yaml,
                     None,
                     Some(format!(
@@ -40,21 +50,31 @@ impl YamlParsableHash for YamlSubgraph {
                     )),
                 )?)?;
 
-                Ok((subgraph_key, YamlSubgraph(url)))
+                let subgraph = Subgraph {
+                    document: document.clone(),
+                    key: subgraph_key.clone(),
+                    url,
+                };
+
+                Ok((subgraph_key, subgraph))
             })
             .collect()
     }
 }
 
-impl From<Subgraph> for YamlSubgraph {
-    fn from(value: Subgraph) -> Self {
-        YamlSubgraph(value)
+impl Default for Subgraph {
+    fn default() -> Self {
+        Self {
+            document: Arc::new(RwLock::new(StrictYaml::String("".to_string()))),
+            key: "".to_string(),
+            url: Url::parse("https://subgraph.com").unwrap(),
+        }
     }
 }
 
-impl From<YamlSubgraph> for Subgraph {
-    fn from(value: YamlSubgraph) -> Self {
-        value.0
+impl PartialEq for Subgraph {
+    fn eq(&self, other: &Self) -> bool {
+        self.key == other.key && self.url == other.url
     }
 }
 
@@ -68,7 +88,7 @@ mod test {
         let yaml = r#"
 test: test
 "#;
-        let error = YamlSubgraph::parse_all_from_yaml(get_document(yaml)).unwrap_err();
+        let error = Subgraph::parse_all_from_yaml(get_document(yaml)).unwrap_err();
         assert_eq!(
             error,
             YamlError::ParseError("missing field: subgraphs".to_string())
@@ -79,7 +99,7 @@ subgraphs:
     TestSubgraph:
         test: https://subgraph.com
 "#;
-        let error = YamlSubgraph::parse_all_from_yaml(get_document(yaml)).unwrap_err();
+        let error = Subgraph::parse_all_from_yaml(get_document(yaml)).unwrap_err();
         assert_eq!(
             error,
             YamlError::ParseError(
@@ -92,7 +112,7 @@ subgraphs:
     TestSubgraph:
         - https://subgraph.com
 "#;
-        let error = YamlSubgraph::parse_all_from_yaml(get_document(yaml)).unwrap_err();
+        let error = Subgraph::parse_all_from_yaml(get_document(yaml)).unwrap_err();
         assert_eq!(
             error,
             YamlError::ParseError(
@@ -104,7 +124,7 @@ subgraphs:
 subgraphs:
     TestSubgraph: https://subgraph.com
 "#;
-        let result = YamlSubgraph::parse_all_from_yaml(get_document(yaml)).unwrap();
+        let result = Subgraph::parse_all_from_yaml(get_document(yaml)).unwrap();
         assert_eq!(result.len(), 1);
         assert!(result.contains_key("TestSubgraph"));
     }

--- a/crates/settings/src/test.rs
+++ b/crates/settings/src/test.rs
@@ -2,6 +2,7 @@ use crate::*;
 use alloy::primitives::Address;
 use std::sync::{Arc, RwLock};
 use strict_yaml_rust::StrictYaml;
+use subgraph::Subgraph;
 
 // Helper function to create a mock network
 pub fn mock_network() -> Arc<Network> {
@@ -32,7 +33,11 @@ pub fn mock_orderbook() -> Arc<Orderbook> {
         key: "".to_string(),
         label: Some("Orderbook1".into()),
         address: Address::repeat_byte(0x04),
-        subgraph: Arc::new("https://subgraph.com".parse().unwrap()),
+        subgraph: Arc::new(Subgraph {
+            document: Arc::new(RwLock::new(StrictYaml::String("".to_string()))),
+            key: "".to_string(),
+            url: "https://subgraph.com".parse().unwrap(),
+        }),
         network: mock_network(),
     })
 }
@@ -77,5 +82,9 @@ pub fn mock_plot(name: &str) -> (String, Plot) {
 }
 
 pub fn mock_subgraph() -> Arc<Subgraph> {
-    Arc::new("http://subgraph.com".parse().unwrap())
+    Arc::new(Subgraph {
+        document: Arc::new(RwLock::new(StrictYaml::String("".to_string()))),
+        key: "".to_string(),
+        url: "https://subgraph.com".parse().unwrap(),
+    })
 }

--- a/crates/settings/src/yaml/orderbook.rs
+++ b/crates/settings/src/yaml/orderbook.rs
@@ -1,8 +1,5 @@
 use super::*;
-use crate::{
-    metaboard::YamlMetaboard, subgraph::YamlSubgraph, Metaboard, Network, Orderbook, Subgraph,
-    Token,
-};
+use crate::{metaboard::Metaboard, subgraph::Subgraph, Network, Orderbook, Token};
 use std::sync::{Arc, RwLock};
 use strict_yaml_rust::StrictYamlEmitter;
 
@@ -51,12 +48,11 @@ impl OrderbookYaml {
     }
 
     pub fn get_subgraph_keys(&self) -> Result<Vec<String>, YamlError> {
-        let subgraphs = YamlSubgraph::parse_all_from_yaml(self.document.clone())?;
+        let subgraphs = Subgraph::parse_all_from_yaml(self.document.clone())?;
         Ok(subgraphs.keys().cloned().collect())
     }
     pub fn get_subgraph(&self, key: &str) -> Result<Subgraph, YamlError> {
-        let yaml_subgraph = YamlSubgraph::parse_from_yaml(self.document.clone(), key)?;
-        Ok(yaml_subgraph.into())
+        Subgraph::parse_from_yaml(self.document.clone(), key)
     }
 
     pub fn get_orderbook_keys(&self) -> Result<Vec<String>, YamlError> {
@@ -68,12 +64,11 @@ impl OrderbookYaml {
     }
 
     pub fn get_metaboard_keys(&self) -> Result<Vec<String>, YamlError> {
-        let metaboards = YamlMetaboard::parse_all_from_yaml(self.document.clone())?;
+        let metaboards = Metaboard::parse_all_from_yaml(self.document.clone())?;
         Ok(metaboards.keys().cloned().collect())
     }
     pub fn get_metaboard(&self, key: &str) -> Result<Metaboard, YamlError> {
-        let yaml_metaboard = YamlMetaboard::parse_from_yaml(self.document.clone(), key)?;
-        Ok(yaml_metaboard.into())
+        Metaboard::parse_from_yaml(self.document.clone(), key)
     }
 }
 
@@ -171,7 +166,7 @@ mod tests {
         assert_eq!(ob_yaml.get_subgraph_keys().unwrap().len(), 2);
         let subgraph = ob_yaml.get_subgraph("mainnet").unwrap();
         assert_eq!(
-            subgraph,
+            subgraph.url,
             Url::parse("https://api.thegraph.com/subgraphs/name/xyz").unwrap()
         );
 
@@ -186,14 +181,12 @@ mod tests {
         assert_eq!(orderbook.label, Some("Primary Orderbook".to_string()));
 
         assert_eq!(ob_yaml.get_metaboard_keys().unwrap().len(), 2);
-        let metaboard = ob_yaml.get_metaboard("board1").unwrap();
         assert_eq!(
-            metaboard,
+            ob_yaml.get_metaboard("board1").unwrap().url,
             Url::parse("https://meta.example.com/board1").unwrap()
         );
-        let metaboard = ob_yaml.get_metaboard("board2").unwrap();
         assert_eq!(
-            metaboard,
+            ob_yaml.get_metaboard("board2").unwrap().url,
             Url::parse("https://meta.example.com/board2").unwrap()
         );
     }

--- a/packages/orderbook/test/js_api/gui.test.ts
+++ b/packages/orderbook/test/js_api/gui.test.ts
@@ -592,7 +592,7 @@ describe('Rain Orderbook JS API Package Bindgen Tests - Gui', async function () 
 
 	describe('state management tests', async () => {
 		let serializedState =
-			'H4sIAAAAAAAA_3WNSQoCUQxEu1VEb-FaUPLHJDuP4BX-kC-N0IL2wuMrmHYhWJuXoag6dR9x4ALZsmuEJgZbqFJsXohLEQOVs22QRJBd8uJtxrdJCiasGMjRQnO2yjyMdRgvB9PrAfqNTue7PGTamf38eRrrfIhIDCmXKu3f_htuu1lLpQGYC9fK6XaV0XydK2WAY3wBw3-Y7v0AAAA=';
+			'H4sIAAAAAAAA_3WNTQrCMBCFWxXRW7gWlJlMkk52HsErmGRGilBBu_D4Ik5dCH2bb37fOzVfaVHJWn1i7lg4FMKioB5B2JGmqEgZOPnQxQwukwQPSgE-b4nqwny2xtwPtR-uB2xtAO3GqvNDnjLucD9tXujIh9hxgksuVXSu_zd3zaSlEQGmwLVxvN9kwN_lyhjgGN-eYsVu_QAAAA==';
 		let gui: DotrainOrderGui;
 		beforeAll(async () => {
 			mockServer


### PR DESCRIPTION
> [!CAUTION]
> Do not merge before #1080

<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

See issue: #1035

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

> New wrappers called `YamlMetaboard(Metaboard)` and `YamlSubgraph(Subgraph)` are created to implement the yaml parseable trait separately. Because both of the types `Metaboard` and `Subgraph` rely on the same type `Url`, rust does not allow two trait implementations.

- Added a new wrapper for Metaboards
- Implement the yaml parseable trait for this new wrapper
- Reimplement subgraph with the new wrapper logic
- Add and update tests

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)
