### PR TITLE
Remove use of getAccount/WagmiConfig from deploymentArgs

### DIFF
--- a/packages/ui-components/src/__tests__/WalletConnect.test.ts
+++ b/packages/ui-components/src/__tests__/WalletConnect.test.ts
@@ -1,10 +1,11 @@
 import { render, screen } from '@testing-library/svelte';
 import WalletConnect from '../lib/components/wallet/WalletConnect.svelte';
 import { describe, it, vi, beforeEach, expect } from 'vitest';
-import { writable, type Writable } from 'svelte/store';
+import { readable, writable, type Writable } from 'svelte/store';
 import type { AppKit } from '@reown/appkit';
 import truncateEthAddress from 'truncate-eth-address';
-const { mockSignerAddressStore, mockConnectedStore } = await vi.hoisted(
+import type { Hex } from 'viem';
+const {mockConnectedStore } = await vi.hoisted(
 	() => import('$lib/__mocks__/stores')
 );
 
@@ -14,7 +15,6 @@ vi.mock('$lib/stores/wagmi', async (importOriginal) => {
 		...original,
 		appKitModal: writable({} as AppKit),
 		connected: mockConnectedStore,
-		signerAddress: mockSignerAddressStore
 	};
 });
 
@@ -25,7 +25,6 @@ describe('WalletConnect component', () => {
 	});
 
 	it('displays "Connect" with red icon when wallet is not connected or wrong network', () => {
-		mockSignerAddressStore.mockSetSubscribeValue('');
 		mockConnectedStore.mockSetSubscribeValue(false);
 
 		render(WalletConnect);
@@ -35,14 +34,13 @@ describe('WalletConnect component', () => {
 	});
 
 	it('displays truncated address when wallet is connected', () => {
-		mockSignerAddressStore.mockSetSubscribeValue('0x123');
 		mockConnectedStore.mockSetSubscribeValue(true);
 
 		render(WalletConnect, {
 			props: {
 				connected: mockConnectedStore as Writable<boolean>,
 				appKitModal: writable({} as AppKit),
-				signerAddress: mockSignerAddressStore
+				signerAddress: readable('0x123' as Hex)
 			}
 		});
 

--- a/packages/ui-components/src/__tests__/WalletConnect.test.ts
+++ b/packages/ui-components/src/__tests__/WalletConnect.test.ts
@@ -5,16 +5,14 @@ import { readable, writable, type Writable } from 'svelte/store';
 import type { AppKit } from '@reown/appkit';
 import truncateEthAddress from 'truncate-eth-address';
 import type { Hex } from 'viem';
-const {mockConnectedStore } = await vi.hoisted(
-	() => import('$lib/__mocks__/stores')
-);
+const { mockConnectedStore } = await vi.hoisted(() => import('$lib/__mocks__/stores'));
 
 vi.mock('$lib/stores/wagmi', async (importOriginal) => {
 	const original = (await importOriginal()) as object;
 	return {
 		...original,
 		appKitModal: writable({} as AppKit),
-		connected: mockConnectedStore,
+		connected: mockConnectedStore
 	};
 });
 

--- a/packages/ui-components/src/__tests__/getDeploymentTransactionArgs.test.ts
+++ b/packages/ui-components/src/__tests__/getDeploymentTransactionArgs.test.ts
@@ -42,14 +42,6 @@ describe('getDeploymentTransactionArgs', () => {
 		});
 	});
 
-	describe('input validation errors', () => {
-		it('should throw NO_WALLET when wallet address is not found', async () => {
-			await expect(
-				getDeploymentTransactionArgs(guiInstance, null as unknown as Hex)
-			).rejects.toThrow(AddOrderErrors.NO_WALLET);
-		});
-	});
-
 	describe('error handling', () => {
 		it('should throw when gui.getDeploymentTransactionArgs returns an error object', async () => {
 			(DotrainOrderGui.prototype.getDeploymentTransactionArgs as Mock).mockResolvedValue({

--- a/packages/ui-components/src/lib/components/deployment/getDeploymentTransactionArgs.ts
+++ b/packages/ui-components/src/lib/components/deployment/getDeploymentTransactionArgs.ts
@@ -5,11 +5,6 @@ import type {
 import type { Hex } from 'viem';
 import type { ExtendedApprovalCalldata } from '$lib/stores/transactionStore';
 
-export enum AddOrderErrors {
-	ADD_ORDER_FAILED = 'Failed to add order',
-	MISSING_GUI = 'Order GUI is required',
-}
-
 export interface HandleAddOrderResult {
 	approvals: ExtendedApprovalCalldata[];
 	deploymentCalldata: DepositAndAddOrderCalldataResult;

--- a/packages/ui-components/src/lib/components/deployment/getDeploymentTransactionArgs.ts
+++ b/packages/ui-components/src/lib/components/deployment/getDeploymentTransactionArgs.ts
@@ -1,5 +1,3 @@
-import type { Config } from '@wagmi/core';
-import { getAccount } from '@wagmi/core';
 import type {
 	DepositAndAddOrderCalldataResult,
 	DotrainOrderGui
@@ -10,7 +8,6 @@ import type { ExtendedApprovalCalldata } from '$lib/stores/transactionStore';
 export enum AddOrderErrors {
 	ADD_ORDER_FAILED = 'Failed to add order',
 	MISSING_GUI = 'Order GUI is required',
-	MISSING_CONFIG = 'Wagmi config is required',
 	NO_WALLET = 'No wallet address found'
 }
 
@@ -23,18 +20,13 @@ export interface HandleAddOrderResult {
 
 export async function getDeploymentTransactionArgs(
 	gui: DotrainOrderGui,
-	wagmiConfig: Config | undefined
+	account: Hex
 ): Promise<HandleAddOrderResult> {
-	if (!wagmiConfig) {
-		throw new Error(AddOrderErrors.MISSING_CONFIG);
-	}
-
-	const { address } = getAccount(wagmiConfig);
-	if (!address) {
+	if (!account) {
 		throw new Error(AddOrderErrors.NO_WALLET);
 	}
 
-	const result = await gui.getDeploymentTransactionArgs(address);
+	const result = await gui.getDeploymentTransactionArgs(account);
 	if (result.error) {
 		throw new Error(result.error.msg);
 	}

--- a/packages/ui-components/src/lib/components/deployment/getDeploymentTransactionArgs.ts
+++ b/packages/ui-components/src/lib/components/deployment/getDeploymentTransactionArgs.ts
@@ -8,7 +8,6 @@ import type { ExtendedApprovalCalldata } from '$lib/stores/transactionStore';
 export enum AddOrderErrors {
 	ADD_ORDER_FAILED = 'Failed to add order',
 	MISSING_GUI = 'Order GUI is required',
-	NO_WALLET = 'No wallet address found'
 }
 
 export interface HandleAddOrderResult {
@@ -18,14 +17,18 @@ export interface HandleAddOrderResult {
 	chainId: number;
 }
 
+/**
+ * Gets the transaction arguments needed for deploying an order
+ * @param gui The order GUI instance containing the order configuration
+ * @param account The wallet address of the user deploying the order
+ * @returns Transaction arguments including approvals, deployment calldata, orderbook address and chain ID
+ * @throws {Error} If getting deployment transaction args fails or if there are validation errors
+ */
+
 export async function getDeploymentTransactionArgs(
 	gui: DotrainOrderGui,
 	account: Hex
 ): Promise<HandleAddOrderResult> {
-	if (!account) {
-		throw new Error(AddOrderErrors.NO_WALLET);
-	}
-
 	const result = await gui.getDeploymentTransactionArgs(account);
 	if (result.error) {
 		throw new Error(result.error.msg);

--- a/packages/ui-components/src/lib/components/wallet/WalletConnect.svelte
+++ b/packages/ui-components/src/lib/components/wallet/WalletConnect.svelte
@@ -5,10 +5,11 @@
 	import type { AppKit } from '@reown/appkit';
 	import { twMerge } from 'tailwind-merge';
 	import truncateEthAddress from 'truncate-eth-address';
+	import type { Account } from '$lib/types/account';
 
 	export let appKitModal: Writable<AppKit>;
 	export let connected: Writable<boolean>;
-	export let signerAddress: Writable<string | null>;
+	export let signerAddress: Account;
 	export let classes: string = '';
 	function handleClick() {
 		$appKitModal.open();

--- a/packages/ui-components/src/lib/errors/DeploymentStepsError.ts
+++ b/packages/ui-components/src/lib/errors/DeploymentStepsError.ts
@@ -13,7 +13,8 @@ export enum DeploymentStepsErrorCode {
 	NO_GUI_DETAILS = 'Error getting GUI details',
 	NO_CHAIN = 'Unsupported chain ID',
 	SERIALIZE_ERROR = 'Error serializing state',
-	ADD_ORDER_FAILED = 'Failed to add order'
+	ADD_ORDER_FAILED = 'Failed to add order',
+	NO_WALLET = 'No connected account found'
 }
 
 export class DeploymentStepsError extends Error {

--- a/packages/webapp/src/routes/deploy/[strategyName]/[deploymentKey]/+page.svelte
+++ b/packages/webapp/src/routes/deploy/[strategyName]/[deploymentKey]/+page.svelte
@@ -2,7 +2,7 @@
 	import { page } from '$app/stores';
 	import { goto } from '$app/navigation';
 	import { DeploymentSteps, GuiProvider } from '@rainlanguage/ui-components';
-	import { wagmiConfig, connected, appKitModal, signerAddress } from '$lib/stores/wagmi';
+	import { wagmiConfig, connected, appKitModal } from '$lib/stores/wagmi';
 	import { handleDeployModal, handleDisclaimerModal } from '$lib/services/modal';
 	import { DotrainOrderGui } from '@rainlanguage/orderbook/js_api';
 	import { onMount } from 'svelte';
@@ -46,7 +46,6 @@
 			{handleDeployModal}
 			{settings}
 			{handleDisclaimerModal}
-			{signerAddress}
 		/>
 	</GuiProvider>
 {:else if getGuiError}


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

Removed the use of getAccount from DeploymentArgs, instead using the useAccount hook to get the connected address from the provider.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [ ] made this PR as small as possible
- [ ] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Deployment and wallet connection components now prompt users to connect their wallet if none is detected, ensuring a smoother experience.
  - Enhanced error notifications clarify when a wallet connection is missing.

- **Refactor**
  - Streamlined account management across deployment and wallet interfaces for improved consistency and reliability.
  - Simplified test setups by removing unused mocks and directly initializing props for better clarity.
  - Updated error handling to provide more specific messages related to wallet connectivity issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->