### PR TITLE
Remove instanceOf Error check on DeploymentStepsErrors

### DIFF
--- a/packages/ui-components/src/lib/errors/DeploymentStepsError.ts
+++ b/packages/ui-components/src/lib/errors/DeploymentStepsError.ts
@@ -37,11 +37,11 @@ export class DeploymentStepsError extends Error {
 		return value;
 	}
 
-	static catch(e: unknown, code: DeploymentStepsErrorCode) {
+	static catch(e: { message: string }, code: DeploymentStepsErrorCode) {
 		const error =
 			e instanceof DeploymentStepsError
 				? e
-				: new DeploymentStepsError(code, e instanceof Error ? e.message : 'Unknown error');
+				: new DeploymentStepsError(code, e.message || 'Unknown error');
 		this.errorStore.set(error);
 	}
 


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

Since they are no Error instances, the wasm errors are not passing this check, and show "uknown error" instead

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [ ] made this PR as small as possible
- [ ] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced error messaging during deployments for more consistent and informative feedback, ensuring a clear default message is provided when specific details are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->