### PR TITLE
Multiple documents for yaml parsing

### DIFF
--- a/crates/settings/src/gui.rs
+++ b/crates/settings/src/gui.rs
@@ -448,8 +448,8 @@ impl YamlParseableValue for Gui {
                     }
                     gui_deployments_res.insert(deployment_name, gui_deployment);
                 }
-                if gui_res.is_some() {
-                    gui_res.as_mut().unwrap().deployments = gui_deployments_res.clone();
+                if let Some(gui) = &mut gui_res {
+                    gui.deployments.clone_from(&gui_deployments_res);
                 }
             }
         }

--- a/crates/settings/src/gui.rs
+++ b/crates/settings/src/gui.rs
@@ -292,7 +292,7 @@ impl YamlParseableValue for Gui {
                     let deployment_name = deployment_name.as_str().unwrap_or_default().to_string();
 
                     let deployment =
-                        Deployment::parse_from_yaml(document.clone(), &deployment_name)?;
+                        Deployment::parse_from_yaml(vec![document.clone()], &deployment_name)?;
 
                     let name = require_string(
                         deployment_yaml,
@@ -317,7 +317,7 @@ impl YamlParseableValue for Gui {
                             "deposits list missing in gui deployment: {deployment_name}",
                         )),
                     )?.iter().enumerate().map(|(deposit_index, deposit_value)| {
-                        let token =  Token::parse_from_yaml(document.clone(), &require_string(
+                        let token =  Token::parse_from_yaml(vec![document.clone()], &require_string(
                             deposit_value,
                             Some("token"),
                             Some(format!(

--- a/crates/settings/src/gui.rs
+++ b/crates/settings/src/gui.rs
@@ -251,48 +251,59 @@ impl_all_wasm_traits!(Gui);
 impl Gui {}
 
 impl YamlParseableValue for Gui {
-    fn parse_from_yaml(_: Arc<RwLock<StrictYaml>>) -> Result<Self, YamlError> {
+    fn parse_from_yaml(_: Vec<Arc<RwLock<StrictYaml>>>) -> Result<Self, YamlError> {
         Err(YamlError::InvalidTraitFunction)
     }
 
     fn parse_from_yaml_optional(
-        document: Arc<RwLock<StrictYaml>>,
+        documents: Vec<Arc<RwLock<StrictYaml>>>,
     ) -> Result<Option<Self>, YamlError> {
-        let document_read = document.read().map_err(|_| YamlError::ReadLockError)?;
+        let mut gui_res: Option<Gui> = None;
+        let mut gui_deployments_res: HashMap<String, GuiDeployment> = HashMap::new();
 
-        if let Some(gui) = optional_hash(&document_read, "gui") {
-            let name = require_string(
-                get_hash_value(gui, "name", Some("name field missing in gui".to_string()))?,
-                None,
-                Some("name field must be a string in gui".to_string()),
-            )?;
+        for document in &documents {
+            let document_read = document.read().map_err(|_| YamlError::ReadLockError)?;
 
-            let description = require_string(
-                get_hash_value(
-                    gui,
-                    "description",
-                    Some("description field missing in gui".to_string()),
-                )?,
-                None,
-                Some("description field must be a string in gui".to_string()),
-            )?;
+            if let Some(gui) = optional_hash(&document_read, "gui") {
+                let name = require_string(
+                    get_hash_value(gui, "name", Some("name field missing in gui".to_string()))?,
+                    None,
+                    Some("name field must be a string in gui".to_string()),
+                )?;
 
-            let deployments = gui
-                .get(&StrictYaml::String("deployments".to_string()))
-                .ok_or(YamlError::ParseError(
-                    "deployments field missing in gui".to_string(),
-                ))?
-                .as_hash()
-                .ok_or(YamlError::ParseError(
-                    "deployments field must be a map in gui".to_string(),
-                ))?;
-            let gui_deployments = deployments
-                .iter()
-                .map(|(deployment_name, deployment_yaml)| {
+                let description = require_string(
+                    get_hash_value(
+                        gui,
+                        "description",
+                        Some("description field missing in gui".to_string()),
+                    )?,
+                    None,
+                    Some("description field must be a string in gui".to_string()),
+                )?;
+
+                if gui_res.is_none() {
+                    gui_res = Some(Gui {
+                        name,
+                        description,
+                        deployments: gui_deployments_res.clone(),
+                    });
+                }
+
+                let deployments = gui
+                    .get(&StrictYaml::String("deployments".to_string()))
+                    .ok_or(YamlError::ParseError(
+                        "deployments field missing in gui".to_string(),
+                    ))?
+                    .as_hash()
+                    .ok_or(YamlError::ParseError(
+                        "deployments field must be a map in gui".to_string(),
+                    ))?;
+
+                for (deployment_name, deployment_yaml) in deployments {
                     let deployment_name = deployment_name.as_str().unwrap_or_default().to_string();
 
                     let deployment =
-                        Deployment::parse_from_yaml(vec![document.clone()], &deployment_name)?;
+                        Deployment::parse_from_yaml(documents.clone(), &deployment_name)?;
 
                     let name = require_string(
                         deployment_yaml,
@@ -317,7 +328,7 @@ impl YamlParseableValue for Gui {
                             "deposits list missing in gui deployment: {deployment_name}",
                         )),
                     )?.iter().enumerate().map(|(deposit_index, deposit_value)| {
-                        let token =  Token::parse_from_yaml(vec![document.clone()], &require_string(
+                        let token =  Token::parse_from_yaml(documents.clone(), &require_string(
                             deposit_value,
                             Some("token"),
                             Some(format!(
@@ -431,19 +442,19 @@ impl YamlParseableValue for Gui {
                         fields,
                         select_tokens,
                     };
-                    Ok((deployment_name, gui_deployment))
-                })
-                .collect::<Result<HashMap<_, _>, YamlError>>()?;
 
-            let gui: Gui = Gui {
-                name,
-                description,
-                deployments: gui_deployments,
-            };
-            Ok(Some(gui))
-        } else {
-            Ok(None)
+                    if gui_deployments_res.contains_key(&deployment_name) {
+                        return Err(YamlError::KeyShadowing(deployment_name));
+                    }
+                    gui_deployments_res.insert(deployment_name, gui_deployment);
+                }
+                if gui_res.is_some() {
+                    gui_res.as_mut().unwrap().deployments = gui_deployments_res.clone();
+                }
+            }
         }
+
+        Ok(gui_res)
     }
 }
 
@@ -611,7 +622,7 @@ mod tests {
 gui:
     test: test
 "#;
-        let error = Gui::parse_from_yaml_optional(get_document(yaml)).unwrap_err();
+        let error = Gui::parse_from_yaml_optional(vec![get_document(yaml)]).unwrap_err();
         assert_eq!(
             error,
             YamlError::ParseError("name field missing in gui".to_string())
@@ -621,7 +632,7 @@ gui:
     name:
       - test
 "#;
-        let error = Gui::parse_from_yaml_optional(get_document(yaml)).unwrap_err();
+        let error = Gui::parse_from_yaml_optional(vec![get_document(yaml)]).unwrap_err();
         assert_eq!(
             error,
             YamlError::ParseError("name field must be a string in gui".to_string())
@@ -631,7 +642,7 @@ gui:
     name:
       - test: test
 "#;
-        let error = Gui::parse_from_yaml_optional(get_document(yaml)).unwrap_err();
+        let error = Gui::parse_from_yaml_optional(vec![get_document(yaml)]).unwrap_err();
         assert_eq!(
             error,
             YamlError::ParseError("name field must be a string in gui".to_string())
@@ -641,7 +652,7 @@ gui:
 gui:
     name: test
 "#;
-        let error = Gui::parse_from_yaml_optional(get_document(yaml)).unwrap_err();
+        let error = Gui::parse_from_yaml_optional(vec![get_document(yaml)]).unwrap_err();
         assert_eq!(
             error,
             YamlError::ParseError("description field missing in gui".to_string())
@@ -652,7 +663,7 @@ gui:
     description:
       - test
 "#;
-        let error = Gui::parse_from_yaml_optional(get_document(yaml)).unwrap_err();
+        let error = Gui::parse_from_yaml_optional(vec![get_document(yaml)]).unwrap_err();
         assert_eq!(
             error,
             YamlError::ParseError("description field must be a string in gui".to_string())
@@ -663,7 +674,7 @@ gui:
     description:
       - test: test
 "#;
-        let error = Gui::parse_from_yaml_optional(get_document(yaml)).unwrap_err();
+        let error = Gui::parse_from_yaml_optional(vec![get_document(yaml)]).unwrap_err();
         assert_eq!(
             error,
             YamlError::ParseError("description field must be a string in gui".to_string())
@@ -674,7 +685,7 @@ gui:
     name: test
     description: test
 "#;
-        let error = Gui::parse_from_yaml_optional(get_document(yaml)).unwrap_err();
+        let error = Gui::parse_from_yaml_optional(vec![get_document(yaml)]).unwrap_err();
         assert_eq!(
             error,
             YamlError::ParseError("deployments field missing in gui".to_string())
@@ -685,7 +696,7 @@ gui:
     description: test
     deployments: test
 "#;
-        let error = Gui::parse_from_yaml_optional(get_document(yaml)).unwrap_err();
+        let error = Gui::parse_from_yaml_optional(vec![get_document(yaml)]).unwrap_err();
         assert_eq!(
             error,
             YamlError::ParseError("deployments field must be a map in gui".to_string())
@@ -697,7 +708,7 @@ gui:
     deployments:
         - test: test
 "#;
-        let error = Gui::parse_from_yaml_optional(get_document(yaml)).unwrap_err();
+        let error = Gui::parse_from_yaml_optional(vec![get_document(yaml)]).unwrap_err();
         assert_eq!(
             error,
             YamlError::ParseError("deployments field must be a map in gui".to_string())
@@ -711,7 +722,7 @@ gui:
         deployment1:
             test: test
 "#;
-        let error = Gui::parse_from_yaml_optional(get_document(yaml)).unwrap_err();
+        let error = Gui::parse_from_yaml_optional(vec![get_document(yaml)]).unwrap_err();
         assert_eq!(
             error,
             YamlError::ParseError("missing field: deployments".to_string())
@@ -759,8 +770,9 @@ gui:
         deployment1:
             test: test
 "#;
-        let error = Gui::parse_from_yaml_optional(get_document(&format!("{yaml_prefix}{yaml}")))
-            .unwrap_err();
+        let error =
+            Gui::parse_from_yaml_optional(vec![get_document(&format!("{yaml_prefix}{yaml}"))])
+                .unwrap_err();
         assert_eq!(
             error,
             YamlError::ParseError("name string missing in gui deployment: deployment1".to_string())
@@ -774,8 +786,9 @@ gui:
         deployment1:
             name: deployment1
 "#;
-        let error = Gui::parse_from_yaml_optional(get_document(&format!("{yaml_prefix}{yaml}")))
-            .unwrap_err();
+        let error =
+            Gui::parse_from_yaml_optional(vec![get_document(&format!("{yaml_prefix}{yaml}"))])
+                .unwrap_err();
         assert_eq!(
             error,
             YamlError::ParseError(
@@ -792,8 +805,9 @@ gui:
             name: some name
             description: some description
 "#;
-        let error = Gui::parse_from_yaml_optional(get_document(&format!("{yaml_prefix}{yaml}")))
-            .unwrap_err();
+        let error =
+            Gui::parse_from_yaml_optional(vec![get_document(&format!("{yaml_prefix}{yaml}"))])
+                .unwrap_err();
         assert_eq!(
             error,
             YamlError::ParseError(
@@ -812,8 +826,9 @@ gui:
             deposits:
                 - test: test
 "#;
-        let error = Gui::parse_from_yaml_optional(get_document(&format!("{yaml_prefix}{yaml}")))
-            .unwrap_err();
+        let error =
+            Gui::parse_from_yaml_optional(vec![get_document(&format!("{yaml_prefix}{yaml}"))])
+                .unwrap_err();
         assert_eq!(
             error,
             YamlError::ParseError(
@@ -833,8 +848,9 @@ gui:
             deposits:
                 - token: test
 "#;
-        let error = Gui::parse_from_yaml_optional(get_document(&format!("{yaml_prefix}{yaml}")))
-            .unwrap_err();
+        let error =
+            Gui::parse_from_yaml_optional(vec![get_document(&format!("{yaml_prefix}{yaml}"))])
+                .unwrap_err();
         assert_eq!(error, YamlError::KeyNotFound("test".to_string()));
 
         let yaml = r#"
@@ -848,8 +864,9 @@ gui:
             deposits:
                 - token: token1
 "#;
-        let error = Gui::parse_from_yaml_optional(get_document(&format!("{yaml_prefix}{yaml}")))
-            .unwrap_err();
+        let error =
+            Gui::parse_from_yaml_optional(vec![get_document(&format!("{yaml_prefix}{yaml}"))])
+                .unwrap_err();
         assert_eq!(
             error,
             YamlError::ParseError(
@@ -871,8 +888,9 @@ gui:
                   presets:
                     - test: test
 "#;
-        let error = Gui::parse_from_yaml_optional(get_document(&format!("{yaml_prefix}{yaml}")))
-            .unwrap_err();
+        let error =
+            Gui::parse_from_yaml_optional(vec![get_document(&format!("{yaml_prefix}{yaml}"))])
+                .unwrap_err();
         assert_eq!(
             error,
             YamlError::ParseError(
@@ -894,8 +912,9 @@ gui:
                   presets:
                     - "1"
 "#;
-        let error = Gui::parse_from_yaml_optional(get_document(&format!("{yaml_prefix}{yaml}")))
-            .unwrap_err();
+        let error =
+            Gui::parse_from_yaml_optional(vec![get_document(&format!("{yaml_prefix}{yaml}"))])
+                .unwrap_err();
         assert_eq!(
             error,
             YamlError::ParseError("fields list missing in gui deployment: deployment1".to_string())
@@ -916,8 +935,9 @@ gui:
             fields:
                 - test: test
 "#;
-        let error = Gui::parse_from_yaml_optional(get_document(&format!("{yaml_prefix}{yaml}")))
-            .unwrap_err();
+        let error =
+            Gui::parse_from_yaml_optional(vec![get_document(&format!("{yaml_prefix}{yaml}"))])
+                .unwrap_err();
         assert_eq!(
             error,
             YamlError::ParseError(
@@ -941,8 +961,9 @@ gui:
             fields:
                 - binding: test
 "#;
-        let error = Gui::parse_from_yaml_optional(get_document(&format!("{yaml_prefix}{yaml}")))
-            .unwrap_err();
+        let error =
+            Gui::parse_from_yaml_optional(vec![get_document(&format!("{yaml_prefix}{yaml}"))])
+                .unwrap_err();
         assert_eq!(
             error,
             YamlError::ParseError(
@@ -969,8 +990,9 @@ gui:
                     - value:
                         - test
 "#;
-        let error = Gui::parse_from_yaml_optional(get_document(&format!("{yaml_prefix}{yaml}")))
-            .unwrap_err();
+        let error =
+            Gui::parse_from_yaml_optional(vec![get_document(&format!("{yaml_prefix}{yaml}"))])
+                .unwrap_err();
         assert_eq!(
             error,
             YamlError::ParseError(
@@ -999,8 +1021,9 @@ gui:
             select-tokens:
                 - test: test
 "#;
-        let error = Gui::parse_from_yaml_optional(get_document(&format!("{yaml_prefix}{yaml}")))
-            .unwrap_err();
+        let error =
+            Gui::parse_from_yaml_optional(vec![get_document(&format!("{yaml_prefix}{yaml}"))])
+                .unwrap_err();
         assert_eq!(
             error,
             YamlError::ParseError(
@@ -1008,5 +1031,174 @@ gui:
                     .to_string()
             )
         );
+    }
+
+    #[test]
+    fn test_parse_gui_from_yaml_multiple_files() {
+        let yaml_one = r#"
+networks:
+    network1:
+        rpc: https://eth.llamarpc.com
+        chain-id: 1
+deployers:
+    deployer1:
+        address: 0x0000000000000000000000000000000000000000
+        network: network1
+scenarios:
+    scenario1:
+        bindings:
+            test: test
+        deployer: deployer1
+tokens:
+    token1:
+        address: 0x0000000000000000000000000000000000000001
+        network: network1
+    token2:
+        address: 0x0000000000000000000000000000000000000002
+        network: network1
+orders:
+    order1:
+        inputs:
+            - token: token1
+        outputs:
+            - token: token2
+        deployer: deployer1
+deployments:
+    deployment1:
+        scenario: scenario1
+        order: order1
+    deployment2:
+        scenario: scenario1
+        order: order1
+gui:
+    name: test
+    description: test
+    deployments:
+        deployment1:
+            name: test
+            description: test
+            deposits:
+                - token: token1
+                  presets:
+                    - "1"
+            fields:
+                - binding: test
+                  name: test
+                  presets:
+                    - value: test
+"#;
+        let yaml_two = r#"
+gui:
+    name: test
+    description: test
+    deployments:
+        deployment2:
+            name: test another
+            description: test another
+            deposits:
+                - token: token2
+                  presets:
+                    - "1"
+            fields:
+                - binding: test
+                  name: test
+                  presets:
+                    - value: test
+"#;
+        let res =
+            Gui::parse_from_yaml_optional(vec![get_document(yaml_one), get_document(yaml_two)])
+                .unwrap();
+
+        let gui = res.unwrap();
+        assert_eq!(gui.deployments.len(), 2);
+
+        let deployment = gui.deployments.get("deployment1").unwrap();
+        assert_eq!(deployment.name, "test");
+        assert_eq!(deployment.description, "test");
+        assert_eq!(deployment.deposits[0].token.key, "token1");
+
+        let deployment = gui.deployments.get("deployment2").unwrap();
+        assert_eq!(deployment.name, "test another");
+        assert_eq!(deployment.description, "test another");
+        assert_eq!(deployment.deposits[0].token.key, "token2");
+    }
+
+    #[test]
+    fn test_parse_gui_from_yaml_duplicate_key() {
+        let yaml_one = r#"
+networks:
+    network1:
+        rpc: https://eth.llamarpc.com
+        chain-id: 1
+deployers:
+    deployer1:
+        address: 0x0000000000000000000000000000000000000000
+        network: network1
+scenarios:
+    scenario1:
+        bindings:
+            test: test
+        deployer: deployer1
+tokens:
+    token1:
+        address: 0x0000000000000000000000000000000000000001
+        network: network1
+    token2:
+        address: 0x0000000000000000000000000000000000000002
+        network: network1
+orders:
+    order1:
+        inputs:
+            - token: token1
+        outputs:
+            - token: token2
+        deployer: deployer1
+deployments:
+    deployment1:
+        scenario: scenario1
+        order: order1
+    deployment2:
+        scenario: scenario1
+        order: order1
+gui:
+    name: test
+    description: test
+    deployments:
+        deployment1:
+            name: test
+            description: test
+            deposits:
+                - token: token1
+                  presets:
+                    - "1"
+            fields:
+                - binding: test
+                  name: test
+                  presets:
+                    - value: test
+"#;
+        let yaml_two = r#"
+gui:
+    name: test
+    description: test
+    deployments:
+        deployment1:
+            name: test
+            description: test
+            deposits:
+                - token: token1
+                  presets:
+                    - "1"
+            fields:
+                - binding: test
+                  name: test
+                  presets:
+                    - value: test
+"#;
+        let error =
+            Gui::parse_from_yaml_optional(vec![get_document(yaml_one), get_document(yaml_two)])
+                .unwrap_err();
+
+        assert_eq!(error, YamlError::KeyShadowing("deployment1".to_string()));
     }
 }

--- a/crates/settings/src/order.rs
+++ b/crates/settings/src/order.rs
@@ -74,152 +74,152 @@ impl YamlParsableHash for Order {
         for document in &documents {
             let document_read = document.read().map_err(|_| YamlError::ReadLockError)?;
 
-            let orders_hash = require_hash(
-                &document_read,
-                Some("orders"),
-                Some("missing field: orders".to_string()),
-            )?;
+            if let Ok(orders_hash) = require_hash(&document_read, Some("orders"), None) {
+                for (key_yaml, order_yaml) in orders_hash {
+                    let order_key = key_yaml.as_str().unwrap_or_default().to_string();
 
-            for (key_yaml, order_yaml) in orders_hash {
-                let order_key = key_yaml.as_str().unwrap_or_default().to_string();
+                    let mut network: Option<Arc<Network>> = None;
 
-                let mut network: Option<Arc<Network>> = None;
+                    let deployer = match optional_string(order_yaml, "deployer") {
+                        Some(deployer_name) => {
+                            let deployer = Arc::new(Deployer::parse_from_yaml(
+                                documents.clone(),
+                                &deployer_name,
+                            )?);
+                            if let Some(n) = &network {
+                                if deployer.network != *n {
+                                    return Err(YamlError::ParseOrderConfigSourceError(
+                                        ParseOrderConfigSourceError::NetworkNotMatch,
+                                    ));
+                                }
+                            } else {
+                                network = Some(deployer.network.clone());
+                            }
+                            Some(deployer)
+                        }
+                        None => None,
+                    };
 
-                let deployer = match optional_string(order_yaml, "deployer") {
-                    Some(deployer_name) => {
-                        let deployer = Arc::new(Deployer::parse_from_yaml(
-                            documents.clone(),
-                            &deployer_name,
-                        )?);
+                    let orderbook = match optional_string(order_yaml, "orderbook") {
+                        Some(orderbook_name) => {
+                            let orderbook = Arc::new(Orderbook::parse_from_yaml(
+                                documents.clone(),
+                                &orderbook_name,
+                            )?);
+                            if let Some(n) = &network {
+                                if orderbook.network != *n {
+                                    return Err(YamlError::ParseOrderConfigSourceError(
+                                        ParseOrderConfigSourceError::NetworkNotMatch,
+                                    ));
+                                }
+                            } else {
+                                network = Some(orderbook.network.clone());
+                            }
+                            Some(orderbook)
+                        }
+                        None => None,
+                    };
+
+                    let inputs = require_vec(
+                        order_yaml,
+                        "inputs",
+                        Some(format!("inputs list missing in order: {order_key}")),
+                    )?
+                    .iter()
+                    .enumerate()
+                    .map(|(i, input)| {
+                        let token_name = require_string(
+                            input,
+                            Some("token"),
+                            Some(format!(
+                                "token string missing in input index: {i} in order: {order_key}"
+                            )),
+                        )?;
+                        let token = Token::parse_from_yaml(documents.clone(), &token_name)?;
+
                         if let Some(n) = &network {
-                            if deployer.network != *n {
+                            if token.network != *n {
                                 return Err(YamlError::ParseOrderConfigSourceError(
                                     ParseOrderConfigSourceError::NetworkNotMatch,
                                 ));
                             }
                         } else {
-                            network = Some(deployer.network.clone());
+                            network = Some(token.network.clone());
                         }
-                        Some(deployer)
-                    }
-                    None => None,
-                };
 
-                let orderbook = match optional_string(order_yaml, "orderbook") {
-                    Some(orderbook_name) => {
-                        let orderbook = Arc::new(Orderbook::parse_from_yaml(
-                            documents.clone(),
-                            &orderbook_name,
-                        )?);
+                        let vault_id = match optional_string(input, "vault-id") {
+                            Some(id) => Some(Order::validate_vault_id(&id)?),
+                            None => None,
+                        };
+
+                        Ok(OrderIO {
+                            token: Arc::new(token),
+                            vault_id,
+                        })
+                    })
+                    .collect::<Result<Vec<_>, YamlError>>()?;
+
+                    let outputs = require_vec(
+                        order_yaml,
+                        "outputs",
+                        Some(format!("outputs list missing in order: {order_key}")),
+                    )?
+                    .iter()
+                    .enumerate()
+                    .map(|(i, output)| {
+                        let token_name = require_string(
+                            output,
+                            Some("token"),
+                            Some(format!(
+                                "token string missing in output index: {i} in order: {order_key}"
+                            )),
+                        )?;
+                        let token = Token::parse_from_yaml(documents.clone(), &token_name)?;
+
                         if let Some(n) = &network {
-                            if orderbook.network != *n {
+                            if token.network != *n {
                                 return Err(YamlError::ParseOrderConfigSourceError(
                                     ParseOrderConfigSourceError::NetworkNotMatch,
                                 ));
                             }
                         } else {
-                            network = Some(orderbook.network.clone());
+                            network = Some(token.network.clone());
                         }
-                        Some(orderbook)
-                    }
-                    None => None,
-                };
 
-                let inputs = require_vec(
-                    order_yaml,
-                    "inputs",
-                    Some(format!("inputs list missing in order: {order_key}")),
-                )?
-                .iter()
-                .enumerate()
-                .map(|(i, input)| {
-                    let token_name = require_string(
-                        input,
-                        Some("token"),
-                        Some(format!(
-                            "token string missing in input index: {i} in order: {order_key}"
-                        )),
-                    )?;
-                    let token = Token::parse_from_yaml(documents.clone(), &token_name)?;
+                        let vault_id = match optional_string(output, "vault-id") {
+                            Some(id) => Some(Order::validate_vault_id(&id)?),
+                            None => None,
+                        };
 
-                    if let Some(n) = &network {
-                        if token.network != *n {
-                            return Err(YamlError::ParseOrderConfigSourceError(
-                                ParseOrderConfigSourceError::NetworkNotMatch,
-                            ));
-                        }
-                    } else {
-                        network = Some(token.network.clone());
-                    }
+                        Ok(OrderIO {
+                            token: Arc::new(token),
+                            vault_id,
+                        })
+                    })
+                    .collect::<Result<Vec<_>, YamlError>>()?;
 
-                    let vault_id = match optional_string(input, "vault-id") {
-                        Some(id) => Some(Order::validate_vault_id(&id)?),
-                        None => None,
+                    let order = Order {
+                        document: document.clone(),
+                        key: order_key.clone(),
+                        inputs,
+                        outputs,
+                        network: network.ok_or(
+                            ParseOrderConfigSourceError::NetworkNotFoundError(String::new()),
+                        )?,
+                        deployer,
+                        orderbook,
                     };
 
-                    Ok(OrderIO {
-                        token: Arc::new(token),
-                        vault_id,
-                    })
-                })
-                .collect::<Result<Vec<_>, YamlError>>()?;
-
-                let outputs = require_vec(
-                    order_yaml,
-                    "outputs",
-                    Some(format!("outputs list missing in order: {order_key}")),
-                )?
-                .iter()
-                .enumerate()
-                .map(|(i, output)| {
-                    let token_name = require_string(
-                        output,
-                        Some("token"),
-                        Some(format!(
-                            "token string missing in output index: {i} in order: {order_key}"
-                        )),
-                    )?;
-                    let token = Token::parse_from_yaml(documents.clone(), &token_name)?;
-
-                    if let Some(n) = &network {
-                        if token.network != *n {
-                            return Err(YamlError::ParseOrderConfigSourceError(
-                                ParseOrderConfigSourceError::NetworkNotMatch,
-                            ));
-                        }
-                    } else {
-                        network = Some(token.network.clone());
+                    if orders.contains_key(&order_key) {
+                        return Err(YamlError::KeyShadowing(order_key));
                     }
-
-                    let vault_id = match optional_string(output, "vault-id") {
-                        Some(id) => Some(Order::validate_vault_id(&id)?),
-                        None => None,
-                    };
-
-                    Ok(OrderIO {
-                        token: Arc::new(token),
-                        vault_id,
-                    })
-                })
-                .collect::<Result<Vec<_>, YamlError>>()?;
-
-                let order = Order {
-                    document: document.clone(),
-                    key: order_key.clone(),
-                    inputs,
-                    outputs,
-                    network: network.ok_or(ParseOrderConfigSourceError::NetworkNotFoundError(
-                        String::new(),
-                    ))?,
-                    deployer,
-                    orderbook,
-                };
-
-                if orders.contains_key(&order_key) {
-                    return Err(YamlError::KeyShadowing(order_key));
+                    orders.insert(order_key, order);
                 }
-                orders.insert(order_key, order);
             }
+        }
+
+        if orders.is_empty() {
+            return Err(YamlError::ParseError("missing field: orders".to_string()));
         }
 
         Ok(orders)
@@ -631,20 +631,31 @@ orders:
     #[test]
     fn test_parse_orders_from_yaml_multiple_files() {
         let yaml_one = r#"
+networks:
+    mainnet:
+        rpc: "https://mainnet.infura.io"
+        chain-id: "1"
+tokens:
+    token-one:
+        network: mainnet
+        address: 0x1234567890123456789012345678901234567890
+    token-two:
+        network: mainnet
+        address: 0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 orders:
     OrderOne:
         inputs:
-            - token: TokenOne
+            - token: token-one
         outputs:
-            - token: TokenTwo
+            - token: token-two
 "#;
         let yaml_two = r#"
 orders:
     OrderTwo:
         inputs:
-            - token: TokenThree
+            - token: token-one
         outputs:
-            - token: TokenFour
+            - token: token-two
 "#;
 
         let documents = vec![get_document(yaml_one), get_document(yaml_two)];
@@ -661,20 +672,31 @@ orders:
     #[test]
     fn test_parse_orders_from_yaml_duplicate_key() {
         let yaml_one = r#"
+networks:
+    mainnet:
+        rpc: "https://mainnet.infura.io"
+        chain-id: "1"
+tokens:
+    token-one:
+        network: mainnet
+        address: 0x1234567890123456789012345678901234567890
+    token-two:
+        network: mainnet
+        address: 0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 orders:
     DuplicateOrder:
         inputs:
-            - token: TokenOne
+            - token: token-one
         outputs:
-            - token: TokenTwo
+            - token: token-two
 "#;
         let yaml_two = r#"
 orders:
     DuplicateOrder:
         inputs:
-            - token: TokenThree
+            - token: token-one
         outputs:
-            - token: TokenFour
+            - token: token-two
 "#;
 
         let documents = vec![get_document(yaml_one), get_document(yaml_two)];

--- a/crates/settings/src/orderbook.rs
+++ b/crates/settings/src/orderbook.rs
@@ -361,18 +361,24 @@ orderbooks:
     #[test]
     fn test_parse_orderbooks_from_yaml_multiple_files() {
         let yaml_one = r#"
+networks:
+    TestNetwork:
+        rpc: https://rpc.com
+        chain-id: 1
+subgraphs:
+    TestSubgraph: https://subgraph.com
 orderbooks:
     OrderbookOne:
         address: 0x1234567890123456789012345678901234567890
-        network: NetworkOne
-        subgraph: SubgraphOne
+        network: TestNetwork
+        subgraph: TestSubgraph
 "#;
         let yaml_two = r#"
 orderbooks:
     OrderbookTwo:
         address: 0x0987654321098765432109876543210987654321
-        network: NetworkTwo
-        subgraph: SubgraphTwo
+        network: TestNetwork
+        subgraph: TestSubgraph
 "#;
 
         let documents = vec![get_document(yaml_one), get_document(yaml_two)];
@@ -395,18 +401,24 @@ orderbooks:
     #[test]
     fn test_parse_orderbooks_from_yaml_duplicate_key() {
         let yaml_one = r#"
+networks:
+    TestNetwork:
+        rpc: https://rpc.com
+        chain-id: 1
+subgraphs:
+    TestSubgraph: https://subgraph.com
 orderbooks:
     DuplicateOrderbook:
         address: 0x1234567890123456789012345678901234567890
-        network: NetworkOne
-        subgraph: SubgraphOne
+        network: TestNetwork
+        subgraph: TestSubgraph
 "#;
         let yaml_two = r#"
 orderbooks:
     DuplicateOrderbook:
         address: 0x0987654321098765432109876543210987654321
-        network: NetworkTwo
-        subgraph: SubgraphTwo
+        network: TestNetwork
+        subgraph: TestSubgraph
 "#;
 
         let documents = vec![get_document(yaml_one), get_document(yaml_two)];

--- a/crates/settings/src/scenario.rs
+++ b/crates/settings/src/scenario.rs
@@ -54,7 +54,8 @@ impl Scenario {
     }
 
     pub fn validate_scenario(
-        document: Arc<RwLock<StrictYaml>>,
+        documents: Vec<Arc<RwLock<StrictYaml>>>,
+        current_document: Arc<RwLock<StrictYaml>>,
         deployer: &mut Option<Arc<Deployer>>,
         scenarios: &mut HashMap<String, Scenario>,
         parent_scenario: ScenarioParent,
@@ -106,7 +107,7 @@ impl Scenario {
             .transpose()?;
 
         if let Some(deployer_name) = optional_string(scenario_yaml, "deployer") {
-            let current_deployer = Deployer::parse_from_yaml(document.clone(), &deployer_name)?;
+            let current_deployer = Deployer::parse_from_yaml(documents.clone(), &deployer_name)?;
 
             if let Some(parent_deployer) = parent_scenario.deployer.as_ref() {
                 if current_deployer.key != parent_deployer.key {
@@ -124,7 +125,7 @@ impl Scenario {
         scenarios.insert(
             scenario_key.clone(),
             Scenario {
-                document: document.clone(),
+                document: current_document.clone(),
                 key: scenario_key.clone(),
                 bindings: bindings.clone(),
                 runs,
@@ -139,7 +140,8 @@ impl Scenario {
             for (child_key, child_scenario_yaml) in scenarios_yaml {
                 let child_key = child_key.as_str().unwrap_or_default().to_string();
                 Self::validate_scenario(
-                    document.clone(),
+                    documents.clone(),
+                    current_document.clone(),
                     deployer,
                     scenarios,
                     ScenarioParent {
@@ -158,38 +160,41 @@ impl Scenario {
 
 impl YamlParsableHash for Scenario {
     fn parse_all_from_yaml(
-        document: Arc<RwLock<StrictYaml>>,
+        documents: Vec<Arc<RwLock<StrictYaml>>>,
     ) -> Result<HashMap<String, Self>, YamlError> {
-        let document_read = document.read().map_err(|_| YamlError::ReadLockError)?;
-        let scenarios_hash = require_hash(
-            &document_read,
-            Some("scenarios"),
-            Some("missing field: scenarios".to_string()),
-        )?;
-
         let mut scenarios = HashMap::new();
 
-        for (key_yaml, scenario_yaml) in scenarios_hash {
-            let scenario_key = key_yaml.as_str().unwrap_or_default().to_string();
-
-            let mut deployer: Option<Arc<Deployer>> = None;
-
-            Self::validate_scenario(
-                document.clone(),
-                &mut deployer,
-                &mut scenarios,
-                ScenarioParent {
-                    bindings: None,
-                    deployer: None,
-                },
-                scenario_key.clone(),
-                scenario_yaml,
+        for document in &documents {
+            let document_read = document.read().map_err(|_| YamlError::ReadLockError)?;
+            let scenarios_hash = require_hash(
+                &document_read,
+                Some("scenarios"),
+                Some("missing field: scenarios".to_string()),
             )?;
 
-            if deployer.is_none() {
-                return Err(YamlError::ParseScenarioConfigSourceError(
-                    ParseScenarioConfigSourceError::DeployerNotFound(scenario_key),
-                ));
+            for (key_yaml, scenario_yaml) in scenarios_hash {
+                let scenario_key = key_yaml.as_str().unwrap_or_default().to_string();
+
+                let mut deployer: Option<Arc<Deployer>> = None;
+
+                Self::validate_scenario(
+                    documents.clone(),
+                    document.clone(),
+                    &mut deployer,
+                    &mut scenarios,
+                    ScenarioParent {
+                        bindings: None,
+                        deployer: None,
+                    },
+                    scenario_key.clone(),
+                    scenario_yaml,
+                )?;
+
+                if deployer.is_none() {
+                    return Err(YamlError::ParseScenarioConfigSourceError(
+                        ParseScenarioConfigSourceError::DeployerNotFound(scenario_key),
+                    ));
+                }
             }
         }
 
@@ -497,7 +502,7 @@ mod tests {
         let yaml = r#"
 test: test
 "#;
-        let error = Scenario::parse_all_from_yaml(get_document(yaml)).unwrap_err();
+        let error = Scenario::parse_all_from_yaml(vec![get_document(yaml)]).unwrap_err();
         assert_eq!(
             error,
             YamlError::ParseError("missing field: scenarios".to_string())
@@ -508,7 +513,7 @@ scenarios:
     scenario1:
         test: test
 "#;
-        let error = Scenario::parse_all_from_yaml(get_document(yaml)).unwrap_err();
+        let error = Scenario::parse_all_from_yaml(vec![get_document(yaml)]).unwrap_err();
         assert_eq!(
             error,
             YamlError::ParseError("bindings map missing in scenario: scenario1".to_string())
@@ -521,7 +526,7 @@ scenarios:
             key1:
                 - value1
 "#;
-        let error = Scenario::parse_all_from_yaml(get_document(yaml)).unwrap_err();
+        let error = Scenario::parse_all_from_yaml(vec![get_document(yaml)]).unwrap_err();
         assert_eq!(
             error,
             YamlError::ParseError(
@@ -536,7 +541,7 @@ scenarios:
             key1:
                 - value1: value2
 "#;
-        let error = Scenario::parse_all_from_yaml(get_document(yaml)).unwrap_err();
+        let error = Scenario::parse_all_from_yaml(vec![get_document(yaml)]).unwrap_err();
         assert_eq!(
             error,
             YamlError::ParseError(
@@ -563,7 +568,7 @@ scenarios:
                 bindings:
                     key1: value
 "#;
-        let error = Scenario::parse_all_from_yaml(get_document(yaml)).unwrap_err();
+        let error = Scenario::parse_all_from_yaml(vec![get_document(yaml)]).unwrap_err();
         assert_eq!(
             error.to_string(),
             YamlError::ParseScenarioConfigSourceError(
@@ -598,13 +603,133 @@ scenarios:
                     key2: value
                 deployer: testnet
 "#;
-        let error = Scenario::parse_all_from_yaml(get_document(yaml)).unwrap_err();
+        let error = Scenario::parse_all_from_yaml(vec![get_document(yaml)]).unwrap_err();
         assert_eq!(
             error.to_string(),
             YamlError::ParseScenarioConfigSourceError(
                 ParseScenarioConfigSourceError::ParentDeployerShadowedError("testnet".to_string())
             )
             .to_string()
+        );
+    }
+
+    const PREFIX: &str = r#"
+    networks:
+        mainnet:
+            rpc: https://rpc.com
+            chain-id: 1
+        testnet:
+            rpc: https://rpc.com
+            chain-id: 2
+    deployers:
+        mainnet:
+            address: 0x1234567890123456789012345678901234567890
+            network: mainnet
+        testnet:
+            address: 0x1234567890123456789012345678901234567890
+            network: testnet
+    "#;
+
+    #[test]
+    fn test_parse_scenarios_from_yaml_multiple_files() {
+        let yaml_one = r#"
+scenarios:
+    scenario1:
+        deployer: mainnet
+        bindings:
+            key1: binding1
+        scenarios:
+            scenario2:
+                bindings:
+                    key2: binding2
+                deployer: testnet
+"#;
+        let yaml_two = r#"
+scenarios:
+    scenario3:
+        deployer: mainnet
+        bindings:
+            key3: binding3
+        scenarios:
+            scenario4:
+                bindings:
+                    key4: binding4
+                deployer: testnet
+"#;
+
+        let documents = vec![
+            get_document(&format!("{}{}", PREFIX, yaml_one)),
+            get_document(&format!("{}{}", PREFIX, yaml_two)),
+        ];
+        let scenarios = Scenario::parse_all_from_yaml(documents).unwrap();
+
+        assert_eq!(scenarios.len(), 4);
+        assert!(scenarios.contains_key("scenario1"));
+        assert!(scenarios.contains_key("scenario1.scenario2"));
+        assert!(scenarios.contains_key("scenario3"));
+        assert!(scenarios.contains_key("scenario3.scenario4"));
+
+        assert_eq!(
+            scenarios
+                .get("scenario1")
+                .unwrap()
+                .bindings
+                .get("key1")
+                .unwrap(),
+            "binding1"
+        );
+        assert_eq!(
+            scenarios
+                .get("scenario1.scenario2")
+                .unwrap()
+                .bindings
+                .get("key2")
+                .unwrap(),
+            "binding2"
+        );
+        assert_eq!(
+            scenarios
+                .get("scenario3")
+                .unwrap()
+                .bindings
+                .get("key3")
+                .unwrap(),
+            "binding3"
+        );
+        assert_eq!(
+            scenarios
+                .get("scenario3.scenario4")
+                .unwrap()
+                .bindings
+                .get("key4")
+                .unwrap(),
+            "binding4"
+        );
+    }
+
+    #[test]
+    fn test_parse_scenarios_from_yaml_duplicate_key() {
+        let yaml_one = r#"
+scenarios:
+    DuplicateScenario:
+        deployer: mainnet
+        bindings:
+            key1: binding1
+"#;
+        let yaml_two = r#"
+scenarios:
+    DuplicateScenario:
+        deployer: mainnet
+        bindings:
+            key1: binding2
+"#;
+
+        let documents = vec![get_document(yaml_one), get_document(yaml_two)];
+        let error = Scenario::parse_all_from_yaml(documents).unwrap_err();
+
+        assert_eq!(
+            error,
+            YamlError::KeyShadowing("DuplicateScenario".to_string())
         );
     }
 }

--- a/crates/settings/src/scenario.rs
+++ b/crates/settings/src/scenario.rs
@@ -619,23 +619,6 @@ scenarios:
         );
     }
 
-    const PREFIX: &str = r#"
-    networks:
-        mainnet:
-            rpc: https://rpc.com
-            chain-id: 1
-        testnet:
-            rpc: https://rpc.com
-            chain-id: 2
-    deployers:
-        mainnet:
-            address: 0x1234567890123456789012345678901234567890
-            network: mainnet
-        testnet:
-            address: 0x1234567890123456789012345678901234567890
-            network: testnet
-    "#;
-
     #[test]
     fn test_parse_scenarios_from_yaml_multiple_files() {
         let yaml_one = r#"

--- a/crates/settings/src/subgraph.rs
+++ b/crates/settings/src/subgraph.rs
@@ -27,18 +27,19 @@ impl Subgraph {
 
 impl YamlParsableHash for Subgraph {
     fn parse_all_from_yaml(
-        document: Arc<RwLock<StrictYaml>>,
+        documents: Vec<Arc<RwLock<StrictYaml>>>,
     ) -> Result<HashMap<String, Subgraph>, YamlError> {
-        let document_read = document.read().map_err(|_| YamlError::ReadLockError)?;
-        let subgraphs_hash = require_hash(
-            &document_read,
-            Some("subgraphs"),
-            Some("missing field: subgraphs".to_string()),
-        )?;
+        let mut subgraphs = HashMap::new();
 
-        subgraphs_hash
-            .iter()
-            .map(|(key_yaml, subgraph_yaml)| {
+        for document in documents {
+            let document_read = document.read().map_err(|_| YamlError::ReadLockError)?;
+            let subgraphs_hash = require_hash(
+                &document_read,
+                Some("subgraphs"),
+                Some("missing field: subgraphs".to_string()),
+            )?;
+
+            for (key_yaml, subgraph_yaml) in subgraphs_hash {
                 let subgraph_key = key_yaml.as_str().unwrap_or_default().to_string();
 
                 let url = Subgraph::validate_url(&require_string(
@@ -55,9 +56,14 @@ impl YamlParsableHash for Subgraph {
                     url,
                 };
 
-                Ok((subgraph_key, subgraph))
-            })
-            .collect()
+                if subgraphs.contains_key(&subgraph_key) {
+                    return Err(YamlError::KeyShadowing(subgraph_key));
+                }
+                subgraphs.insert(subgraph_key, subgraph);
+            }
+        }
+
+        Ok(subgraphs)
     }
 }
 
@@ -87,7 +93,7 @@ mod test {
         let yaml = r#"
 test: test
 "#;
-        let error = Subgraph::parse_all_from_yaml(get_document(yaml)).unwrap_err();
+        let error = Subgraph::parse_all_from_yaml(vec![get_document(yaml)]).unwrap_err();
         assert_eq!(
             error,
             YamlError::ParseError("missing field: subgraphs".to_string())
@@ -98,7 +104,7 @@ subgraphs:
     TestSubgraph:
         test: https://subgraph.com
 "#;
-        let error = Subgraph::parse_all_from_yaml(get_document(yaml)).unwrap_err();
+        let error = Subgraph::parse_all_from_yaml(vec![get_document(yaml)]).unwrap_err();
         assert_eq!(
             error,
             YamlError::ParseError(
@@ -111,7 +117,7 @@ subgraphs:
     TestSubgraph:
         - https://subgraph.com
 "#;
-        let error = Subgraph::parse_all_from_yaml(get_document(yaml)).unwrap_err();
+        let error = Subgraph::parse_all_from_yaml(vec![get_document(yaml)]).unwrap_err();
         assert_eq!(
             error,
             YamlError::ParseError(
@@ -123,8 +129,60 @@ subgraphs:
 subgraphs:
     TestSubgraph: https://subgraph.com
 "#;
-        let result = Subgraph::parse_all_from_yaml(get_document(yaml)).unwrap();
+        let result = Subgraph::parse_all_from_yaml(vec![get_document(yaml)]).unwrap();
         assert_eq!(result.len(), 1);
         assert!(result.contains_key("TestSubgraph"));
+    }
+
+    #[test]
+    fn test_parse_subgraphs_from_yaml_multiple_files() {
+        let yaml_one = r#"
+subgraphs:
+    mainnet: https://api.thegraph.com/subgraphs/name/mainnet
+    testnet: https://api.thegraph.com/subgraphs/name/testnet
+"#;
+        let yaml_two = r#"
+subgraphs:
+    subgraph-one: https://api.thegraph.com/subgraphs/name/one
+    subgraph-two: https://api.thegraph.com/subgraphs/name/two
+"#;
+        let subgraphs =
+            Subgraph::parse_all_from_yaml(vec![get_document(yaml_one), get_document(yaml_two)])
+                .unwrap();
+
+        assert_eq!(subgraphs.len(), 4);
+        assert_eq!(
+            subgraphs.get("mainnet").unwrap().url,
+            Url::parse("https://api.thegraph.com/subgraphs/name/mainnet").unwrap()
+        );
+        assert_eq!(
+            subgraphs.get("testnet").unwrap().url,
+            Url::parse("https://api.thegraph.com/subgraphs/name/testnet").unwrap()
+        );
+        assert_eq!(
+            subgraphs.get("subgraph-one").unwrap().url,
+            Url::parse("https://api.thegraph.com/subgraphs/name/one").unwrap()
+        );
+        assert_eq!(
+            subgraphs.get("subgraph-two").unwrap().url,
+            Url::parse("https://api.thegraph.com/subgraphs/name/two").unwrap()
+        );
+    }
+
+    #[test]
+    fn test_parse_subgraphs_from_yaml_duplicate_key() {
+        let yaml_one = r#"
+subgraphs:
+    mainnet: https://api.thegraph.com/subgraphs/name/mainnet
+    testnet: https://api.thegraph.com/subgraphs/name/testnet
+"#;
+        let yaml_two = r#"
+subgraphs:
+    mainnet: https://api.thegraph.com/subgraphs/name/mainnet
+"#;
+        let error =
+            Subgraph::parse_all_from_yaml(vec![get_document(yaml_one), get_document(yaml_two)])
+                .unwrap_err();
+        assert_eq!(error, YamlError::KeyShadowing("mainnet".to_string()));
     }
 }

--- a/crates/settings/src/token.rs
+++ b/crates/settings/src/token.rs
@@ -75,22 +75,24 @@ impl Token {
 }
 impl YamlParsableHash for Token {
     fn parse_all_from_yaml(
-        document: Arc<RwLock<StrictYaml>>,
+        documents: Vec<Arc<RwLock<StrictYaml>>>,
     ) -> Result<HashMap<String, Self>, YamlError> {
-        let document_read = document.read().map_err(|_| YamlError::ReadLockError)?;
-        let tokens_hash = require_hash(
-            &document_read,
-            Some("tokens"),
-            Some("missing field: tokens".to_string()),
-        )?;
+        let mut tokens = HashMap::new();
 
-        tokens_hash
-            .into_iter()
-            .map(|(key_yaml, token_yaml)| {
+        for document in &documents {
+            let document_read = document.read().map_err(|_| YamlError::ReadLockError)?;
+
+            let tokens_hash = require_hash(
+                &document_read,
+                Some("tokens"),
+                Some("missing field: tokens".to_string()),
+            )?;
+
+            for (key_yaml, token_yaml) in tokens_hash {
                 let token_key = key_yaml.as_str().unwrap_or_default().to_string();
 
                 let network = Network::parse_from_yaml(
-                    document.clone(),
+                    documents.clone(),
                     &require_string(
                         token_yaml,
                         Some("network"),
@@ -124,9 +126,14 @@ impl YamlParsableHash for Token {
                     symbol,
                 };
 
-                Ok((token_key, token))
-            })
-            .collect()
+                if tokens.contains_key(&token_key) {
+                    return Err(YamlError::KeyShadowing(token_key));
+                }
+                tokens.insert(token_key, token);
+            }
+        }
+
+        Ok(tokens)
     }
 }
 
@@ -282,18 +289,18 @@ mod tests {
 
     #[test]
     fn test_parse_tokens_errors() {
-        let error = Token::parse_all_from_yaml(get_document(
+        let error = Token::parse_all_from_yaml(vec![get_document(
             r#"
 test: test
 "#,
-        ))
+        )])
         .unwrap_err();
         assert_eq!(
             error,
             YamlError::ParseError("missing field: tokens".to_string())
         );
 
-        let error = Token::parse_all_from_yaml(get_document(
+        let error = Token::parse_all_from_yaml(vec![get_document(
             r#"
 networks:
     mainnet:
@@ -303,14 +310,14 @@ tokens:
     token1:
         address: "0x1234567890123456789012345678901234567890"
 "#,
-        ))
+        )])
         .unwrap_err();
         assert_eq!(
             error,
             YamlError::ParseError("network string missing in token: token1".to_string())
         );
 
-        let error = Token::parse_all_from_yaml(get_document(
+        let error = Token::parse_all_from_yaml(vec![get_document(
             r#"
 networks:
     mainnet:
@@ -321,7 +328,7 @@ tokens:
         network: "nonexistent"
         address: "0x1234567890123456789012345678901234567890"
 "#,
-        ))
+        )])
         .unwrap_err();
         assert_eq!(
             error,
@@ -330,7 +337,7 @@ tokens:
             )
         );
 
-        let error = Token::parse_all_from_yaml(get_document(
+        let error = Token::parse_all_from_yaml(vec![get_document(
             r#"
 networks:
     mainnet:
@@ -340,14 +347,14 @@ tokens:
     token1:
         network: "mainnet"
 "#,
-        ))
+        )])
         .unwrap_err();
         assert_eq!(
             error,
             YamlError::ParseError("address string missing in token: token1".to_string())
         );
 
-        let error = Token::parse_all_from_yaml(get_document(
+        let error = Token::parse_all_from_yaml(vec![get_document(
             r#"
 networks:
     mainnet:
@@ -358,10 +365,10 @@ tokens:
         network: "mainnet"
         address: "not_a_valid_address"
 "#,
-        ));
+        )]);
         assert!(error.is_err());
 
-        let error = Token::parse_all_from_yaml(get_document(
+        let error = Token::parse_all_from_yaml(vec![get_document(
             r#"
 networks:
     mainnet:
@@ -373,7 +380,97 @@ tokens:
         address: "0x1234567890123456789012345678901234567890"
         decimals: "not_a_number"
 "#,
-        ));
+        )]);
         assert!(error.is_err());
+    }
+
+    #[test]
+    fn test_parse_tokens_from_yaml_multiple_files() {
+        let yaml_one = r#"
+networks:
+    mainnet:
+        rpc: "https://mainnet.infura.io"
+        chain-id: "1"
+tokens:
+    dai:
+        network: "mainnet"
+        address: "0x6b175474e89094c44da98b954eedeac495271d0f"
+        decimals: "18"
+    usdc:
+        network: "mainnet"
+        address: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+        decimals: "6"
+"#;
+        let yaml_two = r#"
+networks:
+    mainnet:
+        rpc: "https://mainnet.infura.io"
+        chain-id: "1"
+tokens:
+    weth:
+        network: "mainnet"
+        address: "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        decimals: "18"
+    usdt:
+        network: "mainnet"
+        address: "0xdac17f958d2ee523a2206206994597c13d831ec7"
+        decimals: "6"
+"#;
+        let tokens =
+            Token::parse_all_from_yaml(vec![get_document(yaml_one), get_document(yaml_two)])
+                .unwrap();
+
+        assert_eq!(tokens.len(), 4);
+        assert_eq!(
+            tokens.get("dai").unwrap().address,
+            Address::from_str("0x6b175474e89094c44da98b954eedeac495271d0f").unwrap()
+        );
+        assert_eq!(tokens.get("dai").unwrap().decimals, Some(18));
+        assert_eq!(
+            tokens.get("usdc").unwrap().address,
+            Address::from_str("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48").unwrap()
+        );
+        assert_eq!(tokens.get("usdc").unwrap().decimals, Some(6));
+        assert_eq!(
+            tokens.get("weth").unwrap().address,
+            Address::from_str("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2").unwrap()
+        );
+        assert_eq!(tokens.get("weth").unwrap().decimals, Some(18));
+        assert_eq!(
+            tokens.get("usdt").unwrap().address,
+            Address::from_str("0xdac17f958d2ee523a2206206994597c13d831ec7").unwrap()
+        );
+        assert_eq!(tokens.get("usdt").unwrap().decimals, Some(6));
+    }
+
+    #[test]
+    fn test_parse_tokens_from_yaml_duplicate_key() {
+        let yaml_one = r#"
+networks:
+    mainnet:
+        rpc: "https://mainnet.infura.io"
+        chain-id: "1"
+tokens:
+    dai:
+        network: "mainnet"
+        address: "0x6b175474e89094c44da98b954eedeac495271d0f"
+    usdc:
+        network: "mainnet"
+        address: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+"#;
+        let yaml_two = r#"
+networks:
+    mainnet:
+        rpc: "https://mainnet.infura.io"
+        chain-id: "1"
+tokens:
+    dai:
+        network: "mainnet"
+        address: "0x6b175474e89094c44da98b954eedeac495271d0f"
+"#;
+        let error =
+            Token::parse_all_from_yaml(vec![get_document(yaml_one), get_document(yaml_two)])
+                .unwrap_err();
+        assert_eq!(error, YamlError::KeyShadowing("dai".to_string()));
     }
 }

--- a/crates/settings/src/yaml/dotrain.rs
+++ b/crates/settings/src/yaml/dotrain.rs
@@ -5,7 +5,6 @@ use std::sync::{Arc, RwLock};
 #[derive(Debug, Clone)]
 pub struct DotrainYaml {
     pub document: Arc<RwLock<StrictYaml>>,
-    pub orderbook_yaml_documents: Vec<Arc<RwLock<StrictYaml>>>,
 }
 
 impl YamlParsable for DotrainYaml {
@@ -21,33 +20,7 @@ impl YamlParsable for DotrainYaml {
             Order::parse_all_from_yaml(vec![document.clone()])?;
         }
 
-        Ok(DotrainYaml {
-            document,
-            orderbook_yaml_documents: vec![],
-        })
-    }
-}
-
-impl YamlParsableWithOrderbook for DotrainYaml {
-    fn new_with_orderbook(
-        source: String,
-        orderbook_sources: Vec<String>,
-        validate: bool,
-    ) -> Result<Self, YamlError> {
-        let mut dotrain_yaml = Self::new(source, validate)?;
-
-        for source in orderbook_sources {
-            let docs = StrictYamlLoader::load_from_str(&source)?;
-            if docs.is_empty() {
-                return Err(YamlError::EmptyFile);
-            }
-            let doc = docs[0].clone();
-            let document = Arc::new(RwLock::new(doc));
-
-            dotrain_yaml.orderbook_yaml_documents.push(document);
-        }
-
-        Ok(dotrain_yaml)
+        Ok(DotrainYaml { document })
     }
 }
 

--- a/crates/settings/src/yaml/dotrain.rs
+++ b/crates/settings/src/yaml/dotrain.rs
@@ -4,53 +4,59 @@ use std::sync::{Arc, RwLock};
 
 #[derive(Debug, Clone)]
 pub struct DotrainYaml {
-    pub document: Arc<RwLock<StrictYaml>>,
+    pub documents: Vec<Arc<RwLock<StrictYaml>>>,
 }
 
 impl YamlParsable for DotrainYaml {
-    fn new(source: String, validate: bool) -> Result<Self, YamlError> {
-        let docs = StrictYamlLoader::load_from_str(&source)?;
-        if docs.is_empty() {
-            return Err(YamlError::EmptyFile);
+    fn new(sources: Vec<String>, validate: bool) -> Result<Self, YamlError> {
+        let mut documents = Vec::new();
+
+        for source in sources {
+            let docs = StrictYamlLoader::load_from_str(&source)?;
+            if docs.is_empty() {
+                return Err(YamlError::EmptyFile);
+            }
+            let doc = docs[0].clone();
+            let document = Arc::new(RwLock::new(doc));
+
+            documents.push(document);
         }
-        let doc = docs[0].clone();
-        let document = Arc::new(RwLock::new(doc));
 
         if validate {
-            Order::parse_all_from_yaml(vec![document.clone()])?;
+            Order::parse_all_from_yaml(documents.clone())?;
         }
 
-        Ok(DotrainYaml { document })
+        Ok(DotrainYaml { documents })
     }
 }
 
 impl DotrainYaml {
     pub fn get_order_keys(&self) -> Result<Vec<String>, YamlError> {
-        let orders = Order::parse_all_from_yaml(vec![self.document.clone()])?;
+        let orders = Order::parse_all_from_yaml(self.documents.clone())?;
         Ok(orders.keys().cloned().collect())
     }
     pub fn get_order(&self, key: &str) -> Result<Order, YamlError> {
-        Order::parse_from_yaml(vec![self.document.clone()], key)
+        Order::parse_from_yaml(self.documents.clone(), key)
     }
 
     pub fn get_scenario_keys(&self) -> Result<Vec<String>, YamlError> {
-        let scenarios = Scenario::parse_all_from_yaml(vec![self.document.clone()])?;
+        let scenarios = Scenario::parse_all_from_yaml(self.documents.clone())?;
         Ok(scenarios.keys().cloned().collect())
     }
     pub fn get_scenario(&self, key: &str) -> Result<Scenario, YamlError> {
-        Scenario::parse_from_yaml(vec![self.document.clone()], key)
+        Scenario::parse_from_yaml(self.documents.clone(), key)
     }
 
     pub fn get_deployment_keys(&self) -> Result<Vec<String>, YamlError> {
-        let deployments = Deployment::parse_all_from_yaml(vec![self.document.clone()])?;
+        let deployments = Deployment::parse_all_from_yaml(self.documents.clone())?;
         Ok(deployments.keys().cloned().collect())
     }
     pub fn get_deployment(&self, key: &str) -> Result<Deployment, YamlError> {
-        Deployment::parse_from_yaml(vec![self.document.clone()], key)
+        Deployment::parse_from_yaml(self.documents.clone(), key)
     }
 
     pub fn get_gui(&self) -> Result<Option<Gui>, YamlError> {
-        Gui::parse_from_yaml_optional(self.document.clone())
+        Gui::parse_from_yaml_optional(self.documents.clone())
     }
 }
 
@@ -133,8 +139,8 @@ mod tests {
 
     #[test]
     fn test_full_yaml() {
-        let ob_yaml = OrderbookYaml::new(FULL_YAML.to_string(), false).unwrap();
-        let dotrain_yaml = DotrainYaml::new(FULL_YAML.to_string(), false).unwrap();
+        let ob_yaml = OrderbookYaml::new(vec![FULL_YAML.to_string()], false).unwrap();
+        let dotrain_yaml = DotrainYaml::new(vec![FULL_YAML.to_string()], false).unwrap();
 
         assert_eq!(dotrain_yaml.get_order_keys().unwrap().len(), 1);
         let order = dotrain_yaml.get_order("order1").unwrap();

--- a/crates/settings/src/yaml/mod.rs
+++ b/crates/settings/src/yaml/mod.rs
@@ -30,14 +30,6 @@ pub trait YamlParsable: Sized {
     }
 }
 
-pub trait YamlParsableWithOrderbook: YamlParsable + Sized {
-    fn new_with_orderbook(
-        source: String,
-        orderbook_sources: Vec<String>,
-        validate: bool,
-    ) -> Result<Self, YamlError>;
-}
-
 pub trait YamlParsableHash: Sized + Clone {
     fn parse_all_from_yaml(
         documents: Vec<Arc<RwLock<StrictYaml>>>,

--- a/crates/settings/src/yaml/mod.rs
+++ b/crates/settings/src/yaml/mod.rs
@@ -30,6 +30,14 @@ pub trait YamlParsable: Sized {
     }
 }
 
+pub trait YamlParsableWithOrderbook: YamlParsable + Sized {
+    fn new_with_orderbook(
+        source: String,
+        orderbook_sources: Vec<String>,
+        validate: bool,
+    ) -> Result<Self, YamlError>;
+}
+
 pub trait YamlParsableHash: Sized + Clone {
     fn parse_all_from_yaml(
         documents: Vec<Arc<RwLock<StrictYaml>>>,

--- a/crates/settings/src/yaml/mod.rs
+++ b/crates/settings/src/yaml/mod.rs
@@ -19,7 +19,7 @@ use thiserror::Error;
 use url::ParseError as UrlParseError;
 
 pub trait YamlParsable: Sized {
-    fn new(source: String, validate: bool) -> Result<Self, YamlError>;
+    fn new(sources: Vec<String>, validate: bool) -> Result<Self, YamlError>;
 
     fn get_yaml_string(document: Arc<RwLock<StrictYaml>>) -> Result<String, YamlError> {
         let document = document.read().unwrap();
@@ -59,10 +59,10 @@ pub trait YamlParsableString {
 }
 
 pub trait YamlParseableValue: Sized {
-    fn parse_from_yaml(document: Arc<RwLock<StrictYaml>>) -> Result<Self, YamlError>;
+    fn parse_from_yaml(documents: Vec<Arc<RwLock<StrictYaml>>>) -> Result<Self, YamlError>;
 
     fn parse_from_yaml_optional(
-        document: Arc<RwLock<StrictYaml>>,
+        documents: Vec<Arc<RwLock<StrictYaml>>>,
     ) -> Result<Option<Self>, YamlError>;
 }
 

--- a/crates/settings/src/yaml/mod.rs
+++ b/crates/settings/src/yaml/mod.rs
@@ -32,11 +32,14 @@ pub trait YamlParsable: Sized {
 
 pub trait YamlParsableHash: Sized + Clone {
     fn parse_all_from_yaml(
-        document: Arc<RwLock<StrictYaml>>,
+        documents: Vec<Arc<RwLock<StrictYaml>>>,
     ) -> Result<HashMap<String, Self>, YamlError>;
 
-    fn parse_from_yaml(document: Arc<RwLock<StrictYaml>>, key: &str) -> Result<Self, YamlError> {
-        let all = Self::parse_all_from_yaml(document)?;
+    fn parse_from_yaml(
+        documents: Vec<Arc<RwLock<StrictYaml>>>,
+        key: &str,
+    ) -> Result<Self, YamlError> {
+        let all = Self::parse_all_from_yaml(documents)?;
         all.get(key)
             .ok_or_else(|| YamlError::KeyNotFound(key.to_string()))
             .cloned()
@@ -93,6 +96,8 @@ pub enum YamlError {
     WriteLockError,
     #[error("Invalid trait function")]
     InvalidTraitFunction,
+    #[error("Key shadowing found: {0}")]
+    KeyShadowing(String),
     #[error(transparent)]
     ParseNetworkConfigSourceError(#[from] ParseNetworkConfigSourceError),
     #[error(transparent)]

--- a/crates/settings/src/yaml/mod.rs
+++ b/crates/settings/src/yaml/mod.rs
@@ -132,6 +132,7 @@ impl PartialEq for YamlError {
             (Self::ConvertError, Self::ConvertError) => true,
             (Self::ReadLockError, Self::ReadLockError) => true,
             (Self::WriteLockError, Self::WriteLockError) => true,
+            (Self::KeyShadowing(a), Self::KeyShadowing(b)) => a == b,
             (Self::ParseNetworkConfigSourceError(a), Self::ParseNetworkConfigSourceError(b)) => {
                 a == b
             }

--- a/crates/settings/src/yaml/orderbook.rs
+++ b/crates/settings/src/yaml/orderbook.rs
@@ -19,7 +19,7 @@ impl YamlParsable for OrderbookYaml {
         let document = Arc::new(RwLock::new(doc));
 
         if validate {
-            Network::parse_all_from_yaml(document.clone())?;
+            Network::parse_all_from_yaml(vec![document.clone()])?;
         }
         Ok(OrderbookYaml { document })
     }
@@ -27,51 +27,51 @@ impl YamlParsable for OrderbookYaml {
 
 impl OrderbookYaml {
     pub fn get_network_keys(&self) -> Result<Vec<String>, YamlError> {
-        let networks = Network::parse_all_from_yaml(self.document.clone())?;
+        let networks = Network::parse_all_from_yaml(vec![self.document.clone()])?;
         Ok(networks.keys().cloned().collect())
     }
     pub fn get_network(&self, key: &str) -> Result<Network, YamlError> {
-        Network::parse_from_yaml(self.document.clone(), key)
+        Network::parse_from_yaml(vec![self.document.clone()], key)
     }
 
     pub fn get_token_keys(&self) -> Result<Vec<String>, YamlError> {
-        let tokens = Token::parse_all_from_yaml(self.document.clone())?;
+        let tokens = Token::parse_all_from_yaml(vec![self.document.clone()])?;
         Ok(tokens.keys().cloned().collect())
     }
     pub fn get_token(&self, key: &str) -> Result<Token, YamlError> {
-        Token::parse_from_yaml(self.document.clone(), key)
+        Token::parse_from_yaml(vec![self.document.clone()], key)
     }
 
     pub fn get_subgraph_keys(&self) -> Result<Vec<String>, YamlError> {
-        let subgraphs = Subgraph::parse_all_from_yaml(self.document.clone())?;
+        let subgraphs = Subgraph::parse_all_from_yaml(vec![self.document.clone()])?;
         Ok(subgraphs.keys().cloned().collect())
     }
     pub fn get_subgraph(&self, key: &str) -> Result<Subgraph, YamlError> {
-        Subgraph::parse_from_yaml(self.document.clone(), key)
+        Subgraph::parse_from_yaml(vec![self.document.clone()], key)
     }
 
     pub fn get_orderbook_keys(&self) -> Result<Vec<String>, YamlError> {
-        let orderbooks = Orderbook::parse_all_from_yaml(self.document.clone())?;
+        let orderbooks = Orderbook::parse_all_from_yaml(vec![self.document.clone()])?;
         Ok(orderbooks.keys().cloned().collect())
     }
     pub fn get_orderbook(&self, key: &str) -> Result<Orderbook, YamlError> {
-        Orderbook::parse_from_yaml(self.document.clone(), key)
+        Orderbook::parse_from_yaml(vec![self.document.clone()], key)
     }
 
     pub fn get_metaboard_keys(&self) -> Result<Vec<String>, YamlError> {
-        let metaboards = Metaboard::parse_all_from_yaml(self.document.clone())?;
+        let metaboards = Metaboard::parse_all_from_yaml(vec![self.document.clone()])?;
         Ok(metaboards.keys().cloned().collect())
     }
     pub fn get_metaboard(&self, key: &str) -> Result<Metaboard, YamlError> {
-        Metaboard::parse_from_yaml(self.document.clone(), key)
+        Metaboard::parse_from_yaml(vec![self.document.clone()], key)
     }
 
     pub fn get_deployer_keys(&self) -> Result<Vec<String>, YamlError> {
-        let deployers = Deployer::parse_all_from_yaml(self.document.clone())?;
+        let deployers = Deployer::parse_all_from_yaml(vec![self.document.clone()])?;
         Ok(deployers.keys().cloned().collect())
     }
     pub fn get_deployer(&self, key: &str) -> Result<Deployer, YamlError> {
-        Deployer::parse_from_yaml(self.document.clone(), key)
+        Deployer::parse_from_yaml(vec![self.document.clone()], key)
     }
 
     pub fn get_sentry(&self) -> Result<bool, YamlError> {

--- a/crates/settings/src/yaml/orderbook.rs
+++ b/crates/settings/src/yaml/orderbook.rs
@@ -6,76 +6,83 @@ use std::sync::{Arc, RwLock};
 
 #[derive(Debug, Clone)]
 pub struct OrderbookYaml {
-    pub document: Arc<RwLock<StrictYaml>>,
+    pub documents: Vec<Arc<RwLock<StrictYaml>>>,
 }
 
 impl YamlParsable for OrderbookYaml {
-    fn new(source: String, validate: bool) -> Result<Self, YamlError> {
-        let docs = StrictYamlLoader::load_from_str(&source)?;
-        if docs.is_empty() {
-            return Err(YamlError::EmptyFile);
+    fn new(sources: Vec<String>, validate: bool) -> Result<Self, YamlError> {
+        let mut documents = Vec::new();
+
+        for source in sources {
+            let docs = StrictYamlLoader::load_from_str(&source)?;
+            if docs.is_empty() {
+                return Err(YamlError::EmptyFile);
+            }
+            let doc = docs[0].clone();
+            let document = Arc::new(RwLock::new(doc));
+
+            documents.push(document);
         }
-        let doc = docs[0].clone();
-        let document = Arc::new(RwLock::new(doc));
 
         if validate {
-            Network::parse_all_from_yaml(vec![document.clone()])?;
+            Network::parse_all_from_yaml(documents.clone())?;
         }
-        Ok(OrderbookYaml { document })
+
+        Ok(OrderbookYaml { documents })
     }
 }
 
 impl OrderbookYaml {
     pub fn get_network_keys(&self) -> Result<Vec<String>, YamlError> {
-        let networks = Network::parse_all_from_yaml(vec![self.document.clone()])?;
+        let networks = Network::parse_all_from_yaml(self.documents.clone())?;
         Ok(networks.keys().cloned().collect())
     }
     pub fn get_network(&self, key: &str) -> Result<Network, YamlError> {
-        Network::parse_from_yaml(vec![self.document.clone()], key)
+        Network::parse_from_yaml(self.documents.clone(), key)
     }
 
     pub fn get_token_keys(&self) -> Result<Vec<String>, YamlError> {
-        let tokens = Token::parse_all_from_yaml(vec![self.document.clone()])?;
+        let tokens = Token::parse_all_from_yaml(self.documents.clone())?;
         Ok(tokens.keys().cloned().collect())
     }
     pub fn get_token(&self, key: &str) -> Result<Token, YamlError> {
-        Token::parse_from_yaml(vec![self.document.clone()], key)
+        Token::parse_from_yaml(self.documents.clone(), key)
     }
 
     pub fn get_subgraph_keys(&self) -> Result<Vec<String>, YamlError> {
-        let subgraphs = Subgraph::parse_all_from_yaml(vec![self.document.clone()])?;
+        let subgraphs = Subgraph::parse_all_from_yaml(self.documents.clone())?;
         Ok(subgraphs.keys().cloned().collect())
     }
     pub fn get_subgraph(&self, key: &str) -> Result<Subgraph, YamlError> {
-        Subgraph::parse_from_yaml(vec![self.document.clone()], key)
+        Subgraph::parse_from_yaml(self.documents.clone(), key)
     }
 
     pub fn get_orderbook_keys(&self) -> Result<Vec<String>, YamlError> {
-        let orderbooks = Orderbook::parse_all_from_yaml(vec![self.document.clone()])?;
+        let orderbooks = Orderbook::parse_all_from_yaml(self.documents.clone())?;
         Ok(orderbooks.keys().cloned().collect())
     }
     pub fn get_orderbook(&self, key: &str) -> Result<Orderbook, YamlError> {
-        Orderbook::parse_from_yaml(vec![self.document.clone()], key)
+        Orderbook::parse_from_yaml(self.documents.clone(), key)
     }
 
     pub fn get_metaboard_keys(&self) -> Result<Vec<String>, YamlError> {
-        let metaboards = Metaboard::parse_all_from_yaml(vec![self.document.clone()])?;
+        let metaboards = Metaboard::parse_all_from_yaml(self.documents.clone())?;
         Ok(metaboards.keys().cloned().collect())
     }
     pub fn get_metaboard(&self, key: &str) -> Result<Metaboard, YamlError> {
-        Metaboard::parse_from_yaml(vec![self.document.clone()], key)
+        Metaboard::parse_from_yaml(self.documents.clone(), key)
     }
 
     pub fn get_deployer_keys(&self) -> Result<Vec<String>, YamlError> {
-        let deployers = Deployer::parse_all_from_yaml(vec![self.document.clone()])?;
+        let deployers = Deployer::parse_all_from_yaml(self.documents.clone())?;
         Ok(deployers.keys().cloned().collect())
     }
     pub fn get_deployer(&self, key: &str) -> Result<Deployer, YamlError> {
-        Deployer::parse_from_yaml(vec![self.document.clone()], key)
+        Deployer::parse_from_yaml(self.documents.clone(), key)
     }
 
     pub fn get_sentry(&self) -> Result<bool, YamlError> {
-        let value = Sentry::parse_from_yaml_optional(self.document.clone())?;
+        let value = Sentry::parse_from_yaml_optional(self.documents[0].clone())?;
         Ok(value.map_or(false, |v| v == "true"))
     }
 }
@@ -147,7 +154,7 @@ mod tests {
 
     #[test]
     fn test_full_yaml() {
-        let ob_yaml = OrderbookYaml::new(FULL_YAML.to_string(), false).unwrap();
+        let ob_yaml = OrderbookYaml::new(vec![FULL_YAML.to_string()], false).unwrap();
 
         assert_eq!(ob_yaml.get_network_keys().unwrap().len(), 1);
         let network = ob_yaml.get_network("mainnet").unwrap();
@@ -210,7 +217,7 @@ mod tests {
 
     #[test]
     fn test_update_network_rpc() {
-        let ob_yaml = OrderbookYaml::new(FULL_YAML.to_string(), false).unwrap();
+        let ob_yaml = OrderbookYaml::new(vec![FULL_YAML.to_string()], false).unwrap();
 
         let mut network = ob_yaml.get_network("mainnet").unwrap();
         assert_eq!(
@@ -235,7 +242,7 @@ mod tests {
 
     #[test]
     fn test_update_token_address() {
-        let ob_yaml = OrderbookYaml::new(FULL_YAML.to_string(), false).unwrap();
+        let ob_yaml = OrderbookYaml::new(vec![FULL_YAML.to_string()], false).unwrap();
 
         let mut token = ob_yaml.get_token("token1").unwrap();
         assert_eq!(


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

In the application, there could be multiple yaml files that need to be processed together. Our initial pass on the yaml structs does not allow processing multiple yaml documents.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Introduce a vector of documents for the parsing of yaml data. If there are duplicate keys, error is thrown.

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)
