### PR TITLE
Set subgraphURL if it exists, otherwise skip tx indexing and notify user

### DIFF
--- a/packages/ui-components/src/__tests__/transactionStore.test.ts
+++ b/packages/ui-components/src/__tests__/transactionStore.test.ts
@@ -400,4 +400,29 @@ describe('transactionStore', () => {
 
 		vi.useRealTimers();
 	});
+	it('should skip subgraph indexing when subgraphUrl is not provided', async () => {
+		(switchChain as Mock).mockResolvedValue({});
+		(sendTransaction as Mock).mockResolvedValue('deployHash');
+		(waitForTransactionReceipt as Mock).mockResolvedValue({});
+		(getExplorerLink as Mock).mockResolvedValue('https://explorer.example.com/tx/deployHash');
+
+		await handleDeploymentTransaction({
+			config: mockConfig,
+			approvals: [],
+			deploymentCalldata: '0xdeployment',
+			orderbookAddress: mockOrderbookAddress as `0x${string}`,
+			chainId: 1,
+			subgraphUrl: '',
+			network: 'flare'
+		});
+
+		expect(get(transactionStore).status).toBe(TransactionStatus.SUCCESS);
+		expect(get(transactionStore).hash).toBe('deployHash');
+		expect(get(transactionStore).message).toBe(
+			'Deployment successful. Check the Orders page for your new order.'
+		);
+		expect(get(transactionStore).network).toBe('flare');
+
+		expect(getTransactionAddOrders).not.toHaveBeenCalled();
+	});
 });

--- a/packages/ui-components/src/lib/components/deployment/DeploymentSteps.svelte
+++ b/packages/ui-components/src/lib/components/deployment/DeploymentSteps.svelte
@@ -57,8 +57,7 @@
 	const gui = useGui();
 	let selectTokens: GuiSelectTokensCfg[] | undefined = undefined;
 	let networkKey: string = '';
-	const subgraphUrl = $settings?.subgraphs?.[networkKey] ?? '';
-
+	let subgraphUrl: string = '';
 	let deploymentStepsError = DeploymentStepsError.error;
 
 	export let wagmiConfig: Writable<Config | undefined>;
@@ -78,6 +77,7 @@
 			throw new Error(networkKeyResult.error.msg);
 		}
 		networkKey = networkKeyResult.value;
+		subgraphUrl = $settings?.subgraphs?.[networkKey] ?? '';
 
 		await areAllTokensSelected();
 	});

--- a/packages/ui-components/src/lib/stores/transactionStore.ts
+++ b/packages/ui-components/src/lib/stores/transactionStore.ts
@@ -306,7 +306,15 @@ const transactionStore = () => {
 			const transactionExplorerLink = await getExplorerLink(hash, chainId, 'tx');
 			awaitTx(hash, TransactionStatus.PENDING_DEPLOYMENT, transactionExplorerLink);
 			await waitForTransactionReceipt(config, { hash });
-			return awaitNewOrderIndexing(subgraphUrl, hash, network);
+			if (subgraphUrl) {
+				return awaitNewOrderIndexing(subgraphUrl, hash, network);
+			}
+			return transactionSuccess(
+				hash,
+				'Deployment successful. Check the Orders page for your new order.',
+				'',
+				network
+			);
 		} catch {
 			return transactionError(TransactionErrorMessage.DEPLOYMENT_FAILED);
 		}


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

- Set SubraphURL from getting the network key
- If no SG URL is found, then notify the user that they can find their new order in orders route

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [ ] made this PR as small as possible
- [ ] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)
