### PR TITLE
Remove trade count from orders table

### DIFF
--- a/packages/ui-components/src/lib/components/tables/OrdersListTable.svelte
+++ b/packages/ui-components/src/lib/components/tables/OrdersListTable.svelte
@@ -130,7 +130,6 @@
 		<TableHeadCell data-testid="orderListHeadingOutputs" padding="px-2 py-4"
 			>Output Token(s)</TableHeadCell
 		>
-		<TableHeadCell data-testid="orderListHeadingTrades" padding="px-2 py-4">Trades</TableHeadCell>
 	</svelte:fragment>
 
 	<svelte:fragment slot="bodyRow" let:item>
@@ -162,9 +161,7 @@
 		<TableBodyCell data-testid="orderListRowOutputs" tdClass="break-word p-2">
 			{item.order.outputs?.map((t) => t.token.symbol)}
 		</TableBodyCell>
-		<TableBodyCell data-testid="orderListRowTrades" tdClass="break-word p-2"
-			>{item.order.trades.length > 99 ? '>99' : item.order.trades.length}</TableBodyCell
-		>
+
 		{#if walletAddressMatchesOrBlank && handleOrderRemoveModal}
 			<div data-testid="wallet-actions">
 				<TableBodyCell tdClass="px-0 text-right">


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

Since there are potentially thousands of entities in the trades array, it wouldn't be wise to create a count by showing the length of trades array.

Closes #947 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [ ] made this PR as small as possible
- [ ] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)
