### PR TITLE
Merging for yamls

### DIFF
--- a/crates/common/src/dotrain_order/mod.rs
+++ b/crates/common/src/dotrain_order/mod.rs
@@ -32,6 +32,15 @@ pub struct DotrainOrder {
     dotrain: String,
     config_source: ConfigSource,
 }
+impl Default for DotrainOrder {
+    fn default() -> Self {
+        Self {
+            config: Config::default(),
+            dotrain: "".to_string(),
+            config_source: ConfigSource::default(),
+        }
+    }
+}
 
 #[derive(Error, Debug)]
 pub enum DotrainOrderError {

--- a/crates/settings/src/deployer.rs
+++ b/crates/settings/src/deployer.rs
@@ -10,7 +10,8 @@ use strict_yaml_rust::StrictYaml;
 use thiserror::Error;
 use typeshare::typeshare;
 use yaml::{
-    default_document, optional_string, require_hash, require_string, YamlError, YamlParsableHash,
+    default_document, optional_string, require_hash, require_string, YamlError,
+    YamlParsableMergableHash,
 };
 
 #[cfg(target_family = "wasm")]
@@ -98,46 +99,70 @@ impl DeployerConfigSource {
     }
 }
 
-impl YamlParsableHash for Deployer {
-    fn parse_all_from_yaml(
-        document: Arc<RwLock<StrictYaml>>,
+impl YamlParsableMergableHash for Deployer {
+    fn parse_and_merge_all_from_yamls(
+        documents: Vec<Arc<RwLock<StrictYaml>>>,
     ) -> Result<HashMap<String, Self>, YamlError> {
-        let document_read = document.read().map_err(|_| YamlError::ReadLockError)?;
-        let deployers_hash = require_hash(
-            &document_read,
-            Some("deployers"),
-            Some("missing field: deployers".to_string()),
-        )?;
+        let mut all_deployers = HashMap::new();
 
-        deployers_hash
-            .iter()
-            .map(|(key_yaml, deployer_yaml)| {
-                let deployer_key = key_yaml.as_str().unwrap_or_default().to_string();
+        // First get all networks from all documents
+        let all_networks = Network::parse_and_merge_all_from_yamls(documents.clone())?;
 
-                let address = Deployer::validate_address(&require_string(
-                    deployer_yaml,
-                    Some("address"),
-                    Some(format!(
-                        "address string missing in deployer: {deployer_key}"
-                    )),
-                )?)?;
+        for document in documents {
+            let document_read = document.read().map_err(|_| YamlError::ReadLockError)?;
+            if let Ok(deployers_hash) = require_hash(
+                &document_read,
+                Some("deployers"),
+                None, // Don't error if not found
+            ) {
+                for (key_yaml, deployer_yaml) in deployers_hash {
+                    let deployer_key = key_yaml.as_str().unwrap_or_default().to_string();
 
-                let network_name = match optional_string(deployer_yaml, "network") {
-                    Some(network_name) => network_name,
-                    None => deployer_key.clone(),
-                };
-                let network = Network::parse_from_yaml(document.clone(), &network_name)?;
+                    // Error on duplicates
+                    if all_deployers.contains_key(&deployer_key) {
+                        return Err(YamlError::DuplicateKey(deployer_key));
+                    }
 
-                let deployer = Deployer {
-                    document: document.clone(),
-                    key: deployer_key.clone(),
-                    address,
-                    network: Arc::new(network),
-                };
+                    let address = Deployer::validate_address(&require_string(
+                        deployer_yaml,
+                        Some("address"),
+                        Some(format!(
+                            "address string missing in deployer: {deployer_key}"
+                        )),
+                    )?)?;
 
-                Ok((deployer_key, deployer))
-            })
-            .collect()
+                    // Get network name from field or use deployer key as fallback
+                    let network_name = optional_string(deployer_yaml, "network")
+                        .unwrap_or_else(|| deployer_key.clone());
+
+                    let network = all_networks
+                        .get(&network_name)
+                        .ok_or_else(|| {
+                            YamlError::ParseError(format!(
+                                "network not found for deployer: {deployer_key}"
+                            ))
+                        })?
+                        .clone();
+
+                    let deployer = Deployer {
+                        document: document.clone(),
+                        key: deployer_key.clone(),
+                        address,
+                        network: Arc::new(network),
+                    };
+
+                    all_deployers.insert(deployer_key, deployer);
+                }
+            }
+        }
+
+        if all_deployers.is_empty() {
+            return Err(YamlError::ParseError(
+                "missing field: deployers".to_string(),
+            ));
+        }
+
+        Ok(all_deployers)
     }
 }
 
@@ -212,7 +237,7 @@ mod tests {
         let yaml = r#"
 test: test
 "#;
-        let error = Deployer::parse_all_from_yaml(get_document(yaml)).unwrap_err();
+        let error = Deployer::parse_and_merge_all_from_yamls(vec![get_document(yaml)]).unwrap_err();
         assert_eq!(
             error,
             YamlError::ParseError("missing field: deployers".to_string())
@@ -222,7 +247,7 @@ test: test
 deployers:
     TestDeployer:
 "#;
-        let error = Deployer::parse_all_from_yaml(get_document(yaml)).unwrap_err();
+        let error = Deployer::parse_and_merge_all_from_yamls(vec![get_document(yaml)]).unwrap_err();
         assert_eq!(
             error,
             YamlError::ParseError("address string missing in deployer: TestDeployer".to_string())
@@ -233,10 +258,10 @@ deployers:
     TestDeployer:
         address: not_a_valid_address
 "#;
-        let error = Deployer::parse_all_from_yaml(get_document(yaml));
+        let error = Deployer::parse_and_merge_all_from_yamls(vec![get_document(yaml)]);
         assert!(error.is_err());
 
-        let error = Deployer::parse_all_from_yaml(get_document(
+        let error = Deployer::parse_and_merge_all_from_yamls(vec![get_document(
             r#"
 networks:
     TestNetwork:
@@ -247,8 +272,104 @@ deployers:
         address: "0x1234567890123456789012345678901234567890"
         network: SomeNetwork
 "#,
-        ))
+        )])
         .unwrap_err();
         assert_eq!(error, YamlError::KeyNotFound("SomeNetwork".to_string()));
+    }
+
+    #[test]
+    fn test_deployer_document_preservation() {
+        // Main document with one deployer
+        let main_yaml = r#"
+networks:
+    mainnet:
+        rpc: https://mainnet.infura.io
+        chain-id: 1
+deployers:
+    deployer1:
+        address: 0x1234567890123456789012345678901234567890
+        network: mainnet
+"#;
+        let main_doc = get_document(main_yaml);
+
+        // Orderbook yaml with another deployer
+        let orderbook_yaml = r#"
+networks:
+    testnet:
+        rpc: https://testnet.infura.io
+        chain-id: 5
+deployers:
+    deployer2:
+        address: 0x0987654321098765432109876543210987654321
+        network: testnet
+"#;
+        let orderbook_doc = get_document(orderbook_yaml);
+
+        // Parse both documents
+        let deployers =
+            Deployer::parse_and_merge_all_from_yamls(vec![main_doc.clone(), orderbook_doc.clone()])
+                .unwrap();
+
+        // Verify deployers came from correct documents
+        let deployer1 = deployers.get("deployer1").unwrap();
+        let deployer2 = deployers.get("deployer2").unwrap();
+
+        // Check document preservation by comparing Arc pointers
+        assert!(Arc::ptr_eq(&deployer1.document, &main_doc));
+        assert!(Arc::ptr_eq(&deployer2.document, &orderbook_doc));
+
+        // Verify networks were correctly merged and assigned
+        assert_eq!(deployer1.network.chain_id, 1);
+        assert_eq!(deployer2.network.chain_id, 5);
+    }
+
+    #[test]
+    fn test_deployer_duplicate_error() {
+        let yaml1 = r#"
+networks:
+    mainnet:
+        rpc: https://mainnet.infura.io
+        chain-id: 1
+deployers:
+    deployer1:
+        address: 0x1234567890123456789012345678901234567890
+        network: mainnet
+"#;
+        let yaml2 = r#"
+networks:
+    testnet:
+        rpc: https://testnet.infura.io
+        chain-id: 5
+deployers:
+    deployer1:
+        address: 0x0987654321098765432109876543210987654321
+        network: testnet
+"#;
+
+        let error = Deployer::parse_and_merge_all_from_yamls(vec![
+            get_document(yaml1),
+            get_document(yaml2),
+        ])
+        .unwrap_err();
+
+        assert_eq!(error, YamlError::DuplicateKey("deployer1".to_string()));
+    }
+
+    #[test]
+    fn test_deployer_network_fallback() {
+        let yaml = r#"
+networks:
+    deployer1:
+        rpc: https://mainnet.infura.io
+        chain-id: 1
+deployers:
+    deployer1:
+        address: 0x1234567890123456789012345678901234567890
+"#;
+        let deployers = Deployer::parse_and_merge_all_from_yamls(vec![get_document(yaml)]).unwrap();
+
+        let deployer = deployers.get("deployer1").unwrap();
+        assert_eq!(deployer.network.chain_id, 1);
+        assert_eq!(deployer.network.key, "deployer1");
     }
 }

--- a/crates/settings/src/deployment.rs
+++ b/crates/settings/src/deployment.rs
@@ -7,7 +7,10 @@ use std::{
 use strict_yaml_rust::StrictYaml;
 use thiserror::Error;
 use typeshare::typeshare;
-use yaml::{default_document, require_hash, require_string, YamlError, YamlParsableHash};
+use yaml::{
+    default_document, require_hash, require_string, YamlError, YamlParsableHash,
+    YamlParsableMergableHash,
+};
 
 #[cfg(target_family = "wasm")]
 use rain_orderbook_bindings::{impl_all_wasm_traits, wasm_traits::prelude::*};
@@ -54,8 +57,8 @@ impl YamlParsableHash for Deployment {
                         )),
                     )?,
                 )?;
-                let order = Order::parse_from_yaml(
-                    document.clone(),
+                let order = Order::parse_from_yamls(
+                    vec![document.clone()],
                     &require_string(
                         deployment_yaml,
                         Some("order"),

--- a/crates/settings/src/gui.rs
+++ b/crates/settings/src/gui.rs
@@ -1,7 +1,8 @@
 use crate::{
     yaml::{
         default_document, get_hash_value, optional_hash, optional_string, optional_vec,
-        require_string, require_vec, YamlError, YamlParsableHash, YamlParseableValue,
+        require_string, require_vec, YamlError, YamlParsableHash, YamlParsableMergableHash,
+        YamlParseableValue,
     },
     Deployment, Token, TokenRef,
 };
@@ -317,7 +318,7 @@ impl YamlParseableValue for Gui {
                             "deposits list missing in gui deployment: {deployment_name}",
                         )),
                     )?.iter().enumerate().map(|(deposit_index, deposit_value)| {
-                        let token =  Token::parse_from_yaml(document.clone(), &require_string(
+                        let token =  Token::parse_from_yamls(vec![document.clone()], &require_string(
                             deposit_value,
                             Some("token"),
                             Some(format!(

--- a/crates/settings/src/metaboard.rs
+++ b/crates/settings/src/metaboard.rs
@@ -1,4 +1,6 @@
-use crate::yaml::{default_document, require_hash, require_string, YamlError, YamlParsableHash};
+use crate::yaml::{
+    default_document, require_hash, require_string, YamlError, YamlParsableMergableHash,
+};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
@@ -25,39 +27,53 @@ impl Metaboard {
     }
 }
 
-impl YamlParsableHash for Metaboard {
-    fn parse_all_from_yaml(
-        document: Arc<RwLock<StrictYaml>>,
-    ) -> Result<HashMap<String, Metaboard>, YamlError> {
-        let document_read = document.read().map_err(|_| YamlError::ReadLockError)?;
-        let metaboards_hash = require_hash(
-            &document_read,
-            Some("metaboards"),
-            Some("missing field: metaboards".to_string()),
-        )?;
+impl YamlParsableMergableHash for Metaboard {
+    fn parse_and_merge_all_from_yamls(
+        documents: Vec<Arc<RwLock<StrictYaml>>>,
+    ) -> Result<HashMap<String, Self>, YamlError> {
+        let mut all_metaboards = HashMap::new();
 
-        metaboards_hash
-            .iter()
-            .map(|(key_yaml, metaboard_yaml)| {
-                let metaboard_key = key_yaml.as_str().unwrap_or_default().to_string();
+        for document in documents {
+            let document_read = document.read().map_err(|_| YamlError::ReadLockError)?;
+            if let Ok(metaboards_hash) = require_hash(
+                &document_read,
+                Some("metaboards"),
+                None, // Don't error if not found
+            ) {
+                for (key_yaml, metaboard_yaml) in metaboards_hash {
+                    let metaboard_key = key_yaml.as_str().unwrap_or_default().to_string();
 
-                let url = Metaboard::validate_url(&require_string(
-                    metaboard_yaml,
-                    None,
-                    Some(format!(
-                        "metaboard value must be a string for key: {metaboard_key}"
-                    )),
-                )?)?;
+                    // Error on duplicates
+                    if all_metaboards.contains_key(&metaboard_key) {
+                        return Err(YamlError::DuplicateKey(metaboard_key));
+                    }
 
-                let metaboard = Metaboard {
-                    document: document.clone(),
-                    key: metaboard_key.clone(),
-                    url,
-                };
+                    let url = Metaboard::validate_url(&require_string(
+                        metaboard_yaml,
+                        None,
+                        Some(format!(
+                            "metaboard value must be a string for key: {metaboard_key}"
+                        )),
+                    )?)?;
 
-                Ok((metaboard_key, metaboard))
-            })
-            .collect()
+                    let metaboard = Metaboard {
+                        document: document.clone(),
+                        key: metaboard_key.clone(),
+                        url,
+                    };
+
+                    all_metaboards.insert(metaboard_key, metaboard);
+                }
+            }
+        }
+
+        if all_metaboards.is_empty() {
+            return Err(YamlError::ParseError(
+                "missing field: metaboards".to_string(),
+            ));
+        }
+
+        Ok(all_metaboards)
     }
 }
 
@@ -87,7 +103,8 @@ mod test {
         let yaml = r#"
 test: test
 "#;
-        let error = Metaboard::parse_all_from_yaml(get_document(yaml)).unwrap_err();
+        let error =
+            Metaboard::parse_and_merge_all_from_yamls(vec![get_document(yaml)]).unwrap_err();
         assert_eq!(
             error,
             YamlError::ParseError("missing field: metaboards".to_string())
@@ -98,7 +115,8 @@ metaboards:
     TestMetaboard:
         test: https://metaboard.com
 "#;
-        let error = Metaboard::parse_all_from_yaml(get_document(yaml)).unwrap_err();
+        let error =
+            Metaboard::parse_and_merge_all_from_yamls(vec![get_document(yaml)]).unwrap_err();
         assert_eq!(
             error,
             YamlError::ParseError(
@@ -108,22 +126,62 @@ metaboards:
 
         let yaml = r#"
 metaboards:
-    TestMetaboard:
-        - https://metaboard.com
+    TestMetaboard: https://metaboard.com
 "#;
-        let error = Metaboard::parse_all_from_yaml(get_document(yaml)).unwrap_err();
-        assert_eq!(
-            error,
-            YamlError::ParseError(
-                "metaboard value must be a string for key: TestMetaboard".to_string()
-            )
-        );
+        let result = Metaboard::parse_and_merge_all_from_yamls(vec![get_document(yaml)]).unwrap();
+        assert_eq!(result.len(), 1);
+        assert!(result.contains_key("TestMetaboard"));
+    }
 
-        let yaml = r#"
+    #[test]
+    fn test_metaboard_document_preservation() {
+        // Main document with one metaboard
+        let main_yaml = r#"
 metaboards:
-    TestMetaboard: invalid-url
+    mainnet: https://api.metaboard.com/main
 "#;
-        let res = Metaboard::parse_all_from_yaml(get_document(yaml));
-        assert!(res.is_err());
+        let main_doc = get_document(main_yaml);
+
+        // Orderbook yaml with another metaboard
+        let orderbook_yaml = r#"
+metaboards:
+    testnet: https://api.metaboard.com/test
+"#;
+        let orderbook_doc = get_document(orderbook_yaml);
+
+        // Parse both documents
+        let metaboards = Metaboard::parse_and_merge_all_from_yamls(vec![
+            main_doc.clone(),
+            orderbook_doc.clone(),
+        ])
+        .unwrap();
+
+        // Verify metaboards came from correct documents
+        let mainnet = metaboards.get("mainnet").unwrap();
+        let testnet = metaboards.get("testnet").unwrap();
+
+        // Check document preservation by comparing Arc pointers
+        assert!(Arc::ptr_eq(&mainnet.document, &main_doc));
+        assert!(Arc::ptr_eq(&testnet.document, &orderbook_doc));
+    }
+
+    #[test]
+    fn test_metaboard_duplicate_error() {
+        let yaml1 = r#"
+metaboards:
+    mainnet: https://api.metaboard.com/main
+"#;
+        let yaml2 = r#"
+metaboards:
+    mainnet: https://api.metaboard.com/other
+"#;
+
+        let error = Metaboard::parse_and_merge_all_from_yamls(vec![
+            get_document(yaml1),
+            get_document(yaml2),
+        ])
+        .unwrap_err();
+
+        assert_eq!(error, YamlError::DuplicateKey("mainnet".to_string()));
     }
 }

--- a/crates/settings/src/orderbook.rs
+++ b/crates/settings/src/orderbook.rs
@@ -10,7 +10,8 @@ use subgraph::Subgraph;
 use thiserror::Error;
 use typeshare::typeshare;
 use yaml::{
-    default_document, optional_string, require_hash, require_string, YamlError, YamlParsableHash,
+    default_document, optional_string, require_hash, require_string, YamlError,
+    YamlParsableMergableHash,
 };
 
 #[typeshare]
@@ -35,57 +36,88 @@ impl Orderbook {
     }
 }
 
-impl YamlParsableHash for Orderbook {
-    fn parse_all_from_yaml(
-        document: Arc<RwLock<StrictYaml>>,
+impl YamlParsableMergableHash for Orderbook {
+    fn parse_and_merge_all_from_yamls(
+        documents: Vec<Arc<RwLock<StrictYaml>>>,
     ) -> Result<HashMap<String, Self>, YamlError> {
-        let document_read = document.read().map_err(|_| YamlError::ReadLockError)?;
-        let orderbooks_hash = require_hash(
-            &document_read,
-            Some("orderbooks"),
-            Some("missing field: orderbooks".to_string()),
-        )?;
+        let mut all_orderbooks = HashMap::new();
 
-        orderbooks_hash
-            .into_iter()
-            .map(|(key_yaml, orderbook_yaml)| {
-                let orderbook_key = key_yaml.as_str().unwrap_or_default().to_string();
+        // First get all networks and subgraphs from all documents
+        let all_networks = Network::parse_and_merge_all_from_yamls(documents.clone())?;
+        let all_subgraphs = Subgraph::parse_and_merge_all_from_yamls(documents.clone())?;
 
-                let address = Orderbook::validate_address(&require_string(
-                    orderbook_yaml,
-                    Some("address"),
-                    Some(format!(
-                        "address string missing in orderbook: {orderbook_key}"
-                    )),
-                )?)?;
+        for document in documents {
+            let document_read = document.read().map_err(|_| YamlError::ReadLockError)?;
+            if let Ok(orderbooks_hash) = require_hash(
+                &document_read,
+                Some("orderbooks"),
+                None, // Don't error if not found
+            ) {
+                for (key_yaml, orderbook_yaml) in orderbooks_hash {
+                    let orderbook_key = key_yaml.as_str().unwrap_or_default().to_string();
 
-                let network_name = match optional_string(orderbook_yaml, "network") {
-                    Some(network_name) => network_name,
-                    None => orderbook_key.clone(),
-                };
-                let network = Network::parse_from_yaml(document.clone(), &network_name)?;
+                    // Error on duplicates
+                    if all_orderbooks.contains_key(&orderbook_key) {
+                        return Err(YamlError::DuplicateKey(orderbook_key));
+                    }
 
-                let subgraph_name = match optional_string(orderbook_yaml, "subgraph") {
-                    Some(subgraph_name) => subgraph_name,
-                    None => orderbook_key.clone(),
-                };
-                let subgraph =
-                    Arc::new(Subgraph::parse_from_yaml(document.clone(), &subgraph_name)?);
+                    let address = Orderbook::validate_address(&require_string(
+                        orderbook_yaml,
+                        Some("address"),
+                        Some(format!(
+                            "address string missing in orderbook: {orderbook_key}"
+                        )),
+                    )?)?;
 
-                let label = optional_string(orderbook_yaml, "label");
+                    // Get network name from field or use orderbook key as fallback
+                    let network_name = optional_string(orderbook_yaml, "network")
+                        .unwrap_or_else(|| orderbook_key.clone());
 
-                let orderbook = Orderbook {
-                    document: document.clone(),
-                    key: orderbook_key.clone(),
-                    address,
-                    network: Arc::new(network),
-                    subgraph,
-                    label,
-                };
+                    let network = all_networks
+                        .get(&network_name)
+                        .ok_or_else(|| {
+                            YamlError::ParseError(format!(
+                                "network not found for orderbook: {orderbook_key}"
+                            ))
+                        })?
+                        .clone();
 
-                Ok((orderbook_key, orderbook))
-            })
-            .collect()
+                    // Get subgraph name from field or use orderbook key as fallback
+                    let subgraph_name = optional_string(orderbook_yaml, "subgraph")
+                        .unwrap_or_else(|| orderbook_key.clone());
+
+                    let subgraph = all_subgraphs
+                        .get(&subgraph_name)
+                        .ok_or_else(|| {
+                            YamlError::ParseError(format!(
+                                "subgraph not found for orderbook: {orderbook_key}"
+                            ))
+                        })?
+                        .clone();
+
+                    let label = optional_string(orderbook_yaml, "label");
+
+                    let orderbook = Orderbook {
+                        document: document.clone(),
+                        key: orderbook_key.clone(),
+                        address,
+                        network: Arc::new(network),
+                        subgraph: Arc::new(subgraph),
+                        label,
+                    };
+
+                    all_orderbooks.insert(orderbook_key, orderbook);
+                }
+            }
+        }
+
+        if all_orderbooks.is_empty() {
+            return Err(YamlError::ParseError(
+                "missing field: orderbooks".to_string(),
+            ));
+        }
+
+        Ok(all_orderbooks)
     }
 }
 
@@ -275,7 +307,8 @@ mod tests {
         let yaml = r#"
 test: test
 "#;
-        let error = Orderbook::parse_all_from_yaml(get_document(yaml)).unwrap_err();
+        let error =
+            Orderbook::parse_and_merge_all_from_yamls(vec![get_document(yaml)]).unwrap_err();
         assert_eq!(
             error,
             YamlError::ParseError("missing field: orderbooks".to_string())
@@ -285,7 +318,8 @@ test: test
 orderbooks:
     TestOrderbook:
 "#;
-        let error = Orderbook::parse_all_from_yaml(get_document(yaml)).unwrap_err();
+        let error =
+            Orderbook::parse_and_merge_all_from_yamls(vec![get_document(yaml)]).unwrap_err();
         assert_eq!(
             error,
             YamlError::ParseError("address string missing in orderbook: TestOrderbook".to_string())
@@ -297,7 +331,8 @@ orderbooks:
         address: 0x1234567890123456789012345678901234567890
         network: TestNetwork
 "#;
-        let error = Orderbook::parse_all_from_yaml(get_document(yaml)).unwrap_err();
+        let error =
+            Orderbook::parse_and_merge_all_from_yamls(vec![get_document(yaml)]).unwrap_err();
         assert_eq!(
             error,
             YamlError::ParseError("missing field: networks".to_string())
@@ -313,7 +348,8 @@ orderbooks:
         address: 0x1234567890123456789012345678901234567890
         network: TestNetwork
 "#;
-        let error = Orderbook::parse_all_from_yaml(get_document(yaml)).unwrap_err();
+        let error =
+            Orderbook::parse_and_merge_all_from_yamls(vec![get_document(yaml)]).unwrap_err();
         assert_eq!(error, YamlError::KeyNotFound("TestNetwork".to_string()));
 
         let yaml = r#"
@@ -326,7 +362,8 @@ orderbooks:
         address: 0x1234567890123456789012345678901234567890
         network: TestNetwork
 "#;
-        let error = Orderbook::parse_all_from_yaml(get_document(yaml)).unwrap_err();
+        let error =
+            Orderbook::parse_and_merge_all_from_yamls(vec![get_document(yaml)]).unwrap_err();
         assert_eq!(
             error,
             YamlError::ParseError("missing field: subgraphs".to_string())
@@ -345,7 +382,8 @@ orderbooks:
         network: TestNetwork
         subgraph: TestSubgraph
 "#;
-        let error = Orderbook::parse_all_from_yaml(get_document(yaml)).unwrap_err();
+        let error =
+            Orderbook::parse_and_merge_all_from_yamls(vec![get_document(yaml)]).unwrap_err();
         assert_eq!(error, YamlError::KeyNotFound("TestSubgraph".to_string()));
     }
 }

--- a/crates/settings/src/scenario.rs
+++ b/crates/settings/src/scenario.rs
@@ -11,7 +11,7 @@ use thiserror::Error;
 use typeshare::typeshare;
 use yaml::{
     default_document, optional_hash, optional_string, require_hash, require_string, YamlError,
-    YamlParsableHash,
+    YamlParsableHash, YamlParsableMergableHash,
 };
 
 #[cfg(target_family = "wasm")]
@@ -106,7 +106,8 @@ impl Scenario {
             .transpose()?;
 
         if let Some(deployer_name) = optional_string(scenario_yaml, "deployer") {
-            let current_deployer = Deployer::parse_from_yaml(document.clone(), &deployer_name)?;
+            let current_deployer =
+                Deployer::parse_from_yamls(vec![document.clone()], &deployer_name)?;
 
             if let Some(parent_deployer) = parent_scenario.deployer.as_ref() {
                 if current_deployer.key != parent_deployer.key {

--- a/crates/settings/src/yaml/orderbook.rs
+++ b/crates/settings/src/yaml/orderbook.rs
@@ -19,7 +19,7 @@ impl YamlParsable for OrderbookYaml {
         let document = Arc::new(RwLock::new(doc));
 
         if validate {
-            Network::parse_all_from_yaml(document.clone())?;
+            Network::parse_and_merge_all_from_yamls(vec![document.clone()])?;
         }
         Ok(OrderbookYaml { document })
     }
@@ -27,51 +27,51 @@ impl YamlParsable for OrderbookYaml {
 
 impl OrderbookYaml {
     pub fn get_network_keys(&self) -> Result<Vec<String>, YamlError> {
-        let networks = Network::parse_all_from_yaml(self.document.clone())?;
+        let networks = Network::parse_and_merge_all_from_yamls(vec![self.document.clone()])?;
         Ok(networks.keys().cloned().collect())
     }
     pub fn get_network(&self, key: &str) -> Result<Network, YamlError> {
-        Network::parse_from_yaml(self.document.clone(), key)
+        Network::parse_from_yamls(vec![self.document.clone()], key)
     }
 
     pub fn get_token_keys(&self) -> Result<Vec<String>, YamlError> {
-        let tokens = Token::parse_all_from_yaml(self.document.clone())?;
+        let tokens = Token::parse_and_merge_all_from_yamls(vec![self.document.clone()])?;
         Ok(tokens.keys().cloned().collect())
     }
     pub fn get_token(&self, key: &str) -> Result<Token, YamlError> {
-        Token::parse_from_yaml(self.document.clone(), key)
+        Token::parse_from_yamls(vec![self.document.clone()], key)
     }
 
     pub fn get_subgraph_keys(&self) -> Result<Vec<String>, YamlError> {
-        let subgraphs = Subgraph::parse_all_from_yaml(self.document.clone())?;
+        let subgraphs = Subgraph::parse_and_merge_all_from_yamls(vec![self.document.clone()])?;
         Ok(subgraphs.keys().cloned().collect())
     }
     pub fn get_subgraph(&self, key: &str) -> Result<Subgraph, YamlError> {
-        Subgraph::parse_from_yaml(self.document.clone(), key)
+        Subgraph::parse_from_yamls(vec![self.document.clone()], key)
     }
 
     pub fn get_orderbook_keys(&self) -> Result<Vec<String>, YamlError> {
-        let orderbooks = Orderbook::parse_all_from_yaml(self.document.clone())?;
+        let orderbooks = Orderbook::parse_and_merge_all_from_yamls(vec![self.document.clone()])?;
         Ok(orderbooks.keys().cloned().collect())
     }
     pub fn get_orderbook(&self, key: &str) -> Result<Orderbook, YamlError> {
-        Orderbook::parse_from_yaml(self.document.clone(), key)
+        Orderbook::parse_from_yamls(vec![self.document.clone()], key)
     }
 
     pub fn get_metaboard_keys(&self) -> Result<Vec<String>, YamlError> {
-        let metaboards = Metaboard::parse_all_from_yaml(self.document.clone())?;
+        let metaboards = Metaboard::parse_and_merge_all_from_yamls(vec![self.document.clone()])?;
         Ok(metaboards.keys().cloned().collect())
     }
     pub fn get_metaboard(&self, key: &str) -> Result<Metaboard, YamlError> {
-        Metaboard::parse_from_yaml(self.document.clone(), key)
+        Metaboard::parse_from_yamls(vec![self.document.clone()], key)
     }
 
     pub fn get_deployer_keys(&self) -> Result<Vec<String>, YamlError> {
-        let deployers = Deployer::parse_all_from_yaml(self.document.clone())?;
+        let deployers = Deployer::parse_and_merge_all_from_yamls(vec![self.document.clone()])?;
         Ok(deployers.keys().cloned().collect())
     }
     pub fn get_deployer(&self, key: &str) -> Result<Deployer, YamlError> {
-        Deployer::parse_from_yaml(self.document.clone(), key)
+        Deployer::parse_from_yamls(vec![self.document.clone()], key)
     }
 
     pub fn get_sentry(&self) -> Result<bool, YamlError> {


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

In the app we support having two separate yamls - one for the config (e.g. things in OrderbookYaml) and one for the order itself (DotrainYaml).

At the moment we don't have this functionality for the new yaml structs. We'll need it to refactor DotrainOrder.

## Solution

DotrainYaml now accepts a Vec of additional yamls, and those get passed through when matching dependencies. For example, an `Orderbook` referenced by an `Order` will first be looked for in the current document, then the others in order.

Shadowing is disallowed per the spec.

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [ ] made this PR as small as possible
- [ ] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)
