### PR TITLE
Implementing default value support for field values

### DIFF
--- a/crates/js_api/src/gui/field_values.rs
+++ b/crates/js_api/src/gui/field_values.rs
@@ -129,12 +129,25 @@ impl DotrainOrderGui {
         Ok(field_definitions)
     }
 
-    pub fn check_field_values(&self) -> Result<(), GuiError> {
+    pub fn check_field_values(&mut self) -> Result<(), GuiError> {
         let deployment = self.get_current_deployment()?;
 
         for field in deployment.fields.iter() {
-            if !self.field_values.contains_key(&field.binding) {
-                return Err(GuiError::FieldValueNotSet(field.name.clone()));
+            if self.field_values.contains_key(&field.binding) {
+                continue;
+            }
+
+            match &field.default {
+                Some(default_value) => {
+                    self.save_field_value(
+                        field.binding.clone(),
+                        PairValue {
+                            is_preset: false,
+                            value: default_value.clone(),
+                        },
+                    )?;
+                }
+                None => return Err(GuiError::FieldValueNotSet(field.name.clone())),
             }
         }
         Ok(())

--- a/crates/js_api/src/gui/field_values.rs
+++ b/crates/js_api/src/gui/field_values.rs
@@ -112,10 +112,21 @@ impl DotrainOrderGui {
         Ok(field_definition.clone())
     }
 
+    /// Get all field definitions, optionally filtered by whether they have a default value.
     #[wasm_bindgen(js_name = "getAllFieldDefinitions")]
-    pub fn get_all_field_definitions(&self) -> Result<Vec<GuiFieldDefinitionCfg>, GuiError> {
+    pub fn get_all_field_definitions(
+        &self,
+        filter_defaults: Option<bool>,
+    ) -> Result<Vec<GuiFieldDefinitionCfg>, GuiError> {
         let deployment = self.get_current_deployment()?;
-        Ok(deployment.fields.clone())
+        let mut field_definitions = deployment.fields.clone();
+
+        match filter_defaults {
+            Some(true) => field_definitions.retain(|field| field.default.is_some()),
+            Some(false) => field_definitions.retain(|field| field.default.is_none()),
+            None => (),
+        }
+        Ok(field_definitions)
     }
 
     pub fn check_field_values(&self) -> Result<(), GuiError> {

--- a/crates/settings/src/gui.rs
+++ b/crates/settings/src/gui.rs
@@ -49,6 +49,8 @@ pub struct GuiFieldDefinitionSourceCfg {
     pub description: Option<String>,
     #[cfg_attr(target_family = "wasm", tsify(optional))]
     pub presets: Option<Vec<GuiPresetSourceCfg>>,
+    #[cfg_attr(target_family = "wasm", tsify(optional))]
+    pub default: Option<String>,
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
@@ -136,6 +138,7 @@ impl GuiConfigSourceCfg {
                                         .collect::<Result<Vec<_>, ParseGuiConfigSourceError>>()
                                 })
                                 .transpose()?,
+                            default: field_source.default.clone(),
                         })
                     })
                     .collect::<Result<Vec<_>, ParseGuiConfigSourceError>>()?;
@@ -247,6 +250,8 @@ pub struct GuiFieldDefinitionCfg {
     pub description: Option<String>,
     #[cfg_attr(target_family = "wasm", tsify(optional))]
     pub presets: Option<Vec<GuiPresetCfg>>,
+    #[cfg_attr(target_family = "wasm", tsify(optional))]
+    pub default: Option<String>,
 }
 #[cfg(target_family = "wasm")]
 impl_wasm_traits!(GuiFieldDefinitionCfg);
@@ -757,11 +762,14 @@ impl YamlParseableValue for GuiCfg {
                             None => None,
                         };
 
+                        let default = optional_string(field_yaml, "default");
+
                         let gui_field_definition = GuiFieldDefinitionCfg {
                             binding,
                             name: interpolated_name,
                             description: interpolated_description,
-                            presets
+                            presets,
+                            default
                         };
                         Ok(gui_field_definition)
                     })
@@ -834,6 +842,7 @@ mod tests {
                                     value: "0.3".to_string(),
                                 },
                             ]),
+                            default: None,
                         },
                         GuiFieldDefinitionSourceCfg {
                             binding: "test-binding-2".to_string(),
@@ -849,6 +858,7 @@ mod tests {
                                     value: "4.8".to_string(),
                                 },
                             ]),
+                            default: Some("0.015".to_string()),
                         },
                         GuiFieldDefinitionSourceCfg {
                             binding: "test-binding-3".to_string(),
@@ -868,6 +878,7 @@ mod tests {
                                     value: "true".to_string(),
                                 },
                             ]),
+                            default: Some("0.25".to_string()),
                         },
                     ],
                     select_tokens: Some(vec![GuiSelectTokensCfg {
@@ -929,6 +940,7 @@ mod tests {
         assert_eq!(field1.binding, "test-binding");
         assert_eq!(field1.name, "test-name");
         assert_eq!(field1.description, Some("test-description".to_string()));
+        assert_eq!(field1.default, None);
         let presets = field1.presets.as_ref().unwrap();
         assert_eq!(presets.len(), 2);
         assert_eq!(presets[0].name, Some("test-preset".to_string()));
@@ -939,6 +951,7 @@ mod tests {
         assert_eq!(field2.binding, "test-binding-2");
         assert_eq!(field2.name, "test-name-2");
         assert_eq!(field2.description, Some("test-description-2".to_string()));
+        assert_eq!(field2.default, Some("0.015".to_string()));
         let presets = field2.presets.as_ref().unwrap();
         assert_eq!(presets.len(), 2);
         assert_eq!(presets[0].name, None);
@@ -948,6 +961,7 @@ mod tests {
         assert_eq!(field3.binding, "test-binding-3");
         assert_eq!(field3.name, "test-name-3");
         assert_eq!(field3.description, Some("test-description-3".to_string()));
+        assert_eq!(field3.default, Some("0.25".to_string()));
         let presets = field3.presets.as_ref().unwrap();
         assert_eq!(presets.len(), 3);
         assert_eq!(presets[0].value, Address::default().to_string());

--- a/packages/orderbook/test/js_api/gui.test.ts
+++ b/packages/orderbook/test/js_api/gui.test.ts
@@ -720,6 +720,21 @@ describe('Rain Orderbook JS API Package Bindgen Tests - Gui', async function () 
 		it('should throw error during get if field binding is not found', () => {
 			expect(() => gui.getFieldValue('binding-3')).toThrow('Field binding not found: binding-3');
 		});
+
+		it('should correctly filter field definitions', async () => {
+			const allFieldDefinitions: GuiFieldDefinitionCfg[] = gui.getAllFieldDefinitions();
+			assert.equal(allFieldDefinitions.length, 2);
+
+			const fieldDefinitionsWithoutDefaults: GuiFieldDefinitionCfg[] =
+				gui.getAllFieldDefinitions(false);
+			assert.equal(fieldDefinitionsWithoutDefaults.length, 1);
+			assert.equal(fieldDefinitionsWithoutDefaults[0].binding, 'binding-1');
+
+			const fieldDefinitionsWithDefaults: GuiFieldDefinitionCfg[] =
+				gui.getAllFieldDefinitions(true);
+			assert.equal(fieldDefinitionsWithDefaults.length, 1);
+			assert.equal(fieldDefinitionsWithDefaults[0].binding, 'binding-2');
+		});
 	});
 
 	describe('field definition tests', async () => {

--- a/packages/orderbook/test/js_api/gui.test.ts
+++ b/packages/orderbook/test/js_api/gui.test.ts
@@ -726,12 +726,12 @@ describe('Rain Orderbook JS API Package Bindgen Tests - Gui', async function () 
 			assert.equal(allFieldDefinitions.length, 2);
 
 			const fieldDefinitionsWithoutDefaults: GuiFieldDefinitionCfg[] =
-				gui.getAllFieldDefinitions(false);
+				gui.getAllFieldDefinitions(true);
 			assert.equal(fieldDefinitionsWithoutDefaults.length, 1);
 			assert.equal(fieldDefinitionsWithoutDefaults[0].binding, 'binding-1');
 
 			const fieldDefinitionsWithDefaults: GuiFieldDefinitionCfg[] =
-				gui.getAllFieldDefinitions(true);
+				gui.getAllFieldDefinitions(false);
 			assert.equal(fieldDefinitionsWithDefaults.length, 1);
 			assert.equal(fieldDefinitionsWithDefaults[0].binding, 'binding-2');
 		});

--- a/packages/orderbook/test/js_api/gui.test.ts
+++ b/packages/orderbook/test/js_api/gui.test.ts
@@ -12,6 +12,8 @@ import {
 	DepositAndAddOrderCalldataResult,
 	GuiCfg,
 	GuiDeploymentCfg,
+	GuiFieldDefinitionCfg,
+	GuiPresetCfg,
 	IOVaultIds,
 	NameAndDescriptionCfg,
 	TokenDeposit,
@@ -49,6 +51,7 @@ gui:
               value: "false"
             - name: Preset 3
               value: "some-string"
+          default: some-default-value
         - binding: binding-2
           name: Field 2 name
           description: Field 2 description
@@ -732,28 +735,29 @@ describe('Rain Orderbook JS API Package Bindgen Tests - Gui', async function () 
 		});
 
 		it('should get field definition', async () => {
-			const allFieldDefinitions = gui.getAllFieldDefinitions();
+			const allFieldDefinitions: GuiFieldDefinitionCfg[] = gui.getAllFieldDefinitions();
 			assert.equal(allFieldDefinitions.length, 2);
 
-			const fieldDefinition = gui.getFieldDefinition('binding-1');
+			const fieldDefinition: GuiFieldDefinitionCfg = gui.getFieldDefinition('binding-1');
 			assert.equal(fieldDefinition.name, 'Field 1 name');
 			assert.equal(fieldDefinition.description, 'Field 1 description');
-			assert.equal(fieldDefinition.presets.length, 3);
+			assert.equal(fieldDefinition.presets?.length, 3);
+			assert.equal(fieldDefinition.default, 'some-default-value');
 
-			const preset1 = fieldDefinition.presets[0];
-			assert.equal(preset1.name, 'Preset 1');
-			assert.equal(preset1.value, '0x1234567890abcdef1234567890abcdef12345678');
-			const preset2 = fieldDefinition.presets[1];
-			assert.equal(preset2.name, 'Preset 2');
-			assert.equal(preset2.value, 'false');
-			const preset3 = fieldDefinition.presets[2];
-			assert.equal(preset3.name, 'Preset 3');
-			assert.equal(preset3.value, 'some-string');
+			let presets = fieldDefinition.presets as GuiPresetCfg[];
+			assert.equal(presets[0].name, 'Preset 1');
+			assert.equal(presets[0].value, '0x1234567890abcdef1234567890abcdef12345678');
+			assert.equal(presets[1].name, 'Preset 2');
+			assert.equal(presets[1].value, 'false');
+			assert.equal(presets[2].name, 'Preset 3');
+			assert.equal(presets[2].value, 'some-string');
 
-			const fieldDefinition2 = gui.getFieldDefinition('binding-2');
-			assert.equal(fieldDefinition2.presets[0].value, '99.2');
-			assert.equal(fieldDefinition2.presets[1].value, '582.1');
-			assert.equal(fieldDefinition2.presets[2].value, '648.239');
+			const fieldDefinition2: GuiFieldDefinitionCfg = gui.getFieldDefinition('binding-2');
+			presets = fieldDefinition2.presets as GuiPresetCfg[];
+			assert.equal(presets[0].value, '99.2');
+			assert.equal(presets[1].value, '582.1');
+			assert.equal(presets[2].value, '648.239');
+			assert.equal(fieldDefinition2.default, undefined);
 		});
 
 		it('should throw error during get if field binding is not found', () => {

--- a/packages/ui-components/src/__tests__/FieldDefinitionInput.test.ts
+++ b/packages/ui-components/src/__tests__/FieldDefinitionInput.test.ts
@@ -2,6 +2,7 @@ import { render, fireEvent } from '@testing-library/svelte';
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import FieldDefinitionInput from '../lib/components/deployment/FieldDefinitionInput.svelte';
 import { DotrainOrderGui } from '@rainlanguage/orderbook/js_api';
+import userEvent from '@testing-library/user-event';
 
 vi.mock('@rainlanguage/orderbook/js_api', () => ({
 	DotrainOrderGui: vi.fn().mockImplementation(() => ({
@@ -108,5 +109,24 @@ describe('FieldDefinitionInput', () => {
 		});
 
 		expect(queryByText('Custom')).toBeNull();
+	});
+
+	it('renders default value if it exists', async () => {
+		const { getByPlaceholderText } = render(FieldDefinitionInput, {
+			props: {
+				fieldDefinition: { ...mockFieldDefinition, default: 'default value' },
+				gui: mockGui
+			}
+		});
+
+		const input = getByPlaceholderText('Enter custom value') as HTMLInputElement;
+		expect(input.value).toBe('default value');
+
+		await userEvent.type(input, '@');
+
+		expect(mockGui.saveFieldValue).toHaveBeenCalledWith('test-binding', {
+			isPreset: false,
+			value: 'default value@'
+		});
 	});
 });

--- a/packages/ui-components/src/lib/components/deployment/DeploymentSteps.svelte
+++ b/packages/ui-components/src/lib/components/deployment/DeploymentSteps.svelte
@@ -44,7 +44,8 @@
 
 	let allDepositFields: GuiDepositCfg[] = [];
 	let allTokenOutputs: OrderIOCfg[] = [];
-	let allFieldDefinitions: GuiFieldDefinitionCfg[] = [];
+	let allFieldDefinitionsWithoutDefaults: GuiFieldDefinitionCfg[] = [];
+	let allFieldDefinitionsWithDefaults: GuiFieldDefinitionCfg[] = [];
 	let allTokensSelected: boolean = false;
 	let showAdvancedOptions: boolean = false;
 	let checkingDeployment: boolean = false;
@@ -62,7 +63,8 @@
 
 	function getAllFieldDefinitions() {
 		try {
-			allFieldDefinitions = gui.getAllFieldDefinitions();
+			allFieldDefinitionsWithoutDefaults = gui.getAllFieldDefinitions(false);
+			allFieldDefinitionsWithDefaults = gui.getAllFieldDefinitions(true);
 		} catch (e) {
 			DeploymentStepsError.catch(e, DeploymentStepsErrorCode.NO_FIELD_DEFINITIONS);
 		}
@@ -230,11 +232,18 @@
 				{/if}
 
 				{#if allTokensSelected || selectTokens?.length === 0}
-					{#if allFieldDefinitions.length > 0}
-						<FieldDefinitionsSection {allFieldDefinitions} {gui} />
+					{#if allFieldDefinitionsWithoutDefaults.length > 0}
+						<FieldDefinitionsSection
+							allFieldDefinitions={allFieldDefinitionsWithoutDefaults}
+							{gui}
+						/>
 					{/if}
 
 					<Toggle bind:checked={showAdvancedOptions}>Show advanced options</Toggle>
+
+					{#if allFieldDefinitionsWithDefaults.length > 0 && showAdvancedOptions}
+						<FieldDefinitionsSection allFieldDefinitions={allFieldDefinitionsWithDefaults} {gui} />
+					{/if}
 
 					{#if allDepositFields.length > 0 && showAdvancedOptions}
 						<DepositsSection bind:allDepositFields {gui} />

--- a/packages/ui-components/src/lib/components/deployment/FieldDefinitionInput.svelte
+++ b/packages/ui-components/src/lib/components/deployment/FieldDefinitionInput.svelte
@@ -14,12 +14,14 @@
 	export let gui: DotrainOrderGui;
 
 	let currentValue: GuiPresetCfg | undefined;
-	let inputValue: string | null = currentValue?.value || null;
+	let inputValue: string | null = fieldDefinition.default
+		? fieldDefinition.default
+		: currentValue?.value || null;
 
 	onMount(() => {
 		try {
 			currentValue = gui.getFieldValue(fieldDefinition.binding);
-			inputValue = currentValue?.value || null;
+			inputValue = fieldDefinition.default ? fieldDefinition.default : currentValue?.value || null;
 		} catch {
 			currentValue = undefined;
 		}


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

See issue: #1368

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

- Add an optional default field to field value definitions in gui yaml
- Update `getAllFieldDefinitions` function to work with default filter parameter
- Update UI to show field definitions with default value under the advanced options section
- Set input value to default value in field definition if default exist
- During calldata generation, save default value if no input is entered by the user
- Update tests

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)
