### PR TITLE
Remove replace select token function in gui sdk

### DIFF
--- a/crates/js_api/src/gui/select_tokens.rs
+++ b/crates/js_api/src/gui/select_tokens.rs
@@ -1,7 +1,7 @@
 use super::*;
 use rain_orderbook_app_settings::{
     deployment::DeploymentCfg, gui::GuiSelectTokensCfg, network::NetworkCfg, order::OrderCfg,
-    token::TokenCfg,
+    token::TokenCfg, yaml::YamlParsableHash,
 };
 use std::str::FromStr;
 
@@ -74,6 +74,12 @@ impl DotrainOrderGui {
             return Err(GuiError::TokenNotFound(key.clone()));
         }
 
+        if TokenCfg::parse_from_yaml(self.dotrain_order.dotrain_yaml().documents, &key, None)
+            .is_ok()
+        {
+            TokenCfg::remove_record_from_yaml(self.dotrain_order.orderbook_yaml().documents, &key)?;
+        }
+
         let address = Address::from_str(&address)?;
 
         let order_key = DeploymentCfg::parse_order_key(
@@ -99,17 +105,6 @@ impl DotrainOrderGui {
         )?;
 
         self.execute_state_update_callback()?;
-        Ok(())
-    }
-
-    #[wasm_bindgen(js_name = "replaceSelectToken")]
-    pub async fn replace_select_token(
-        &mut self,
-        key: String,
-        address: String,
-    ) -> Result<(), GuiError> {
-        self.remove_select_token(key.clone())?;
-        self.save_select_token(key, address).await?;
         Ok(())
     }
 

--- a/packages/orderbook/test/js_api/gui.test.ts
+++ b/packages/orderbook/test/js_api/gui.test.ts
@@ -1618,14 +1618,14 @@ ${dotrainWithoutVaultIds}`;
 			assert.equal(tokenInfo.symbol, 'T1');
 			assert.equal(tokenInfo.decimals, 6);
 
-			await gui.replaceSelectToken('token1', '0x8888888888888888888888888888888888888888');
+			await gui.saveSelectToken('token1', '0x8888888888888888888888888888888888888888');
 			assert.equal(gui.isSelectTokenSet('token1'), true);
 			tokenInfo = await gui.getTokenInfo('token1');
 			assert.equal(tokenInfo.name, 'Teken 2');
 			assert.equal(tokenInfo.symbol, 'T2');
 			assert.equal(tokenInfo.decimals, 18);
 
-			assert.equal(stateUpdateCallback.mock.calls.length, 3);
+			assert.equal(stateUpdateCallback.mock.calls.length, 2);
 			expect(stateUpdateCallback).toHaveBeenCalledWith(gui.serializeState());
 		});
 

--- a/packages/ui-components/src/__tests__/SelectToken.test.ts
+++ b/packages/ui-components/src/__tests__/SelectToken.test.ts
@@ -10,7 +10,6 @@ describe('SelectToken', () => {
 	let mockStateUpdateCallback: Mock;
 	const mockGui: DotrainOrderGui = {
 		saveSelectToken: vi.fn(),
-		replaceSelectToken: vi.fn(),
 		isSelectTokenSet: vi.fn(),
 		getTokenInfo: vi.fn().mockResolvedValue({
 			symbol: 'ETH',
@@ -32,11 +31,6 @@ describe('SelectToken', () => {
 	beforeEach(() => {
 		mockStateUpdateCallback = vi.fn();
 		mockGui.saveSelectToken = vi.fn().mockImplementation(() => {
-			mockStateUpdateCallback();
-			return Promise.resolve();
-		});
-		mockGui.replaceSelectToken = vi.fn().mockImplementation(() => {
-			mockStateUpdateCallback();
 			mockStateUpdateCallback();
 			return Promise.resolve();
 		});
@@ -127,7 +121,7 @@ describe('SelectToken', () => {
 		await userEvent.clear(input);
 		await user.paste('invalid');
 		await waitFor(() => {
-			expect(mockGui.replaceSelectToken).toHaveBeenCalled();
+			expect(mockGui.saveSelectToken).toHaveBeenCalled();
 			expect(mockStateUpdateCallback).toHaveBeenCalledTimes(2);
 		});
 	});

--- a/packages/ui-components/src/__tests__/SelectToken.test.ts
+++ b/packages/ui-components/src/__tests__/SelectToken.test.ts
@@ -122,7 +122,7 @@ describe('SelectToken', () => {
 		await user.paste('invalid');
 		await waitFor(() => {
 			expect(mockGui.saveSelectToken).toHaveBeenCalled();
-			expect(mockStateUpdateCallback).toHaveBeenCalledTimes(2);
+			expect(mockStateUpdateCallback).toHaveBeenCalledTimes(1);
 		});
 	});
 

--- a/packages/ui-components/src/lib/components/deployment/SelectToken.svelte
+++ b/packages/ui-components/src/lib/components/deployment/SelectToken.svelte
@@ -48,11 +48,7 @@
 			}
 			checking = true;
 			try {
-				if (gui.isSelectTokenSet(token.key)) {
-					await gui.replaceSelectToken(token.key, currentTarget.value);
-				} else {
-					await gui.saveSelectToken(token.key, currentTarget.value);
-				}
+				await gui.saveSelectToken(token.key, currentTarget.value);
 				await getInfoForSelectedToken();
 			} catch (e) {
 				const errorMessage = (e as Error).message ? (e as Error).message : 'Invalid token address.';


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

See issue: #1443

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

This PR removes the said function and directly uses save select token to replace the select token.

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)

fix #1443

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced token management by ensuring tokens are removed from the orderbook YAML before saving new tokens.
- **Refactor**
	- Streamlined the token management process so that token saving now consistently handles both new and existing tokens by consolidating functionality.
- **Tests**
	- Updated test cases to align with the revised token saving behavior, ensuring a more reliable update to the application state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->