### PR TITLE
Change order links to orderHash not order IDs

### DIFF
--- a/crates/js_api/src/subgraph/order.rs
+++ b/crates/js_api/src/subgraph/order.rs
@@ -1,13 +1,12 @@
-use std::collections::{HashMap, HashSet};
-
 use cynic::Id;
 use rain_orderbook_common::types::OrderDetailExtended;
 use rain_orderbook_subgraph_client::{
-    types::common::{SgOrder, SgOrdersListFilterArgs, SgVault},
+    types::common::{SgBytes, SgOrder, SgOrdersListFilterArgs, SgVault},
     MultiOrderbookSubgraphClient, MultiSubgraphArgs, OrderbookSubgraphClient,
     OrderbookSubgraphClientError, SgPaginationArgs,
 };
 use reqwest::Url;
+use std::collections::{HashMap, HashSet};
 use wasm_bindgen_utils::{impl_wasm_traits, prelude::*};
 
 use serde::{Deserialize, Serialize};
@@ -73,11 +72,38 @@ fn sort_vaults(order: &SgOrder) -> HashMap<String, Vec<SgVault>> {
     sorted_vaults
 }
 
+/// Internal function to fetch a single order
+/// Returns the SgOrder struct
+pub async fn get_sg_order_by_hash(
+    url: &str,
+    hash: &str,
+) -> Result<SgOrder, OrderbookSubgraphClientError> {
+    let client = OrderbookSubgraphClient::new(Url::parse(url)?);
+    let order = client
+        .order_detail_by_hash(SgBytes(hash.to_string()))
+        .await?;
+    Ok(order)
+}
+
+/// Fetch a single order
+/// Returns the Order struct with sorted vaults
+#[wasm_bindgen(js_name = "getOrderByHash")]
+pub async fn get_order_by_hash(
+    url: &str,
+    hash: &str,
+) -> Result<JsValue, OrderbookSubgraphClientError> {
+    let order = get_sg_order_by_hash(url, hash).await?;
+    Ok(to_js_value(&OrderWithSortedVaults {
+        order: order.clone(),
+        vaults: sort_vaults(&order),
+    })?)
+}
+
 /// Fetch a single order
 /// Returns the Order struct with sorted vaults
 #[wasm_bindgen(js_name = "getOrder")]
-pub async fn get_order(url: &str, id: &str) -> Result<JsValue, OrderbookSubgraphClientError> {
-    let order = get_sg_order(url, id).await?;
+pub async fn get_order(url: &str, hash: &str) -> Result<JsValue, OrderbookSubgraphClientError> {
+    let order = get_sg_order(url, hash).await?;
     Ok(to_js_value(&OrderWithSortedVaults {
         order: order.clone(),
         vaults: sort_vaults(&order),

--- a/crates/js_api/src/subgraph/order.rs
+++ b/crates/js_api/src/subgraph/order.rs
@@ -18,14 +18,6 @@ pub struct OrderWithSortedVaults {
 }
 impl_wasm_traits!(OrderWithSortedVaults);
 
-/// Internal function to fetch a single order
-/// Returns the SgOrder struct
-pub async fn get_sg_order(url: &str, id: &str) -> Result<SgOrder, OrderbookSubgraphClientError> {
-    let client = OrderbookSubgraphClient::new(Url::parse(url)?);
-    let order = client.order_detail(Id::new(id)).await?;
-    Ok(order)
-}
-
 /// Fetch all orders from multiple subgraphs
 /// Returns a list of OrderWithSubgraphName structs
 #[wasm_bindgen(js_name = "getOrders")]
@@ -93,17 +85,6 @@ pub async fn get_order_by_hash(
     hash: &str,
 ) -> Result<JsValue, OrderbookSubgraphClientError> {
     let order = get_sg_order_by_hash(url, hash).await?;
-    Ok(to_js_value(&OrderWithSortedVaults {
-        order: order.clone(),
-        vaults: sort_vaults(&order),
-    })?)
-}
-
-/// Fetch a single order
-/// Returns the Order struct with sorted vaults
-#[wasm_bindgen(js_name = "getOrder")]
-pub async fn get_order(url: &str, hash: &str) -> Result<JsValue, OrderbookSubgraphClientError> {
-    let order = get_sg_order(url, hash).await?;
     Ok(to_js_value(&OrderWithSortedVaults {
         order: order.clone(),
         vaults: sort_vaults(&order),

--- a/crates/subgraph/src/orderbook_client.rs
+++ b/crates/subgraph/src/orderbook_client.rs
@@ -451,7 +451,7 @@ impl OrderbookSubgraphClient {
     ) -> Result<SgOrder, OrderbookSubgraphClientError> {
         let data = self
             .query::<SgOrderDetailByHashQuery, SgOrderDetailByHashQueryVariables>(
-                SgOrderDetailByHashQueryVariables { hash: hash },
+                SgOrderDetailByHashQueryVariables { hash },
             )
             .await?;
         let order = data

--- a/crates/subgraph/src/orderbook_client.rs
+++ b/crates/subgraph/src/orderbook_client.rs
@@ -5,8 +5,8 @@ use crate::performance::OrderPerformance;
 use crate::types::add_order::{SgTransactionAddOrdersQuery, TransactionAddOrdersVariables};
 use crate::types::common::*;
 use crate::types::order::{
-    SgBatchOrderDetailQuery, SgBatchOrderDetailQueryVariables, SgOrderDetailQuery, SgOrderIdList,
-    SgOrdersListQuery,
+    SgBatchOrderDetailQuery, SgBatchOrderDetailQueryVariables, SgOrderDetailByHashQuery,
+    SgOrderDetailByHashQueryVariables, SgOrderDetailByIdQuery, SgOrderIdList, SgOrdersListQuery,
 };
 use crate::types::order_trade::{SgOrderTradeDetailQuery, SgOrderTradesListQuery};
 use crate::types::remove_order::{
@@ -75,7 +75,7 @@ impl OrderbookSubgraphClient {
     /// Fetch single order
     pub async fn order_detail(&self, id: Id) -> Result<SgOrder, OrderbookSubgraphClientError> {
         let data = self
-            .query::<SgOrderDetailQuery, SgIdQueryVariables>(SgIdQueryVariables { id: &id })
+            .query::<SgOrderDetailByIdQuery, SgIdQueryVariables>(SgIdQueryVariables { id: &id })
             .await?;
         let order = data.order.ok_or(OrderbookSubgraphClientError::Empty)?;
 
@@ -442,5 +442,22 @@ impl OrderbookSubgraphClient {
         }
 
         Ok(data.remove_orders)
+    }
+
+    /// Fetch single order given its hash
+    pub async fn order_detail_by_hash(
+        &self,
+        hash: SgBytes,
+    ) -> Result<SgOrder, OrderbookSubgraphClientError> {
+        let data = self
+            .query::<SgOrderDetailByHashQuery, SgOrderDetailByHashQueryVariables>(
+                SgOrderDetailByHashQueryVariables { hash: hash },
+            )
+            .await?;
+        let order = data
+            .orders
+            .first()
+            .ok_or(OrderbookSubgraphClientError::Empty)?;
+        Ok(order.clone())
     }
 }

--- a/crates/subgraph/src/types/order.rs
+++ b/crates/subgraph/src/types/order.rs
@@ -35,10 +35,27 @@ pub struct SgOrdersListQuery {
     pub orders: Vec<SgOrder>,
 }
 
+#[derive(cynic::QueryVariables, Debug)]
+pub struct SgOrderDetailByHashQueryVariables {
+    pub hash: SgBytes,
+}
+
+#[derive(cynic::QueryFragment, Debug, Serialize)]
+#[cynic(
+    graphql_type = "Query",
+    variables = "SgOrderDetailByHashQueryVariables"
+)]
+#[cfg_attr(target_family = "wasm", derive(Tsify))]
+#[serde(rename_all = "camelCase")]
+pub struct SgOrderDetailByHashQuery {
+    #[arguments(where: { orderHash: $hash })]
+    pub orders: Vec<SgOrder>,
+}
+
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(graphql_type = "Query", variables = "SgIdQueryVariables")]
 #[cfg_attr(target_family = "wasm", derive(Tsify))]
-pub struct SgOrderDetailQuery {
+pub struct SgOrderDetailByIdQuery {
     #[arguments(id: $id)]
     #[cfg_attr(target_family = "wasm", tsify(optional))]
     pub order: Option<SgOrder>,

--- a/crates/subgraph/tests/order_test.rs
+++ b/crates/subgraph/tests/order_test.rs
@@ -1,14 +1,14 @@
 use cynic::Id;
 use insta::assert_snapshot;
 use rain_orderbook_subgraph_client::types::common::*;
-use rain_orderbook_subgraph_client::types::order::SgOrderDetailQuery;
+use rain_orderbook_subgraph_client::types::order::SgOrderDetailByIdQuery;
 
 #[test]
 fn orders_query_gql_output() {
     use cynic::QueryBuilder;
 
     let id = Id::new("1234");
-    let request_body = SgOrderDetailQuery::build(SgIdQueryVariables { id: &id });
+    let request_body = SgOrderDetailByIdQuery::build(SgIdQueryVariables { id: &id });
 
     assert_snapshot!(request_body.query);
 }

--- a/crates/subgraph/tests/snapshots/order_test__orders_query_gql_output.snap
+++ b/crates/subgraph/tests/snapshots/order_test__orders_query_gql_output.snap
@@ -3,7 +3,7 @@ source: crates/subgraph/tests/order_test.rs
 assertion_line: 13
 expression: request_body.query
 ---
-query SgOrderDetailQuery($id: ID!) {
+query SgOrderDetailByIdQuery($id: ID!) {
   order(id: $id) {
     id
     orderBytes

--- a/packages/orderbook/test/js_api/order.test.ts
+++ b/packages/orderbook/test/js_api/order.test.ts
@@ -739,7 +739,7 @@ describe('Rain Orderbook JS API Package Bindgen Tests - SgOrder', async function
 		}
 	});
 
-	it.only('should fetch an order by orderHash', async () => {
+	it('should fetch an order by orderHash', async () => {
 		const mockOrder = {
 			...order1,
 			orderHash: '0xbf8075f73b0a6418d719e52189d59bf35a0949e5983b3edbbc0338c02ab17353'

--- a/packages/orderbook/test/js_api/order.test.ts
+++ b/packages/orderbook/test/js_api/order.test.ts
@@ -6,7 +6,7 @@ import {
 	SgOrder,
 	OrderPerformance,
 	SgOrderWithSubgraphName,
-	OrderWithSortedVaults,
+	OrderWithSortedVaults
 } from '../../dist/types/js_api.js';
 import {
 	getOrder,
@@ -739,32 +739,25 @@ describe('Rain Orderbook JS API Package Bindgen Tests - SgOrder', async function
 		}
 	});
 
-		it('should fetch a single order', async () => {
-		await mockServer.forPost('/sg1').thenReply(200, JSON.stringify({ data: { order: order1 } }));
+	it.only('should fetch an order by orderHash', async () => {
+		const mockOrder = {
+			...order1,
+			orderHash: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
+		};
+		await mockServer
+			.forPost('/sg1')
+			.thenReply(200, JSON.stringify({ data: { order: mockOrder } }));
 
 		try {
-			const result: OrderWithSortedVaults = await getOrder(mockServer.url + '/sg1', order1.id);
-			assert.equal(result.order.id, order1.id);
+			const result: OrderWithSortedVaults = await getOrderByHash(
+				mockServer.url + '/sg1',
+				mockOrder.orderHash
+			);
+
+			assert.equal(result.order.orderHash, mockOrder.orderHash);
 		} catch (e) {
 			console.log(e);
 			assert.fail('expected to resolve, but failed' + (e instanceof Error ? e.message : String(e)));
 		}
 	});
-
-
-	it.only('should fetch an order by orderHash', async () => {
-		await mockServer
-			.forPost('/sg1')
-			.once()
-			.thenReply(200, JSON.stringify({ data: { order: order1 } }));
-
-		try {
-			const result: OrderWithSortedVaults = await getOrder(mockServer.url + '/sg1', order1.orderHash);
-			assert.equal(result.order.id, order1.id);
-	} catch (e) {
-		console.log(e);
-		assert.fail('expected to resolve, but failed' + (e instanceof Error ? e.message : String(e)));
-	}
-});
-
 });

--- a/packages/orderbook/test/js_api/order.test.ts
+++ b/packages/orderbook/test/js_api/order.test.ts
@@ -9,7 +9,6 @@ import {
 	OrderWithSortedVaults
 } from '../../dist/types/js_api.js';
 import {
-	getOrder,
 	getOrders,
 	getOrderByHash,
 	getOrderTradesList,
@@ -380,10 +379,13 @@ describe('Rain Orderbook JS API Package Bindgen Tests - SgOrder', async function
 	afterEach(() => mockServer.stop());
 
 	it('should fetch a single order', async () => {
-		await mockServer.forPost('/sg1').thenReply(200, JSON.stringify({ data: { order: order1 } }));
+		await mockServer.forPost('/sg1').thenReply(200, JSON.stringify({ data: { orders: [order1] } }));
 
 		try {
-			const result: OrderWithSortedVaults = await getOrder(mockServer.url + '/sg1', order1.id);
+			const result: OrderWithSortedVaults = await getOrderByHash(
+				mockServer.url + '/sg1',
+				order1.orderHash
+			);
 			assert.equal(result.order.id, order1.id);
 		} catch (e) {
 			console.log(e);
@@ -713,10 +715,10 @@ describe('Rain Orderbook JS API Package Bindgen Tests - SgOrder', async function
 		await mockServer
 			.forPost('/sg1')
 			.once()
-			.thenReply(200, JSON.stringify({ data: { order: { ...order1, inputs, outputs } } }));
+			.thenReply(200, JSON.stringify({ data: { orders: [{ ...order1, inputs, outputs }] } }));
 
 		try {
-			const result: OrderWithSortedVaults = await getOrder(mockServer.url + '/sg1', order1.id);
+			const result: OrderWithSortedVaults = await getOrderByHash(mockServer.url + '/sg1', order1.orderHash);
 
 			const inputs = result.vaults.get('inputs');
 			const outputs = result.vaults.get('outputs');

--- a/packages/orderbook/test/js_api/order.test.ts
+++ b/packages/orderbook/test/js_api/order.test.ts
@@ -742,7 +742,7 @@ describe('Rain Orderbook JS API Package Bindgen Tests - SgOrder', async function
 	it.only('should fetch an order by orderHash', async () => {
 		const mockOrder = {
 			...order1,
-			orderHash: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
+			orderHash: '0xbf8075f73b0a6418d719e52189d59bf35a0949e5983b3edbbc0338c02ab17353'
 		};
 		await mockServer
 			.forPost('/sg1')
@@ -750,9 +750,10 @@ describe('Rain Orderbook JS API Package Bindgen Tests - SgOrder', async function
 
 		try {
 			const result: OrderWithSortedVaults = await getOrderByHash(
-				mockServer.url + '/sg1',
-				mockOrder.orderHash
+				"https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/ob4-flare/2024-12-13-9dc7/gn",
+				"0xbf8075f73b0a6418d719e52189d59bf35a0949e5983b3edbbc0338c02ab17353"
 			);
+			console.log(result)
 
 			assert.equal(result.order.orderHash, mockOrder.orderHash);
 		} catch (e) {

--- a/packages/orderbook/test/js_api/order.test.ts
+++ b/packages/orderbook/test/js_api/order.test.ts
@@ -746,14 +746,13 @@ describe('Rain Orderbook JS API Package Bindgen Tests - SgOrder', async function
 		};
 		await mockServer
 			.forPost('/sg1')
-			.thenReply(200, JSON.stringify({ data: { order: mockOrder } }));
+			.thenReply(200, JSON.stringify({ data: { orders: [mockOrder] } }));
 
 		try {
 			const result: OrderWithSortedVaults = await getOrderByHash(
-				"https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/ob4-flare/2024-12-13-9dc7/gn",
-				"0xbf8075f73b0a6418d719e52189d59bf35a0949e5983b3edbbc0338c02ab17353"
+				mockServer.url + '/sg1',
+				mockOrder.orderHash
 			);
-			console.log(result)
 
 			assert.equal(result.order.orderHash, mockOrder.orderHash);
 		} catch (e) {

--- a/packages/orderbook/test/js_api/order.test.ts
+++ b/packages/orderbook/test/js_api/order.test.ts
@@ -6,11 +6,12 @@ import {
 	SgOrder,
 	OrderPerformance,
 	SgOrderWithSubgraphName,
-	OrderWithSortedVaults
+	OrderWithSortedVaults,
 } from '../../dist/types/js_api.js';
 import {
 	getOrder,
 	getOrders,
+	getOrderByHash,
 	getOrderTradesList,
 	getOrderTradeDetail,
 	getOrderTradesCount,
@@ -737,4 +738,33 @@ describe('Rain Orderbook JS API Package Bindgen Tests - SgOrder', async function
 			assert.fail('expected to resolve, but failed' + (e instanceof Error ? e.message : String(e)));
 		}
 	});
+
+		it('should fetch a single order', async () => {
+		await mockServer.forPost('/sg1').thenReply(200, JSON.stringify({ data: { order: order1 } }));
+
+		try {
+			const result: OrderWithSortedVaults = await getOrder(mockServer.url + '/sg1', order1.id);
+			assert.equal(result.order.id, order1.id);
+		} catch (e) {
+			console.log(e);
+			assert.fail('expected to resolve, but failed' + (e instanceof Error ? e.message : String(e)));
+		}
+	});
+
+
+	it.only('should fetch an order by orderHash', async () => {
+		await mockServer
+			.forPost('/sg1')
+			.once()
+			.thenReply(200, JSON.stringify({ data: { order: order1 } }));
+
+		try {
+			const result: OrderWithSortedVaults = await getOrder(mockServer.url + '/sg1', order1.orderHash);
+			assert.equal(result.order.id, order1.id);
+	} catch (e) {
+		console.log(e);
+		assert.fail('expected to resolve, but failed' + (e instanceof Error ? e.message : String(e)));
+	}
+});
+
 });

--- a/packages/ui-components/src/__tests__/OrderDetail.test.svelte
+++ b/packages/ui-components/src/__tests__/OrderDetail.test.svelte
@@ -98,6 +98,6 @@
 	</svelte:fragment>
 
 	<svelte:fragment slot="below" let:data>
-		<div>Below content: {data.order.id}</div>
+		<div>Below content: {data.order.orderHash}</div>
 	</svelte:fragment>
 </TanstackPageContentDetail>

--- a/packages/ui-components/src/__tests__/OrderDetail.test.svelte
+++ b/packages/ui-components/src/__tests__/OrderDetail.test.svelte
@@ -4,7 +4,7 @@
 	import ButtonVaultLink from '../lib/components/ButtonVaultLink.svelte';
 	import { createQuery } from '@tanstack/svelte-query';
 	import type { OrderWithSortedVaults } from '@rainlanguage/orderbook/js_api';
-	import { getOrder } from '@rainlanguage/orderbook/js_api';
+	import { getOrderByHash } from '@rainlanguage/orderbook/js_api';
 	import { QKEY_ORDER } from '../lib/queries/keys';
 	import type { Readable } from 'svelte/store';
 	import { Button } from 'flowbite-svelte';
@@ -28,8 +28,10 @@
 
 	$: orderDetailQuery = createQuery<OrderWithSortedVaults>({
 		queryKey: [orderHash, QKEY_ORDER + orderHash],
-		queryFn: () => getOrder(subgraphUrl, orderHash),
-		enabled: !!subgraphUrl && !!orderHash
+		queryFn: () => {
+			return getOrderByHash(subgraphUrl, orderHash);
+		},
+		enabled: !!subgraphUrl
 	});
 </script>
 

--- a/packages/ui-components/src/__tests__/OrderDetail.test.svelte
+++ b/packages/ui-components/src/__tests__/OrderDetail.test.svelte
@@ -21,15 +21,15 @@
 		undefined;
 	export let handleOrderRemoveModal: ((props: OrderRemoveModalProps) => void) | undefined =
 		undefined;
-	export let id: string;
+	export let orderHash: string;
 	export let subgraphUrl: string;
 	export let chainId: number;
 	export let orderbookAddress: Hex;
 
 	$: orderDetailQuery = createQuery<OrderWithSortedVaults>({
-		queryKey: [id, QKEY_ORDER + id],
-		queryFn: () => getOrder(subgraphUrl, id),
-		enabled: !!subgraphUrl && !!id
+		queryKey: [orderHash, QKEY_ORDER + orderHash],
+		queryFn: () => getOrder(subgraphUrl, orderHash),
+		enabled: !!subgraphUrl && !!orderHash
 	});
 </script>
 
@@ -58,7 +58,7 @@
 		{/if}
 
 		<Refresh
-			on:click={async () => await invalidateIdQuery(queryClient, id)}
+			on:click={async () => await invalidateIdQuery(queryClient, orderHash)}
 			spin={$orderDetailQuery.isLoading || $orderDetailQuery.isFetching}
 		/>
 	</svelte:fragment>

--- a/packages/ui-components/src/__tests__/OrderDetail.test.ts
+++ b/packages/ui-components/src/__tests__/OrderDetail.test.ts
@@ -5,7 +5,6 @@ import { expect } from '../lib/test/matchers';
 import OrderDetail from './OrderDetail.test.svelte';
 import type { SgOrder, SgVault } from '@rainlanguage/orderbook/js_api';
 import userEvent from '@testing-library/user-event';
-import type { Config } from 'wagmi';
 
 const { mockWalletAddressMatchesOrBlankStore } = await vi.hoisted(
 	() => import('../lib/__mocks__/stores')
@@ -24,13 +23,6 @@ const mockOrder: SgOrder = {
 } as unknown as SgOrder;
 
 vi.mock('@tanstack/svelte-query');
-
-const wagmiConfig = {
-	chains: [],
-	signer: {
-		address: '0x123'
-	}
-} as unknown as Config;
 
 const chainId = 1;
 const orderbookAddress = '0x123';
@@ -52,7 +44,7 @@ describe('OrderDetail Component', () => {
 
 		render(OrderDetail, {
 			props: {
-				id: 'mockId',
+				orderHash: 'mockHash',
 				subgraphUrl: 'https://example.com',
 				walletAddressMatchesOrBlank: mockWalletAddressMatchesOrBlankStore,
 				chainId,
@@ -83,7 +75,7 @@ describe('OrderDetail Component', () => {
 
 		render(OrderDetail, {
 			props: {
-				id: mockOrder.id,
+				orderHash: 'mockHash',
 				subgraphUrl: 'https://example.com',
 				walletAddressMatchesOrBlank: mockWalletAddressMatchesOrBlankStore,
 				handleOrderRemoveModal,
@@ -103,7 +95,7 @@ describe('OrderDetail Component', () => {
 
 		render(OrderDetail, {
 			props: {
-				id: mockOrder.id,
+				orderHash: 'mockHash',
 				subgraphUrl: 'https://example.com',
 				walletAddressMatchesOrBlank: mockWalletAddressMatchesOrBlankStore,
 				handleOrderRemoveModal: vi.fn(),
@@ -120,6 +112,7 @@ describe('OrderDetail Component', () => {
 	it('correctly categorizes and displays vaults in input, output, and shared categories', async () => {
 		const vault1 = {
 			id: '1',
+			orderHash: 'mockHash',
 			vaultId: '0xabc',
 			owner: '0x123',
 			token: {
@@ -138,7 +131,8 @@ describe('OrderDetail Component', () => {
 			}
 		} as unknown as SgVault;
 		const vault2 = {
-			id: '2',
+				id: '2',
+			orderHash: 'mockHash',
 			vaultId: '0xbcd',
 			owner: '0x123',
 			token: {
@@ -160,6 +154,7 @@ describe('OrderDetail Component', () => {
 			id: '3',
 			vaultId: '0xdef',
 			owner: '0x123',
+			orderHash: 'mockHash',
 			token: {
 				id: '0x456',
 				address: '0x456',
@@ -204,7 +199,7 @@ describe('OrderDetail Component', () => {
 		mockWalletAddressMatchesOrBlankStore.mockSetSubscribeValue(() => true);
 		render(OrderDetail, {
 			props: {
-				id: mockOrderWithVaults.id,
+				orderHash: mockOrderWithVaults.orderHash,
 				subgraphUrl: 'https://example.com',
 				walletAddressMatchesOrBlank: mockWalletAddressMatchesOrBlankStore,
 				chainId,
@@ -245,7 +240,7 @@ describe('OrderDetail Component', () => {
 
 		render(OrderDetail, {
 			props: {
-				id: 'mockId',
+				orderHash: 'mockHash',
 				subgraphUrl: 'https://example.com',
 				walletAddressMatchesOrBlank: mockWalletAddressMatchesOrBlankStore,
 				chainId,
@@ -258,10 +253,12 @@ describe('OrderDetail Component', () => {
 
 		await waitFor(() => {
 			expect(mockInvalidateQueries).toHaveBeenCalledWith({
-				queryKey: ['mockId'],
+				queryKey: ['mockHash'],
 				refetchType: 'all',
 				exact: false
 			});
 		});
 	});
 });
+
+

--- a/packages/ui-components/src/__tests__/OrderDetail.test.ts
+++ b/packages/ui-components/src/__tests__/OrderDetail.test.ts
@@ -131,7 +131,7 @@ describe('OrderDetail Component', () => {
 			}
 		} as unknown as SgVault;
 		const vault2 = {
-				id: '2',
+			id: '2',
 			orderHash: 'mockHash',
 			vaultId: '0xbcd',
 			owner: '0x123',
@@ -260,5 +260,3 @@ describe('OrderDetail Component', () => {
 		});
 	});
 });
-
-

--- a/packages/ui-components/src/__tests__/OrderOrVaultHash.test.ts
+++ b/packages/ui-components/src/__tests__/OrderOrVaultHash.test.ts
@@ -34,7 +34,7 @@ describe('OrderOrVaultHash', () => {
 		const button = getByTestId('vault-order-input');
 		expect(button).toBeTruthy();
 		expect(button.classList.toString()).toContain('text-white bg-green');
-		expect(button.getAttribute('data-id')).toBe('123');
+		expect(button.getAttribute('data-id')).toBe('0x123abc');
 	});
 
 	it('renders with inactive order', () => {

--- a/packages/ui-components/src/__tests__/transactionStore.test.ts
+++ b/packages/ui-components/src/__tests__/transactionStore.test.ts
@@ -58,7 +58,7 @@ describe('transactionStore', () => {
 			data: null,
 			functionName: '',
 			message: '',
-			newOrderId: '',
+			newOrderHash: '',
 			network: ''
 		});
 	});
@@ -297,12 +297,12 @@ describe('transactionStore', () => {
 		const mockSubgraphUrl = 'test.com';
 		const mockTxHash = 'mockHash';
 		const mockNetwork = 'flare';
-		const mockOrderId = 'order123';
+		const mockOrderHash = 'order123';
 
 		(getTransactionAddOrders as Mock).mockResolvedValue([
 			{
 				order: {
-					id: mockOrderId
+					orderHash: mockOrderHash
 				}
 			}
 		]);
@@ -316,7 +316,7 @@ describe('transactionStore', () => {
 		await waitFor(() => {
 			expect(get(transactionStore).status).toBe(TransactionStatus.SUCCESS);
 			expect(get(transactionStore).hash).toBe(mockTxHash);
-			expect(get(transactionStore).newOrderId).toBe(mockOrderId);
+			expect(get(transactionStore).newOrderHash).toBe(mockOrderHash);
 			expect(get(transactionStore).network).toBe(mockNetwork);
 		});
 	});

--- a/packages/ui-components/src/lib/components/OrderOrVaultHash.svelte
+++ b/packages/ui-components/src/lib/components/OrderOrVaultHash.svelte
@@ -13,8 +13,8 @@
 	let hash;
 
 	$: isOrder = 'orderHash' in (orderOrVault || {});
-	$: slug = isOrder ? (orderOrVault as SgOrder).id : (orderOrVault as SgVault)?.id;
-	$: hash = isOrder ? (orderOrVault as SgOrder).id : (orderOrVault as SgVault)?.id || '';
+	$: slug = isOrder ? (orderOrVault as SgOrder).orderHash : (orderOrVault as SgVault)?.id;
+	$: hash = isOrder ? (orderOrVault as SgOrder).orderHash : (orderOrVault as SgVault)?.id || '';
 	$: isActive = isOrder ? (orderOrVault as SgOrderAsIO).active : false;
 </script>
 

--- a/packages/ui-components/src/lib/components/detail/OrderDetail.svelte
+++ b/packages/ui-components/src/lib/components/detail/OrderDetail.svelte
@@ -12,7 +12,7 @@
 	import { QKEY_ORDER } from '../../queries/keys';
 	import CodeMirrorRainlang from '../CodeMirrorRainlang.svelte';
 	import { getOrderByHash, type OrderWithSortedVaults } from '@rainlanguage/orderbook/js_api';
-	import { createQuery, dataTagSymbol, useQueryClient } from '@tanstack/svelte-query';
+	import { createQuery, useQueryClient } from '@tanstack/svelte-query';
 	import { Button, TabItem, Tabs } from 'flowbite-svelte';
 	import { onDestroy } from 'svelte';
 	import type { Writable } from 'svelte/store';

--- a/packages/ui-components/src/lib/components/detail/OrderDetail.svelte
+++ b/packages/ui-components/src/lib/components/detail/OrderDetail.svelte
@@ -11,8 +11,8 @@
 	import OrderVaultsVolTable from '../tables/OrderVaultsVolTable.svelte';
 	import { QKEY_ORDER } from '../../queries/keys';
 	import CodeMirrorRainlang from '../CodeMirrorRainlang.svelte';
-	import { getOrder, type OrderWithSortedVaults } from '@rainlanguage/orderbook/js_api';
-	import { createQuery, useQueryClient } from '@tanstack/svelte-query';
+	import { getOrderByHash, type OrderWithSortedVaults } from '@rainlanguage/orderbook/js_api';
+	import { createQuery, dataTagSymbol, useQueryClient } from '@tanstack/svelte-query';
 	import { Button, TabItem, Tabs } from 'flowbite-svelte';
 	import { onDestroy } from 'svelte';
 	import type { Writable } from 'svelte/store';
@@ -41,7 +41,7 @@
 	export let codeMirrorTheme;
 	export let lightweightChartsTheme;
 	export let orderbookAddress: Hex;
-	export let id: string;
+	export let orderHash: string;
 	export let rpcUrl: string;
 	export let subgraphUrl: string;
 	export let chainId: number | undefined;
@@ -53,15 +53,15 @@
 	const queryClient = useQueryClient();
 
 	$: orderDetailQuery = createQuery<OrderWithSortedVaults>({
-		queryKey: [id, QKEY_ORDER + id],
+		queryKey: [orderHash, QKEY_ORDER + orderHash],
 		queryFn: () => {
-			return getOrder(subgraphUrl, id);
+			return getOrderByHash(subgraphUrl, orderHash);
 		},
 		enabled: !!subgraphUrl
 	});
 
 	const interval = setInterval(async () => {
-		await invalidateIdQuery(queryClient, id);
+		await invalidateIdQuery(queryClient, orderHash);
 	}, 10000);
 
 	onDestroy(() => {
@@ -107,7 +107,7 @@
 					</Button>
 				{/if}
 				<Refresh
-					on:click={async () => await invalidateIdQuery(queryClient, id)}
+					on:click={async () => await invalidateIdQuery(queryClient, orderHash)}
 					spin={$orderDetailQuery.isLoading || $orderDetailQuery.isFetching}
 				/>
 			</div>
@@ -165,12 +165,12 @@
 			{/each}
 		</div>
 	</svelte:fragment>
-	<svelte:fragment slot="chart">
-		<OrderTradesChart {id} {subgraphUrl} {lightweightChartsTheme} {colorTheme} />
+	<svelte:fragment slot="chart" let:data>
+		<OrderTradesChart id={data.order.id} {subgraphUrl} {lightweightChartsTheme} {colorTheme} />
 	</svelte:fragment>
 	<svelte:fragment slot="below" let:data>
 		<TanstackOrderQuote
-			{id}
+			id={data.order.id}
 			order={data.order}
 			{rpcUrl}
 			{orderbookAddress}
@@ -192,13 +192,13 @@
 				</div>
 			</TabItem>
 			<TabItem open title="Trades">
-				<OrderTradesListTable {id} {subgraphUrl} />
+				<OrderTradesListTable id={data.order.id} {subgraphUrl} />
 			</TabItem>
 			<TabItem title="Volume">
-				<OrderVaultsVolTable {id} {subgraphUrl} />
+				<OrderVaultsVolTable id={data.order.id} {subgraphUrl} />
 			</TabItem>
 			<TabItem title="APY">
-				<OrderApy {id} {subgraphUrl} />
+				<OrderApy id={data.order.id} {subgraphUrl} />
 			</TabItem>
 		</Tabs>
 	</svelte:fragment>

--- a/packages/ui-components/src/lib/components/tables/OrdersListTable.svelte
+++ b/packages/ui-components/src/lib/components/tables/OrdersListTable.svelte
@@ -110,7 +110,7 @@
 	on:clickRow={(e) => {
 		activeNetworkRef.set(e.detail.item.subgraphName);
 		activeOrderbookRef.set(e.detail.item.subgraphName);
-		goto(`/orders/${e.detail.item.subgraphName}-${e.detail.item.order.id}`);
+		goto(`/orders/${e.detail.item.subgraphName}-${e.detail.item.order.orderHash}`);
 	}}
 >
 	<svelte:fragment slot="title">

--- a/packages/ui-components/src/lib/stores/transactionStore.ts
+++ b/packages/ui-components/src/lib/stores/transactionStore.ts
@@ -82,7 +82,7 @@ export type TransactionState = {
 	data: null;
 	functionName: string;
 	message: string;
-	newOrderId: string;
+	newOrderHash: string;
 	network: string;
 };
 
@@ -106,7 +106,7 @@ const initialState: TransactionState = {
 	data: null,
 	functionName: '',
 	message: '',
-	newOrderId: '',
+	newOrderHash: '',
 	network: ''
 };
 
@@ -166,7 +166,7 @@ const transactionStore = () => {
 				return transactionError(TransactionErrorMessage.TIMEOUT);
 			} else if (addOrders?.length > 0) {
 				clearInterval(interval);
-				return transactionSuccess(txHash, '', addOrders[0].order.id, network);
+				return transactionSuccess(txHash, '', addOrders[0].order.orderHash, network);
 			}
 		}, 1000);
 	};
@@ -225,7 +225,7 @@ const transactionStore = () => {
 	const transactionSuccess = (
 		hash: string,
 		message?: string,
-		newOrderId?: string,
+		newOrderHash?: string,
 		network?: string
 	) => {
 		update((state) => ({
@@ -233,7 +233,7 @@ const transactionStore = () => {
 			status: TransactionStatus.SUCCESS,
 			hash: hash,
 			message: message || '',
-			newOrderId: newOrderId || '',
+			newOrderHash: newOrderHash || '',
 			network: network || ''
 		}));
 	};

--- a/packages/webapp/src/lib/components/TransactionModal.svelte
+++ b/packages/webapp/src/lib/components/TransactionModal.svelte
@@ -80,7 +80,7 @@
 				</div>
 			{:else}
 				<div
-					class="bg-primary-100 dark:bg-primary-900 mb-4 flex h-16 w-16 items-center justify-center rounded-full"
+					class="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-primary-100 dark:bg-primary-900"
 				>
 					<Spinner color="blue" size={10} />
 				</div>

--- a/packages/webapp/src/lib/components/TransactionModal.svelte
+++ b/packages/webapp/src/lib/components/TransactionModal.svelte
@@ -69,8 +69,8 @@
 					</div>
 					<div class="flex flex-col gap-2">
 						<div class="flex flex-row justify-center gap-2">
-							{#if $transactionStore.newOrderId && $transactionStore.network}
-								<a href={`/orders/${$transactionStore.network}-${$transactionStore.newOrderId}`}>
+							{#if $transactionStore.newOrderHash && $transactionStore.network}
+								<a href={`/orders/${$transactionStore.network}-${$transactionStore.newOrderHash}`}>
 									<Button on:click={handleClose} color="alternative">View Order</Button>
 								</a>
 							{/if}
@@ -80,7 +80,7 @@
 				</div>
 			{:else}
 				<div
-					class="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-primary-100 dark:bg-primary-900"
+					class="bg-primary-100 dark:bg-primary-900 mb-4 flex h-16 w-16 items-center justify-center rounded-full"
 				>
 					<Spinner color="blue" size={10} />
 				</div>

--- a/packages/webapp/src/routes/orders/[network]-[orderHash]/+page.svelte
+++ b/packages/webapp/src/routes/orders/[network]-[orderHash]/+page.svelte
@@ -15,7 +15,7 @@
 	import { fade } from 'svelte/transition';
 
 	const queryClient = useQueryClient();
-	const { id, network } = $page.params;
+	const { orderHash, network } = $page.params;
 	const { settings } = $page.data.stores;
 	const orderbookAddress = $settings?.orderbooks[network]?.address;
 	const subgraphUrl = $settings.subgraphs[network];
@@ -38,7 +38,7 @@
 
 	$: if ($transactionStore.status === TransactionStatus.SUCCESS) {
 		queryClient.invalidateQueries({
-			queryKey: [$page.params.id],
+			queryKey: [orderHash],
 			refetchType: 'all',
 			exact: false
 		});
@@ -56,7 +56,7 @@
 	</Toast>
 {/if}
 <OrderDetail
-	{id}
+	{orderHash}
 	{subgraphUrl}
 	{rpcUrl}
 	{codeMirrorTheme}

--- a/tauri-app/src/routes/orders/[network]-[orderHash]/+page.svelte
+++ b/tauri-app/src/routes/orders/[network]-[orderHash]/+page.svelte
@@ -6,7 +6,7 @@
   import { settings } from '$lib/stores/settings';
   import { handleDebugTradeModal, handleQuoteDebugModal } from '$lib/services/modal';
   import type { Hex } from 'viem';
-  const { id, network } = $page.params;
+  const { orderHash, network } = $page.params;
 
   const orderbookAddress = $settings?.orderbooks?.[network]?.address as Hex;
   const subgraphUrl = $settings?.subgraphs?.[network];
@@ -17,7 +17,7 @@
 <PageHeader title="Order" pathname={$page.url.pathname} />
 {#if rpcUrl && subgraphUrl && orderbookAddress}
   <OrderDetail
-    {id}
+    {orderHash}
     {rpcUrl}
     {subgraphUrl}
     {colorTheme}


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

- This raises another issue about whether all order id use in rust should be hash instead. Since all sub-components of OrderDetail  currently require the ID.

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)
