### PR TITLE
New context struct

### DIFF
--- a/crates/settings/src/deployer.rs
+++ b/crates/settings/src/deployer.rs
@@ -128,7 +128,7 @@ impl YamlParsableHash for Deployer {
                     Some(network_name) => network_name,
                     None => deployer_key.clone(),
                 };
-                let network = Network::parse_from_yaml(document.clone(), None, &network_name)?;
+                let network = Network::parse_from_yaml(document.clone(), &network_name, None)?;
 
                 let deployer = Deployer {
                     document: document.clone(),

--- a/crates/settings/src/deployment.rs
+++ b/crates/settings/src/deployment.rs
@@ -49,7 +49,6 @@ impl YamlParsableHash for Deployment {
                 // First parse the order
                 let order = Order::parse_from_yaml(
                     document.clone(),
-                    None,
                     &require_string(
                         deployment_yaml,
                         Some("order"),
@@ -57,6 +56,7 @@ impl YamlParsableHash for Deployment {
                             "order string missing in deployment: {deployment_key}"
                         )),
                     )?,
+                    None,
                 )?;
 
                 let context = Context::with_order(Arc::new(order.clone()));
@@ -64,7 +64,6 @@ impl YamlParsableHash for Deployment {
                 // Parse scenario with context
                 let scenario = Scenario::parse_from_yaml(
                     document.clone(),
-                    Some(&context),
                     &require_string(
                         deployment_yaml,
                         Some("scenario"),
@@ -72,6 +71,7 @@ impl YamlParsableHash for Deployment {
                             "scenario string missing in deployment: {deployment_key}"
                         )),
                     )?,
+                    Some(&context),
                 )?;
 
                 if let Some(deployer) = &order.deployer {

--- a/crates/settings/src/gui.rs
+++ b/crates/settings/src/gui.rs
@@ -297,8 +297,8 @@ impl YamlParseableValue for Gui {
                 .map(|(deployment_name, deployment_yaml)| {
                     let deployment_name = deployment_name.as_str().unwrap_or_default().to_string();
 
-                    let deployment = Deployment::parse_from_yaml(document.clone(), None, &deployment_name)?;
-                    
+                    let deployment = Deployment::parse_from_yaml(document.clone(), &deployment_name, None)?;
+
                     let context = Context::with_order(deployment.order.clone());
 
                     let name = require_string(
@@ -326,10 +326,10 @@ impl YamlParseableValue for Gui {
                     )?.iter().enumerate().map(|(deposit_index, deposit_value)| {
                         let token = Token::parse_from_yaml(
                             document.clone(),
-                            None,
                             &require_string(deposit_value, Some("token"), Some(format!(
                                 "token string missing for deposit index: {deposit_index} in gui deployment: {deployment_name}",
                             )))?,
+                            None,
                         )?;
 
                         let presets = require_vec(

--- a/crates/settings/src/gui.rs
+++ b/crates/settings/src/gui.rs
@@ -1097,9 +1097,10 @@ gui:
                     - value: "1"
 "#;
 
-        let gui = Gui::parse_from_yaml_optional(get_document(&format!("{yaml_prefix}{yaml}")), "", None)
-            .unwrap()
-            .unwrap();
+        let gui =
+            Gui::parse_from_yaml_optional(get_document(&format!("{yaml_prefix}{yaml}")), "", None)
+                .unwrap()
+                .unwrap();
 
         let deployment = gui.deployments.get("deployment1").unwrap();
         let field = &deployment.fields[0];

--- a/crates/settings/src/metaboard.rs
+++ b/crates/settings/src/metaboard.rs
@@ -1,4 +1,6 @@
-use crate::yaml::{default_document, require_hash, require_string, YamlError, YamlParsableHash};
+use crate::yaml::{
+    context::Context, default_document, require_hash, require_string, YamlError, YamlParsableHash,
+};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
@@ -28,6 +30,7 @@ impl Metaboard {
 impl YamlParsableHash for Metaboard {
     fn parse_all_from_yaml(
         document: Arc<RwLock<StrictYaml>>,
+        _context: Option<&Context>,
     ) -> Result<HashMap<String, Metaboard>, YamlError> {
         let document_read = document.read().map_err(|_| YamlError::ReadLockError)?;
         let metaboards_hash = require_hash(
@@ -87,7 +90,7 @@ mod test {
         let yaml = r#"
 test: test
 "#;
-        let error = Metaboard::parse_all_from_yaml(get_document(yaml)).unwrap_err();
+        let error = Metaboard::parse_all_from_yaml(get_document(yaml), None).unwrap_err();
         assert_eq!(
             error,
             YamlError::ParseError("missing field: metaboards".to_string())
@@ -98,7 +101,7 @@ metaboards:
     TestMetaboard:
         test: https://metaboard.com
 "#;
-        let error = Metaboard::parse_all_from_yaml(get_document(yaml)).unwrap_err();
+        let error = Metaboard::parse_all_from_yaml(get_document(yaml), None).unwrap_err();
         assert_eq!(
             error,
             YamlError::ParseError(
@@ -111,7 +114,7 @@ metaboards:
     TestMetaboard:
         - https://metaboard.com
 "#;
-        let error = Metaboard::parse_all_from_yaml(get_document(yaml)).unwrap_err();
+        let error = Metaboard::parse_all_from_yaml(get_document(yaml), None).unwrap_err();
         assert_eq!(
             error,
             YamlError::ParseError(
@@ -123,7 +126,7 @@ metaboards:
 metaboards:
     TestMetaboard: invalid-url
 "#;
-        let res = Metaboard::parse_all_from_yaml(get_document(yaml));
+        let res = Metaboard::parse_all_from_yaml(get_document(yaml), None);
         assert!(res.is_err());
     }
 }

--- a/crates/settings/src/network.rs
+++ b/crates/settings/src/network.rs
@@ -1,4 +1,5 @@
 use crate::config_source::*;
+use crate::yaml::context::Context;
 use crate::yaml::{
     default_document, optional_string, require_hash, require_string, YamlError, YamlParsableHash,
 };
@@ -99,6 +100,7 @@ impl_all_wasm_traits!(Network);
 impl YamlParsableHash for Network {
     fn parse_all_from_yaml(
         document: Arc<RwLock<StrictYaml>>,
+        _context: Option<&Context>,
     ) -> Result<HashMap<String, Self>, YamlError> {
         let document_read = document.read().map_err(|_| YamlError::ReadLockError)?;
         let networks_hash = require_hash(
@@ -223,7 +225,7 @@ mod tests {
         let yaml = r#"
 test: test
 "#;
-        let error = Network::parse_all_from_yaml(get_document(yaml)).unwrap_err();
+        let error = Network::parse_all_from_yaml(get_document(yaml), None).unwrap_err();
         assert_eq!(
             error,
             YamlError::ParseError("missing field: networks".to_string())
@@ -233,7 +235,7 @@ test: test
 networks:
     mainnet:
 "#;
-        let error = Network::parse_all_from_yaml(get_document(yaml)).unwrap_err();
+        let error = Network::parse_all_from_yaml(get_document(yaml), None).unwrap_err();
         assert_eq!(
             error,
             YamlError::ParseError("rpc string missing in network: mainnet".to_string())
@@ -244,7 +246,7 @@ networks:
     mainnet:
         rpc: https://mainnet.infura.io
 "#;
-        let error = Network::parse_all_from_yaml(get_document(yaml)).unwrap_err();
+        let error = Network::parse_all_from_yaml(get_document(yaml), None).unwrap_err();
         assert_eq!(
             error,
             YamlError::ParseError(

--- a/crates/settings/src/order.rs
+++ b/crates/settings/src/order.rs
@@ -89,8 +89,8 @@ impl YamlParsableHash for Order {
                     Some(deployer_name) => {
                         let deployer = Arc::new(Deployer::parse_from_yaml(
                             document.clone(),
-                            None,
                             &deployer_name,
+                            None,
                         )?);
                         if let Some(n) = &network {
                             if deployer.network != *n {
@@ -110,8 +110,8 @@ impl YamlParsableHash for Order {
                     Some(orderbook_name) => {
                         let orderbook = Arc::new(Orderbook::parse_from_yaml(
                             document.clone(),
-                            None,
                             &orderbook_name,
+                            None,
                         )?);
                         if let Some(n) = &network {
                             if orderbook.network != *n {
@@ -142,7 +142,7 @@ impl YamlParsableHash for Order {
                             "token string missing in input index: {i} in order: {order_key}"
                         )),
                     )?;
-                    let token = Token::parse_from_yaml(document.clone(), None, &token_name)?;
+                    let token = Token::parse_from_yaml(document.clone(), &token_name, None)?;
 
                     if let Some(n) = &network {
                         if token.network != *n {
@@ -181,7 +181,7 @@ impl YamlParsableHash for Order {
                             "token string missing in output index: {i} in order: {order_key}"
                         )),
                     )?;
-                    let token = Token::parse_from_yaml(document.clone(), None, &token_name)?;
+                    let token = Token::parse_from_yaml(document.clone(), &token_name, None)?;
 
                     if let Some(n) = &network {
                         if token.network != *n {

--- a/crates/settings/src/orderbook.rs
+++ b/crates/settings/src/orderbook.rs
@@ -65,7 +65,7 @@ impl YamlParsableHash for Orderbook {
                     Some(network_name) => network_name,
                     None => orderbook_key.clone(),
                 };
-                let network = Network::parse_from_yaml(document.clone(), None, &network_name)?;
+                let network = Network::parse_from_yaml(document.clone(), &network_name, None)?;
 
                 let subgraph_name = match optional_string(orderbook_yaml, "subgraph") {
                     Some(subgraph_name) => subgraph_name,
@@ -73,8 +73,8 @@ impl YamlParsableHash for Orderbook {
                 };
                 let subgraph = Arc::new(Subgraph::parse_from_yaml(
                     document.clone(),
-                    None,
                     &subgraph_name,
+                    None,
                 )?);
 
                 let label = optional_string(orderbook_yaml, "label");

--- a/crates/settings/src/scenario.rs
+++ b/crates/settings/src/scenario.rs
@@ -116,7 +116,7 @@ impl Scenario {
 
         if let Some(deployer_name) = optional_string(scenario_yaml, "deployer") {
             let current_deployer =
-                Deployer::parse_from_yaml(document.clone(), None, &deployer_name)?;
+                Deployer::parse_from_yaml(document.clone(), &deployer_name, None)?;
 
             if let Some(parent_deployer) = parent_scenario.deployer.as_ref() {
                 if current_deployer.key != parent_deployer.key {

--- a/crates/settings/src/subgraph.rs
+++ b/crates/settings/src/subgraph.rs
@@ -1,3 +1,4 @@
+use crate::yaml::context::Context;
 use crate::yaml::{default_document, require_hash, require_string, YamlError, YamlParsableHash};
 use serde::{Deserialize, Serialize};
 use std::{
@@ -28,6 +29,7 @@ impl Subgraph {
 impl YamlParsableHash for Subgraph {
     fn parse_all_from_yaml(
         document: Arc<RwLock<StrictYaml>>,
+        _context: Option<&Context>,
     ) -> Result<HashMap<String, Subgraph>, YamlError> {
         let document_read = document.read().map_err(|_| YamlError::ReadLockError)?;
         let subgraphs_hash = require_hash(
@@ -87,7 +89,7 @@ mod test {
         let yaml = r#"
 test: test
 "#;
-        let error = Subgraph::parse_all_from_yaml(get_document(yaml)).unwrap_err();
+        let error = Subgraph::parse_all_from_yaml(get_document(yaml), None).unwrap_err();
         assert_eq!(
             error,
             YamlError::ParseError("missing field: subgraphs".to_string())
@@ -98,7 +100,7 @@ subgraphs:
     TestSubgraph:
         test: https://subgraph.com
 "#;
-        let error = Subgraph::parse_all_from_yaml(get_document(yaml)).unwrap_err();
+        let error = Subgraph::parse_all_from_yaml(get_document(yaml), None).unwrap_err();
         assert_eq!(
             error,
             YamlError::ParseError(
@@ -111,7 +113,7 @@ subgraphs:
     TestSubgraph:
         - https://subgraph.com
 "#;
-        let error = Subgraph::parse_all_from_yaml(get_document(yaml)).unwrap_err();
+        let error = Subgraph::parse_all_from_yaml(get_document(yaml), None).unwrap_err();
         assert_eq!(
             error,
             YamlError::ParseError(
@@ -123,7 +125,7 @@ subgraphs:
 subgraphs:
     TestSubgraph: https://subgraph.com
 "#;
-        let result = Subgraph::parse_all_from_yaml(get_document(yaml)).unwrap();
+        let result = Subgraph::parse_all_from_yaml(get_document(yaml), None).unwrap();
         assert_eq!(result.len(), 1);
         assert!(result.contains_key("TestSubgraph"));
     }

--- a/crates/settings/src/token.rs
+++ b/crates/settings/src/token.rs
@@ -93,12 +93,12 @@ impl YamlParsableHash for Token {
 
                 let network = Network::parse_from_yaml(
                     document.clone(),
-                    None,
                     &require_string(
                         token_yaml,
                         Some("network"),
                         Some(format!("network string missing in token: {token_key}")),
                     )?,
+                    None,
                 )
                 .map_err(|_| {
                     ParseTokenConfigSourceError::NetworkNotFoundError(token_key.clone())

--- a/crates/settings/src/yaml/context.rs
+++ b/crates/settings/src/yaml/context.rs
@@ -2,7 +2,7 @@ use crate::{Order, OrderIO, Token};
 use std::sync::Arc;
 use thiserror::Error;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct Context {
     pub order: Option<Arc<Order>>,
 }
@@ -31,7 +31,7 @@ impl Context {
     fn resolve_path(&self, path: &str) -> Result<String, ContextError> {
         let parts: Vec<&str> = path.split('.').collect();
 
-        match parts.get(0) {
+        match parts.first() {
             Some(&"order") => self.resolve_order_path(&parts[1..]),
             _ => Err(ContextError::InvalidPath(path.to_string())),
         }
@@ -39,7 +39,7 @@ impl Context {
 
     fn resolve_order_path(&self, parts: &[&str]) -> Result<String, ContextError> {
         let order = self.order.as_ref().ok_or(ContextError::NoOrder)?;
-        match parts.get(0) {
+        match parts.first() {
             Some(&"inputs") => self.resolve_io_path(&order.inputs, &parts[1..]),
             Some(&"outputs") => self.resolve_io_path(&order.outputs, &parts[1..]),
             _ => Err(ContextError::InvalidPath(parts.join("."))),
@@ -48,7 +48,7 @@ impl Context {
 
     fn resolve_io_path(&self, ios: &[OrderIO], parts: &[&str]) -> Result<String, ContextError> {
         let index = parts
-            .get(0)
+            .first()
             .ok_or_else(|| ContextError::InvalidPath(parts.join(".")))?
             .parse::<usize>()
             .map_err(|_| ContextError::InvalidIndex(parts[0].to_string()))?;
@@ -68,7 +68,7 @@ impl Context {
     }
 
     fn resolve_token_path(&self, token: &Token, parts: &[&str]) -> Result<String, ContextError> {
-        match parts.get(0) {
+        match parts.first() {
             Some(&"address") => Ok(format!("{:?}", token.address)),
             Some(&"symbol") => Ok(token
                 .symbol

--- a/crates/settings/src/yaml/context.rs
+++ b/crates/settings/src/yaml/context.rs
@@ -1,0 +1,194 @@
+use crate::{Order, OrderIO, Token};
+use std::sync::Arc;
+use thiserror::Error;
+
+#[derive(Debug, Clone)]
+pub struct Context {
+    pub order: Option<Arc<Order>>,
+}
+
+#[derive(Error, Debug, PartialEq)]
+pub enum ContextError {
+    #[error("No order in context")]
+    NoOrder,
+    #[error("Invalid path: {0}")]
+    InvalidPath(String),
+    #[error("Invalid index: {0}")]
+    InvalidIndex(String),
+    #[error("Property not found: {0}")]
+    PropertyNotFound(String),
+}
+
+impl Context {
+    pub fn new() -> Self {
+        Self { order: None }
+    }
+
+    pub fn with_order(order: Arc<Order>) -> Self {
+        Self { order: Some(order) }
+    }
+
+    fn resolve_path(&self, path: &str) -> Result<String, ContextError> {
+        let parts: Vec<&str> = path.split('.').collect();
+
+        match parts.get(0) {
+            Some(&"order") => self.resolve_order_path(&parts[1..]),
+            _ => Err(ContextError::InvalidPath(path.to_string())),
+        }
+    }
+
+    fn resolve_order_path(&self, parts: &[&str]) -> Result<String, ContextError> {
+        let order = self.order.as_ref().ok_or(ContextError::NoOrder)?;
+        match parts.get(0) {
+            Some(&"inputs") => self.resolve_io_path(&order.inputs, &parts[1..]),
+            Some(&"outputs") => self.resolve_io_path(&order.outputs, &parts[1..]),
+            _ => Err(ContextError::InvalidPath(parts.join("."))),
+        }
+    }
+
+    fn resolve_io_path(&self, ios: &[OrderIO], parts: &[&str]) -> Result<String, ContextError> {
+        let index = parts
+            .get(0)
+            .ok_or_else(|| ContextError::InvalidPath(parts.join(".")))?
+            .parse::<usize>()
+            .map_err(|_| ContextError::InvalidIndex(parts[0].to_string()))?;
+
+        let io = ios
+            .get(index)
+            .ok_or_else(|| ContextError::InvalidIndex(index.to_string()))?;
+
+        match parts.get(1) {
+            Some(&"token") => self.resolve_token_path(&io.token, &parts[2..]),
+            Some(&"vault-id") => match &io.vault_id {
+                Some(vault_id) => Ok(vault_id.to_string()),
+                None => Err(ContextError::PropertyNotFound("vault-id".to_string())),
+            },
+            _ => Err(ContextError::InvalidPath(parts.join("."))),
+        }
+    }
+
+    fn resolve_token_path(&self, token: &Token, parts: &[&str]) -> Result<String, ContextError> {
+        match parts.get(0) {
+            Some(&"address") => Ok(format!("{:?}", token.address)),
+            Some(&"symbol") => Ok(token
+                .symbol
+                .clone()
+                .ok_or_else(|| ContextError::PropertyNotFound("symbol".to_string()))?),
+            Some(&"label") => Ok(token
+                .label
+                .clone()
+                .ok_or_else(|| ContextError::PropertyNotFound("label".to_string()))?),
+            Some(&"decimals") => Ok(token
+                .decimals
+                .ok_or_else(|| ContextError::PropertyNotFound("decimals".to_string()))?
+                .to_string()),
+            _ => Err(ContextError::InvalidPath(parts.join("."))),
+        }
+    }
+
+    pub fn interpolate(&self, input: &str) -> Result<String, ContextError> {
+        let mut result = input.to_string();
+        let mut start = 0;
+
+        while let Some(var_start) = result[start..].find("${") {
+            let var_start = start + var_start;
+            if let Some(var_end) = result[var_start..].find('}') {
+                let var_end = var_start + var_end + 1;
+                let var = &result[var_start + 2..var_end - 1];
+                let replacement = self.resolve_path(var)?;
+                result.replace_range(var_start..var_end, &replacement);
+                start = var_start + replacement.len();
+            } else {
+                break;
+            }
+        }
+
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test::*;
+    use crate::yaml::RwLock;
+    use crate::Order;
+    use alloy::primitives::{Address, U256};
+    use strict_yaml_rust::StrictYaml;
+
+    fn setup_test_order_with_vault_id() -> Arc<Order> {
+        let token = Token {
+            document: Arc::new(RwLock::new(StrictYaml::String("".to_string()))),
+            key: "test_token".to_string(),
+            network: mock_network(),
+            address: Address::repeat_byte(0x42),
+            decimals: Some(18),
+            label: Some("Test Token".to_string()),
+            symbol: Some("TST".to_string()),
+        };
+
+        Arc::new(Order {
+            document: Arc::new(RwLock::new(StrictYaml::String("".to_string()))),
+            key: "test_order".to_string(),
+            inputs: vec![OrderIO {
+                token: Arc::new(token.clone()),
+                vault_id: Some(U256::from(42)),
+            }],
+            outputs: vec![OrderIO {
+                token: Arc::new(token),
+                vault_id: None,
+            }],
+            network: mock_network(),
+            deployer: None,
+            orderbook: None,
+        })
+    }
+
+    #[test]
+    fn test_context_interpolation() {
+        let order = setup_test_order_with_vault_id();
+        let context = Context::with_order(order.clone());
+
+        // Test basic interpolation
+        assert_eq!(
+            context
+                .interpolate("Address: ${order.inputs.0.token.address}")
+                .unwrap(),
+            "Address: 0x4242424242424242424242424242424242424242"
+        );
+
+        // Test multiple interpolations
+        assert_eq!(
+            context
+                .interpolate(
+                    "Symbol: ${order.inputs.0.token.symbol}, \
+                     Label: ${order.inputs.0.token.label}"
+                )
+                .unwrap(),
+            "Symbol: TST, Label: Test Token"
+        );
+
+        // Test error cases
+        assert!(context.interpolate("${invalid}").is_err());
+        assert!(context
+            .interpolate("${order.inputs.999.token.address}")
+            .is_err());
+        assert!(context
+            .interpolate("${order.inputs.0.token.invalid}")
+            .is_err());
+
+        // Test vault-id interpolation
+        assert_eq!(
+            context
+                .interpolate("Vault ID: ${order.inputs.0.vault-id}")
+                .unwrap(),
+            "Vault ID: 42"
+        );
+
+        // Test that missing vault-id returns error
+        assert!(matches!(
+            context.interpolate("${order.outputs.0.vault-id}"),
+            Err(ContextError::PropertyNotFound(_))
+        ));
+    }
+}

--- a/crates/settings/src/yaml/dotrain.rs
+++ b/crates/settings/src/yaml/dotrain.rs
@@ -30,7 +30,7 @@ impl DotrainYaml {
         Ok(orders.keys().cloned().collect())
     }
     pub fn get_order(&self, key: &str) -> Result<Order, YamlError> {
-        Order::parse_from_yaml(self.document.clone(), None, key)
+        Order::parse_from_yaml(self.document.clone(), key, None)
     }
 
     pub fn get_scenario_keys(&self) -> Result<Vec<String>, YamlError> {
@@ -38,7 +38,7 @@ impl DotrainYaml {
         Ok(scenarios.keys().cloned().collect())
     }
     pub fn get_scenario(&self, key: &str) -> Result<Scenario, YamlError> {
-        Scenario::parse_from_yaml(self.document.clone(), None, key)
+        Scenario::parse_from_yaml(self.document.clone(), key, None)
     }
 
     pub fn get_deployment_keys(&self) -> Result<Vec<String>, YamlError> {
@@ -46,7 +46,7 @@ impl DotrainYaml {
         Ok(deployments.keys().cloned().collect())
     }
     pub fn get_deployment(&self, key: &str) -> Result<Deployment, YamlError> {
-        Deployment::parse_from_yaml(self.document.clone(), None, key)
+        Deployment::parse_from_yaml(self.document.clone(), key, None)
     }
 
     pub fn get_gui(&self) -> Result<Option<Gui>, YamlError> {

--- a/crates/settings/src/yaml/dotrain.rs
+++ b/crates/settings/src/yaml/dotrain.rs
@@ -17,7 +17,7 @@ impl YamlParsable for DotrainYaml {
         let document = Arc::new(RwLock::new(doc));
 
         if validate {
-            Order::parse_all_from_yaml(document.clone())?;
+            Order::parse_all_from_yaml(document.clone(), None)?;
         }
 
         Ok(DotrainYaml { document })
@@ -26,31 +26,31 @@ impl YamlParsable for DotrainYaml {
 
 impl DotrainYaml {
     pub fn get_order_keys(&self) -> Result<Vec<String>, YamlError> {
-        let orders = Order::parse_all_from_yaml(self.document.clone())?;
+        let orders = Order::parse_all_from_yaml(self.document.clone(), None)?;
         Ok(orders.keys().cloned().collect())
     }
     pub fn get_order(&self, key: &str) -> Result<Order, YamlError> {
-        Order::parse_from_yaml(self.document.clone(), key)
+        Order::parse_from_yaml(self.document.clone(), None, key)
     }
 
     pub fn get_scenario_keys(&self) -> Result<Vec<String>, YamlError> {
-        let scenarios = Scenario::parse_all_from_yaml(self.document.clone())?;
+        let scenarios = Scenario::parse_all_from_yaml(self.document.clone(), None)?;
         Ok(scenarios.keys().cloned().collect())
     }
     pub fn get_scenario(&self, key: &str) -> Result<Scenario, YamlError> {
-        Scenario::parse_from_yaml(self.document.clone(), key)
+        Scenario::parse_from_yaml(self.document.clone(), None, key)
     }
 
     pub fn get_deployment_keys(&self) -> Result<Vec<String>, YamlError> {
-        let deployments = Deployment::parse_all_from_yaml(self.document.clone())?;
+        let deployments = Deployment::parse_all_from_yaml(self.document.clone(), None)?;
         Ok(deployments.keys().cloned().collect())
     }
     pub fn get_deployment(&self, key: &str) -> Result<Deployment, YamlError> {
-        Deployment::parse_from_yaml(self.document.clone(), key)
+        Deployment::parse_from_yaml(self.document.clone(), None, key)
     }
 
     pub fn get_gui(&self) -> Result<Option<Gui>, YamlError> {
-        Gui::parse_from_yaml_optional(self.document.clone())
+        Gui::parse_from_yaml_optional(self.document.clone(), "", None)
     }
 }
 

--- a/crates/settings/src/yaml/mod.rs
+++ b/crates/settings/src/yaml/mod.rs
@@ -40,8 +40,8 @@ pub trait YamlParsableHash: Sized + Clone {
 
     fn parse_from_yaml(
         document: Arc<RwLock<StrictYaml>>,
-        context: Option<&Context>,
         key: &str,
+        context: Option<&Context>,
     ) -> Result<Self, YamlError> {
         let all = Self::parse_all_from_yaml(document, context)?;
         all.get(key)

--- a/crates/settings/src/yaml/mod.rs
+++ b/crates/settings/src/yaml/mod.rs
@@ -1,3 +1,4 @@
+pub mod context;
 pub mod dotrain;
 pub mod orderbook;
 
@@ -7,6 +8,7 @@ use crate::{
     ParseScenarioConfigSourceError, ParseTokenConfigSourceError,
 };
 use alloy::primitives::ruint::ParseError as RuintParseError;
+use context::Context;
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 use std::sync::{PoisonError, RwLockReadGuard, RwLockWriteGuard};
@@ -33,10 +35,15 @@ pub trait YamlParsable: Sized {
 pub trait YamlParsableHash: Sized + Clone {
     fn parse_all_from_yaml(
         document: Arc<RwLock<StrictYaml>>,
+        context: Option<&Context>,
     ) -> Result<HashMap<String, Self>, YamlError>;
 
-    fn parse_from_yaml(document: Arc<RwLock<StrictYaml>>, key: &str) -> Result<Self, YamlError> {
-        let all = Self::parse_all_from_yaml(document)?;
+    fn parse_from_yaml(
+        document: Arc<RwLock<StrictYaml>>,
+        context: Option<&Context>,
+        key: &str,
+    ) -> Result<Self, YamlError> {
+        let all = Self::parse_all_from_yaml(document, context)?;
         all.get(key)
             .ok_or_else(|| YamlError::KeyNotFound(key.to_string()))
             .cloned()
@@ -56,10 +63,16 @@ pub trait YamlParsableString {
 }
 
 pub trait YamlParseableValue: Sized {
-    fn parse_from_yaml(document: Arc<RwLock<StrictYaml>>) -> Result<Self, YamlError>;
+    fn parse_from_yaml(
+        document: Arc<RwLock<StrictYaml>>,
+        key: &str,
+        context: Option<&Context>,
+    ) -> Result<Self, YamlError>;
 
     fn parse_from_yaml_optional(
         document: Arc<RwLock<StrictYaml>>,
+        key: &str,
+        context: Option<&Context>,
     ) -> Result<Option<Self>, YamlError>;
 }
 

--- a/crates/settings/src/yaml/orderbook.rs
+++ b/crates/settings/src/yaml/orderbook.rs
@@ -19,7 +19,7 @@ impl YamlParsable for OrderbookYaml {
         let document = Arc::new(RwLock::new(doc));
 
         if validate {
-            Network::parse_all_from_yaml(document.clone())?;
+            Network::parse_all_from_yaml(document.clone(), None)?;
         }
         Ok(OrderbookYaml { document })
     }
@@ -27,51 +27,51 @@ impl YamlParsable for OrderbookYaml {
 
 impl OrderbookYaml {
     pub fn get_network_keys(&self) -> Result<Vec<String>, YamlError> {
-        let networks = Network::parse_all_from_yaml(self.document.clone())?;
+        let networks = Network::parse_all_from_yaml(self.document.clone(), None)?;
         Ok(networks.keys().cloned().collect())
     }
     pub fn get_network(&self, key: &str) -> Result<Network, YamlError> {
-        Network::parse_from_yaml(self.document.clone(), key)
+        Network::parse_from_yaml(self.document.clone(), None, key)
     }
 
     pub fn get_token_keys(&self) -> Result<Vec<String>, YamlError> {
-        let tokens = Token::parse_all_from_yaml(self.document.clone())?;
+        let tokens = Token::parse_all_from_yaml(self.document.clone(), None)?;
         Ok(tokens.keys().cloned().collect())
     }
     pub fn get_token(&self, key: &str) -> Result<Token, YamlError> {
-        Token::parse_from_yaml(self.document.clone(), key)
+        Token::parse_from_yaml(self.document.clone(), None, key)
     }
 
     pub fn get_subgraph_keys(&self) -> Result<Vec<String>, YamlError> {
-        let subgraphs = Subgraph::parse_all_from_yaml(self.document.clone())?;
+        let subgraphs = Subgraph::parse_all_from_yaml(self.document.clone(), None)?;
         Ok(subgraphs.keys().cloned().collect())
     }
     pub fn get_subgraph(&self, key: &str) -> Result<Subgraph, YamlError> {
-        Subgraph::parse_from_yaml(self.document.clone(), key)
+        Subgraph::parse_from_yaml(self.document.clone(), None, key)
     }
 
     pub fn get_orderbook_keys(&self) -> Result<Vec<String>, YamlError> {
-        let orderbooks = Orderbook::parse_all_from_yaml(self.document.clone())?;
+        let orderbooks = Orderbook::parse_all_from_yaml(self.document.clone(), None)?;
         Ok(orderbooks.keys().cloned().collect())
     }
     pub fn get_orderbook(&self, key: &str) -> Result<Orderbook, YamlError> {
-        Orderbook::parse_from_yaml(self.document.clone(), key)
+        Orderbook::parse_from_yaml(self.document.clone(), None, key)
     }
 
     pub fn get_metaboard_keys(&self) -> Result<Vec<String>, YamlError> {
-        let metaboards = Metaboard::parse_all_from_yaml(self.document.clone())?;
+        let metaboards = Metaboard::parse_all_from_yaml(self.document.clone(), None)?;
         Ok(metaboards.keys().cloned().collect())
     }
     pub fn get_metaboard(&self, key: &str) -> Result<Metaboard, YamlError> {
-        Metaboard::parse_from_yaml(self.document.clone(), key)
+        Metaboard::parse_from_yaml(self.document.clone(), None, key)
     }
 
     pub fn get_deployer_keys(&self) -> Result<Vec<String>, YamlError> {
-        let deployers = Deployer::parse_all_from_yaml(self.document.clone())?;
+        let deployers = Deployer::parse_all_from_yaml(self.document.clone(), None)?;
         Ok(deployers.keys().cloned().collect())
     }
     pub fn get_deployer(&self, key: &str) -> Result<Deployer, YamlError> {
-        Deployer::parse_from_yaml(self.document.clone(), key)
+        Deployer::parse_from_yaml(self.document.clone(), None, key)
     }
 
     pub fn get_sentry(&self) -> Result<bool, YamlError> {

--- a/crates/settings/src/yaml/orderbook.rs
+++ b/crates/settings/src/yaml/orderbook.rs
@@ -31,7 +31,7 @@ impl OrderbookYaml {
         Ok(networks.keys().cloned().collect())
     }
     pub fn get_network(&self, key: &str) -> Result<Network, YamlError> {
-        Network::parse_from_yaml(self.document.clone(), None, key)
+        Network::parse_from_yaml(self.document.clone(), key, None)
     }
 
     pub fn get_token_keys(&self) -> Result<Vec<String>, YamlError> {
@@ -39,7 +39,7 @@ impl OrderbookYaml {
         Ok(tokens.keys().cloned().collect())
     }
     pub fn get_token(&self, key: &str) -> Result<Token, YamlError> {
-        Token::parse_from_yaml(self.document.clone(), None, key)
+        Token::parse_from_yaml(self.document.clone(), key, None)
     }
 
     pub fn get_subgraph_keys(&self) -> Result<Vec<String>, YamlError> {
@@ -47,7 +47,7 @@ impl OrderbookYaml {
         Ok(subgraphs.keys().cloned().collect())
     }
     pub fn get_subgraph(&self, key: &str) -> Result<Subgraph, YamlError> {
-        Subgraph::parse_from_yaml(self.document.clone(), None, key)
+        Subgraph::parse_from_yaml(self.document.clone(), key, None)
     }
 
     pub fn get_orderbook_keys(&self) -> Result<Vec<String>, YamlError> {
@@ -55,7 +55,7 @@ impl OrderbookYaml {
         Ok(orderbooks.keys().cloned().collect())
     }
     pub fn get_orderbook(&self, key: &str) -> Result<Orderbook, YamlError> {
-        Orderbook::parse_from_yaml(self.document.clone(), None, key)
+        Orderbook::parse_from_yaml(self.document.clone(), key, None)
     }
 
     pub fn get_metaboard_keys(&self) -> Result<Vec<String>, YamlError> {
@@ -63,7 +63,7 @@ impl OrderbookYaml {
         Ok(metaboards.keys().cloned().collect())
     }
     pub fn get_metaboard(&self, key: &str) -> Result<Metaboard, YamlError> {
-        Metaboard::parse_from_yaml(self.document.clone(), None, key)
+        Metaboard::parse_from_yaml(self.document.clone(), key, None)
     }
 
     pub fn get_deployer_keys(&self) -> Result<Vec<String>, YamlError> {
@@ -71,7 +71,7 @@ impl OrderbookYaml {
         Ok(deployers.keys().cloned().collect())
     }
     pub fn get_deployer(&self, key: &str) -> Result<Deployer, YamlError> {
-        Deployer::parse_from_yaml(self.document.clone(), None, key)
+        Deployer::parse_from_yaml(self.document.clone(), key, None)
     }
 
     pub fn get_sentry(&self) -> Result<bool, YamlError> {


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

For #1100 

## Solution

Created a new `Context` struct that currently can optionally contain an `Order`. This could be extended in the future.

It then has fns to interpolate strings, looking for the vars and following the path. Currently supports order tokens (symbols, addresses, etc).

Added a context arg to the yaml parsing straits, then setup:
- When a deployment is being parsed, the order will be parsed first then passed to the scenario parsing fn (so bindings can be interpolated
- When a gui deployment is being parsed, the deployment's order will be used for interpolating field names and descriptions.

This won't work in practice yet, because we're still adding the new yaml handling to Gui and getting calldata's for Gui.

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [x] included screenshots (if this involves a front-end change)
