### PR TITLE
fix pkgs publish workflow

### DIFF
--- a/.github/workflows/npm-package-release.yml
+++ b/.github/workflows/npm-package-release.yml
@@ -69,14 +69,13 @@ jobs:
           git config --global user.name "${{ secrets.CI_GIT_USER }}"
 
       # set npm version
-      - name: Set Version 1/2
-        run: npm version prerelease --preid alpha --no-git-tag-version -w @rainlanguage/ui-components -w @rainlanguage/orderbook
-
-      - name: Set Version 2/2
-        run: echo "NEW_VERSION=$(jq -r '.version' ./packages/orderbook/package.json)" >> $GITHUB_ENV
+      - name: Set Version
+        run: |
+          npm version prerelease --preid alpha --no-git-tag-version -w @rainlanguage/ui-components -w @rainlanguage/orderbook
+          echo "NEW_VERSION=$(jq -r '.version' ./packages/orderbook/package.json)" >> $GITHUB_ENV
 
       - name: Update orderbook Dependency Version for ui-components
-        run: npm install -w @rainlanguage/ui-components @rainlanguage/orderbook@${{ env.NEW_VERSION }}
+        run: npm install -w @rainlanguage/ui-components @rainlanguage/orderbook@${{ env.NEW_VERSION }} --save-exact
 
       # Commit changes and tag
       - name: Commit And Tag

--- a/.github/workflows/npm-package-release.yml
+++ b/.github/workflows/npm-package-release.yml
@@ -69,10 +69,11 @@ jobs:
           git config --global user.name "${{ secrets.CI_GIT_USER }}"
 
       # set npm version
-      - name: Set Version
-        run: |
-          npm version prerelease --preid alpha --no-git-tag-version -ws -w @rainlanguage/ui-components -w @rainlanguage/orderbook
-          echo "NEW_VERSION=$(jq -r '.version' ./packages/orderbook/package.json)" >> $GITHUB_ENV
+      - name: Set Version 1/2
+        run: npm version prerelease --preid alpha --no-git-tag-version -w @rainlanguage/ui-components -w @rainlanguage/orderbook
+
+      - name: Set Version 2/2
+        run: echo "NEW_VERSION=$(jq -r '.version' ./packages/orderbook/package.json)" >> $GITHUB_ENV
 
       - name: Update orderbook Dependency Version for ui-components
         run: npm install -w @rainlanguage/ui-components @rainlanguage/orderbook@${{ env.NEW_VERSION }}

--- a/.github/workflows/npm-package-release.yml
+++ b/.github/workflows/npm-package-release.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   release:
+    if: ${{ github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, 'NPM Package Release') }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/package-lock.json
+++ b/package-lock.json
@@ -21093,7 +21093,7 @@
                 "@fontsource/dm-sans": "^5.0.18",
                 "@imask/svelte": "^7.3.0",
                 "@observablehq/plot": "^0.6.13",
-                "@rainlanguage/orderbook": "^0.0.1-alpha.7",
+                "@rainlanguage/orderbook": "^0.0.1-alpha.8",
                 "@reown/appkit": "^1.6.4",
                 "@reown/appkit-adapter-wagmi": "^1.6.4",
                 "@sentry/sveltekit": "^7.107.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21093,7 +21093,7 @@
                 "@fontsource/dm-sans": "^5.0.18",
                 "@imask/svelte": "^7.3.0",
                 "@observablehq/plot": "^0.6.13",
-                "@rainlanguage/orderbook": "^0.0.1-alpha.8",
+                "@rainlanguage/orderbook": "0.0.1-alpha.8",
                 "@reown/appkit": "^1.6.4",
                 "@reown/appkit-adapter-wagmi": "^1.6.4",
                 "@sentry/sveltekit": "^7.107.0",

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -53,7 +53,7 @@
 		"@fontsource/dm-sans": "^5.0.18",
 		"@imask/svelte": "^7.3.0",
 		"@observablehq/plot": "^0.6.13",
-		"@rainlanguage/orderbook": "^0.0.1-alpha.7",
+		"@rainlanguage/orderbook": "^0.0.1-alpha.8",
 		"@reown/appkit": "^1.6.4",
 		"@reown/appkit-adapter-wagmi": "^1.6.4",
 		"@sentry/sveltekit": "^7.107.0",

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -53,7 +53,7 @@
 		"@fontsource/dm-sans": "^5.0.18",
 		"@imask/svelte": "^7.3.0",
 		"@observablehq/plot": "^0.6.13",
-		"@rainlanguage/orderbook": "^0.0.1-alpha.8",
+		"@rainlanguage/orderbook": "0.0.1-alpha.8",
 		"@reown/appkit": "^1.6.4",
 		"@reown/appkit-adapter-wagmi": "^1.6.4",
 		"@sentry/sveltekit": "^7.107.0",


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation
the pkgs publish workflow retriggers itself on push, so here we add a simple check to avoid retriggering scenario
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [ ] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Refined the deployment process so that release tasks execute only under approved commit conditions.
	- Updated the version of the `@rainlanguage/orderbook` dependency to `0.0.1-alpha.8`, ensuring strict version usage without allowing minor updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->