### PR TITLE
tauri release fix

### DIFF
--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -69,14 +69,10 @@ jobs:
 
       - run: nix develop .#tauri-shell -c ob-tauri-unit-test
 
-      - run: nix develop .#tauri-shell --command ob-tauri-before-build-ci
-        working-directory: ./tauri-app
-        env:
-          WALLETCONNECT_PROJECT_ID: ${{ secrets.WALLETCONNECT_PROJECT_ID }}
-
       - run: nix develop .#tauri-shell --command ob-tauri-before-release
         working-directory: ./tauri-app
         env:
+          WALLETCONNECT_PROJECT_ID: ${{ secrets.WALLETCONNECT_PROJECT_ID }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           SENTRY_ORG: rainlang

--- a/flake.nix
+++ b/flake.nix
@@ -134,6 +134,7 @@
               sentry-cli releases set-commits --auto ''${COMMIT_SHA}
 
               # Overwrite env variables with release values
+              echo WALLETCONNECT_PROJECT_ID=''${WALLETCONNECT_PROJECT_ID} >> .env
               echo SENTRY_AUTH_TOKEN=''${SENTRY_AUTH_TOKEN} >> .env
               echo SENTRY_ORG=''${SENTRY_ORG} >> .env
               echo SENTRY_PROJECT=''${SENTRY_PROJECT} >> .env


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

The `ob-tauri-before-build-ci` command is good for PRs because it sets some defaults, but it's redundant for releases and is causing the `ob-tauri-before-release` command to fail

## Solution

Removed `ob-tauri-before-build-ci` from `tauri-release.yaml`

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- ~[ ] unit-tested any new functionality~
- ~[ ] linked any relevant issues or PRs~
- ~[ ] included screenshots (if this involves a front-end change)~
