### PR TITLE
Make subgraph url reactive to network key change

### DIFF
--- a/packages/ui-components/src/__tests__/DeploymentSteps.test.ts
+++ b/packages/ui-components/src/__tests__/DeploymentSteps.test.ts
@@ -679,7 +679,7 @@ describe('DeploymentSteps', () => {
 		});
 	});
 
-	it.only('correctly derives subgraphUrl from settings and networkKey', async () => {
+	it('correctly derives subgraphUrl from settings and networkKey', async () => {
 		(DotrainOrderGui.prototype.areAllTokensSelected as Mock).mockReturnValue({ value: true });
 		(DotrainOrderGui.prototype.hasAnyDeposit as Mock).mockReturnValue({ value: false });
 		(DotrainOrderGui.prototype.hasAnyVaultId as Mock).mockReturnValue({ value: false });

--- a/packages/ui-components/src/lib/components/deployment/DeploymentSteps.svelte
+++ b/packages/ui-components/src/lib/components/deployment/DeploymentSteps.svelte
@@ -57,7 +57,7 @@
 	const gui = useGui();
 	let selectTokens: GuiSelectTokensCfg[] | undefined = undefined;
 	let networkKey: string = '';
-	const subgraphUrl = $settings?.subgraphs?.[networkKey] ?? '';
+	$: subgraphUrl = $settings?.subgraphs?.[networkKey] ?? '';
 
 	let deploymentStepsError = DeploymentStepsError.error;
 


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [ ] made this PR as small as possible
- [ ] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded test coverage by simulating account retrieval and verifying that deployment actions now receive updated configuration parameters.
  - Introduced a new test to confirm that user-initiated deployment correctly reflects dynamic settings.

- **Refactor**
  - Updated the deployment component to use a reactive approach, ensuring configuration values automatically update as settings change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->