### PR TITLE
Add new method to OrderbookYaml wasm bindings

### DIFF
--- a/crates/js_api/src/gui/select_tokens.rs
+++ b/crates/js_api/src/gui/select_tokens.rs
@@ -47,17 +47,6 @@ impl DotrainOrderGui {
         Ok(())
     }
 
-    #[wasm_export(js_name = "getNetworkKey", unchecked_return_type = "string")]
-    pub fn get_network_key(&self) -> Result<String, GuiError> {
-        let order_key = DeploymentCfg::parse_order_key(
-            self.dotrain_order.dotrain_yaml().documents,
-            &self.selected_deployment,
-        )?;
-        let network_key =
-            OrderCfg::parse_network_key(self.dotrain_order.dotrain_yaml().documents, &order_key)?;
-        Ok(network_key)
-    }
-
     #[wasm_export(js_name = "saveSelectToken", unchecked_return_type = "void")]
     pub async fn save_select_token(
         &mut self,

--- a/crates/js_api/src/yaml/mod.rs
+++ b/crates/js_api/src/yaml/mod.rs
@@ -7,7 +7,7 @@ use rain_orderbook_app_settings::{
     orderbook::OrderbookCfg,
     yaml::{
         dotrain::DotrainYaml as DotrainYamlCfg, orderbook::OrderbookYaml as OrderbookYamlCfg,
-        FieldErrorKind, YamlError, YamlParsable,
+        YamlError, YamlParsable,
     },
 };
 use rain_orderbook_common::dotrain::RainDocument;

--- a/crates/settings/src/deployment.rs
+++ b/crates/settings/src/deployment.rs
@@ -129,9 +129,7 @@ impl YamlParsableHash for DeploymentCfg {
             }
         }
 
-        if deployments.is_empty()
-            && context.map_or(true, |ctx| ctx.get_current_deployment().is_none())
-        {
+        if deployments.is_empty() {
             return Err(YamlError::Field {
                 kind: FieldErrorKind::Missing("deployments".to_string()),
                 location: "root".to_string(),

--- a/crates/settings/src/deployment.rs
+++ b/crates/settings/src/deployment.rs
@@ -39,6 +39,11 @@ impl DeploymentCfg {
                     deployments_hash.get(&StrictYaml::String(deployment_key.to_string()))
                 {
                     return require_string(deployment_yaml, Some("order"), None);
+                } else {
+                    return Err(YamlError::Field {
+                        kind: FieldErrorKind::Missing(deployment_key.to_string()),
+                        location: "deployments".to_string(),
+                    });
                 }
             } else {
                 return Err(YamlError::Field {

--- a/crates/settings/src/deployment.rs
+++ b/crates/settings/src/deployment.rs
@@ -124,7 +124,9 @@ impl YamlParsableHash for DeploymentCfg {
             }
         }
 
-        if deployments.is_empty() {
+        if deployments.is_empty()
+            && context.map_or(true, |ctx| ctx.get_current_deployment().is_none())
+        {
             return Err(YamlError::Field {
                 kind: FieldErrorKind::Missing("deployments".to_string()),
                 location: "root".to_string(),

--- a/crates/settings/src/order.rs
+++ b/crates/settings/src/order.rs
@@ -394,6 +394,41 @@ impl OrderCfg {
         )
     }
 
+    pub fn parse_orderbook_key(
+        documents: Vec<Arc<RwLock<StrictYaml>>>,
+        order_key: &str,
+    ) -> Result<String, YamlError> {
+        let mut orderbook_key: Option<String> = None;
+
+        for document in &documents {
+            let document_read = document.read().map_err(|_| YamlError::ReadLockError)?;
+
+            if let Ok(orders_hash) = require_hash(&document_read, Some("orders"), None) {
+                if let Some(order_yaml) =
+                    orders_hash.get(&StrictYaml::String(order_key.to_string()))
+                {
+                    if let Some(key) = optional_string(order_yaml, "orderbook") {
+                        orderbook_key = Some(key);
+                    }
+                }
+            } else {
+                return Err(YamlError::Field {
+                    kind: FieldErrorKind::InvalidType {
+                        field: "orders".to_string(),
+                        expected: "a map".to_string(),
+                    },
+                    location: "root".to_string(),
+                });
+            }
+        }
+
+        Ok(
+            orderbook_key.ok_or(ParseOrderConfigSourceError::OrderbookKeyNotFoundError(
+                order_key.to_string(),
+            ))?,
+        )
+    }
+
     pub fn parse_vault_ids(
         documents: Vec<Arc<RwLock<StrictYaml>>>,
         order_key: &str,
@@ -802,6 +837,8 @@ pub enum ParseOrderConfigSourceError {
     TokenParseError(ParseTokenConfigSourceError),
     #[error("Network not found for Order: {0}")]
     NetworkNotFoundError(String),
+    #[error("Orderbook key not found for order: {0}")]
+    OrderbookKeyNotFoundError(String),
     #[error("Network does not match")]
     NetworkNotMatch,
     #[error("Deployer network does not match: expected {expected}, found {found}")]
@@ -851,6 +888,8 @@ impl ParseOrderConfigSourceError {
                 format!("Network mismatch in your YAML configuration: The output token '{}' is using network '{}' but the order is using network '{}'. Please ensure all components use the same network.", key, found, expected),
             ParseOrderConfigSourceError::VaultParseError(err) =>
                 format!("The vault ID in your YAML configuration is invalid. Please provide a valid number: {}", err),
+            ParseOrderConfigSourceError::OrderbookKeyNotFoundError(order_key) =>
+                format!("No orderbook key found for order: {order_key}. Please update your order YAML configuration to include an orderbook key."),
         }
     }
 }
@@ -1392,5 +1431,76 @@ orders:
             error.to_readable_msg(),
             "Field 'orders' in root must be a map"
         );
+    }
+
+    #[test]
+    fn test_parse_orderbook_key() {
+        let yaml = r#"
+orders: test
+"#;
+        let error = OrderCfg::parse_orderbook_key(vec![get_document(yaml)], "order1").unwrap_err();
+        assert_eq!(
+            error,
+            YamlError::Field {
+                kind: FieldErrorKind::InvalidType {
+                    field: "orders".to_string(),
+                    expected: "a map".to_string()
+                },
+                location: "root".to_string()
+            }
+        );
+        assert_eq!(
+            error.to_readable_msg(),
+            "Field 'orders' in root must be a map"
+        );
+
+        let yaml = r#"
+orders:
+  - test
+"#;
+        let error = OrderCfg::parse_orderbook_key(vec![get_document(yaml)], "order1").unwrap_err();
+        assert_eq!(
+            error,
+            YamlError::Field {
+                kind: FieldErrorKind::InvalidType {
+                    field: "orders".to_string(),
+                    expected: "a map".to_string()
+                },
+                location: "root".to_string()
+            }
+        );
+        assert_eq!(
+            error.to_readable_msg(),
+            "Field 'orders' in root must be a map"
+        );
+
+        let yaml = r#"
+orders:
+  - test: test
+"#;
+        let error = OrderCfg::parse_orderbook_key(vec![get_document(yaml)], "order1").unwrap_err();
+        assert_eq!(
+            error,
+            YamlError::Field {
+                kind: FieldErrorKind::InvalidType {
+                    field: "orders".to_string(),
+                    expected: "a map".to_string()
+                },
+                location: "root".to_string()
+            }
+        );
+        assert_eq!(
+            error.to_readable_msg(),
+            "Field 'orders' in root must be a map"
+        );
+
+        let yaml = r#"
+orders:
+  order1:
+    orderbook: orderbook1
+"#;
+        let orderbook_key =
+            OrderCfg::parse_orderbook_key(vec![get_document(yaml)], "order1").unwrap();
+        assert_eq!(orderbook_key, "orderbook1");
     }
 }

--- a/packages/orderbook/test/js_api/gui.test.ts
+++ b/packages/orderbook/test/js_api/gui.test.ts
@@ -1914,10 +1914,5 @@ ${dotrainWithoutVaultIds}`;
 				extractWasmEncodedData(gui.serializeState())
 			);
 		});
-
-		it('should get network key', async () => {
-			const networkKey = extractWasmEncodedData<string>(gui.getNetworkKey());
-			assert.equal(networkKey, 'some-network');
-		});
 	});
 });

--- a/packages/orderbook/test/js_api/orderbookYaml.test.ts
+++ b/packages/orderbook/test/js_api/orderbookYaml.test.ts
@@ -80,6 +80,17 @@ deployments:
         order: some-order
 `;
 
+const RAINLANG = `
+---
+#calculate-io
+max-output: max-value(),
+io: 1;
+#handle-io
+:;
+#handle-add-order
+:;
+`;
+
 const extractWasmEncodedData = <T>(result: WasmEncodedResult<T>, errorMessage?: string): T => {
 	if (result.error) {
 		assert.fail(errorMessage ?? result.error.msg);
@@ -147,6 +158,18 @@ describe('Rain Orderbook JS API Package Bindgen Tests - Settings', async functio
 			expect(result.error.readableMsg).toBe(
 				'There was an error processing the YAML configuration. Please check the YAML file for any issues. Error: "Key \'test\' not found"'
 			);
+		});
+
+		it('should work with dotrain', async function () {
+			const dotrain = `
+            ${YAML}
+            ${RAINLANG}
+            `;
+			const orderbookYaml = new OrderbookYaml([dotrain]);
+			const orderbook = extractWasmEncodedData<OrderbookCfg>(
+				orderbookYaml.getOrderbookByDeploymentKey('some-deployment')
+			);
+			assert.equal(orderbook.address, '0xc95a5f8efe14d7a20bd2e5bafec4e71f8ce0b9a6');
 		});
 	});
 });

--- a/packages/orderbook/test/js_api/orderbookYaml.test.ts
+++ b/packages/orderbook/test/js_api/orderbookYaml.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { OrderbookYaml } from '../../dist/cjs/js_api.js';
 import { OrderbookCfg, WasmEncodedResult } from '../../dist/types/js_api.js';
 
-const YAML_WITHOUT_ORDERBOOK = `
+const YAML = `
 networks:
     some-network:
         rpc: http://localhost:8085/rpc-url
@@ -62,11 +62,19 @@ orders:
           vault-id: 1
       deployer: some-deployer
       orderbook: some-orderbook
+    some-order2:
+      inputs:
+        - token: token1
+      outputs:
+        - token: token2
 
 deployments:
     some-deployment:
         scenario: some-scenario
         order: some-order
+    some-deployment2:
+        scenario: some-scenario
+        order: some-order2
     other-deployment:
         scenario: some-scenario.sub-scenario
         order: some-order
@@ -86,13 +94,13 @@ const extractWasmEncodedData = <T>(result: WasmEncodedResult<T>, errorMessage?: 
 
 describe('Rain Orderbook JS API Package Bindgen Tests - Settings', async function () {
 	it('should create a new settings object', async function () {
-		const orderbookYaml = new OrderbookYaml([YAML_WITHOUT_ORDERBOOK]);
+		const orderbookYaml = new OrderbookYaml([YAML]);
 		assert.ok(orderbookYaml);
 	});
 
 	describe('orderbook tests', async function () {
-		it('should get the orderbook', async function () {
-			const orderbookYaml = new OrderbookYaml([YAML_WITHOUT_ORDERBOOK]);
+		it('should get the orderbook by address', async function () {
+			const orderbookYaml = new OrderbookYaml([YAML]);
 
 			const orderbook = extractWasmEncodedData<OrderbookCfg>(
 				orderbookYaml.getOrderbookByAddress('0xc95A5f8eFe14d7a20BD2E5BAFEC4E71f8Ce0B9A6')
@@ -113,6 +121,31 @@ describe('Rain Orderbook JS API Package Bindgen Tests - Settings', async functio
 			);
 			expect(result.error.readableMsg).toBe(
 				'There was an error processing the YAML configuration. Please check the YAML file for any issues. Error: "Key \'0x0000000000000000000000000000000000000000\' not found"'
+			);
+		});
+
+		it('should get the orderbook by deployment key', async function () {
+			const orderbookYaml = new OrderbookYaml([YAML]);
+
+			const orderbook = extractWasmEncodedData<OrderbookCfg>(
+				orderbookYaml.getOrderbookByDeploymentKey('some-deployment')
+			);
+			assert.equal(orderbook.address, '0xc95a5f8efe14d7a20bd2e5bafec4e71f8ce0b9a6');
+			assert.equal(orderbook.network.chainId, 123);
+			assert.equal(orderbook.subgraph.url, 'https://www.some-sg.com/');
+
+			let result = orderbookYaml.getOrderbookByDeploymentKey('some-deployment2');
+			expect(result.error.msg).toBe(
+				"Orderbook yaml error: Missing required field 'orderbook' in order with key: some-order2"
+			);
+			expect(result.error.readableMsg).toBe(
+				'There was an error processing the YAML configuration. Please check the YAML file for any issues. Error: "Missing required field \'orderbook\' in order with key: some-order2"'
+			);
+
+			result = orderbookYaml.getOrderbookByDeploymentKey('test');
+			expect(result.error.msg).toBe("Orderbook yaml error: Key 'test' not found");
+			expect(result.error.readableMsg).toBe(
+				'There was an error processing the YAML configuration. Please check the YAML file for any issues. Error: "Key \'test\' not found"'
 			);
 		});
 	});

--- a/packages/orderbook/test/js_api/orderbookYaml.test.ts
+++ b/packages/orderbook/test/js_api/orderbookYaml.test.ts
@@ -147,16 +147,18 @@ describe('Rain Orderbook JS API Package Bindgen Tests - Settings', async functio
 
 			let result = orderbookYaml.getOrderbookByDeploymentKey('some-deployment2');
 			expect(result.error.msg).toBe(
-				"Orderbook yaml error: Missing required field 'orderbook' in order with key: some-order2"
+				'Orderbook yaml error: Orderbook key not found for order: some-order2'
 			);
 			expect(result.error.readableMsg).toBe(
-				'There was an error processing the YAML configuration. Please check the YAML file for any issues. Error: "Missing required field \'orderbook\' in order with key: some-order2"'
+				'There was an error processing the YAML configuration. Please check the YAML file for any issues. Error: "Orderbook key not found for order: some-order2"'
 			);
 
 			result = orderbookYaml.getOrderbookByDeploymentKey('test');
-			expect(result.error.msg).toBe("Orderbook yaml error: Key 'test' not found");
+			expect(result.error.msg).toBe(
+				"Orderbook yaml error: Missing required field 'test' in deployments"
+			);
 			expect(result.error.readableMsg).toBe(
-				'There was an error processing the YAML configuration. Please check the YAML file for any issues. Error: "Key \'test\' not found"'
+				'There was an error processing the YAML configuration. Please check the YAML file for any issues. Error: "Missing required field \'test\' in deployments"'
 			);
 		});
 

--- a/packages/ui-components/src/__tests__/DeploymentSteps.test.ts
+++ b/packages/ui-components/src/__tests__/DeploymentSteps.test.ts
@@ -1,11 +1,16 @@
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/svelte';
 import DeploymentSteps from '../lib/components/deployment/DeploymentSteps.svelte';
-import { DotrainOrderGui, type ScenarioCfg } from '@rainlanguage/orderbook/js_api';
+import {
+	DotrainOrderGui,
+	type ScenarioCfg,
+	OrderbookYaml,
+	type OrderbookCfg
+} from '@rainlanguage/orderbook/js_api';
 import type { ComponentProps } from 'svelte';
 import { writable } from 'svelte/store';
 import type { AppKit } from '@reown/appkit';
-import type { ConfigSource, GuiDeploymentCfg } from '@rainlanguage/orderbook/js_api';
+import type { GuiDeploymentCfg } from '@rainlanguage/orderbook/js_api';
 import type { DeployModalProps, DisclaimerModalProps } from '../lib/types/modal';
 import userEvent from '@testing-library/user-event';
 import { useGui } from '$lib/hooks/useGui';
@@ -637,12 +642,7 @@ const defaultProps: DeploymentStepsProps = {
 	signerAddress: mockSignerAddressStore,
 	appKitModal: writable({} as AppKit),
 	handleDeployModal: vi.fn() as unknown as (args: DeployModalProps) => void,
-	handleDisclaimerModal: vi.fn() as unknown as (args: DisclaimerModalProps) => void,
-	settings: writable({
-		subgraphs: {
-			flare: 'https://subgraph.com/flare'
-		}
-	} as ConfigSource)
+	handleDisclaimerModal: vi.fn() as unknown as (args: DisclaimerModalProps) => void
 };
 
 describe('DeploymentSteps', () => {
@@ -653,9 +653,27 @@ describe('DeploymentSteps', () => {
 		vi.clearAllMocks();
 		guiInstance = new DotrainOrderGui();
 
+		const orderbookCfg: OrderbookCfg = {
+			key: 'orderbook',
+			address: '0x0000000000000000000000000000000000000000',
+			network: {
+				key: 'flare',
+				rpc: 'https://rpc.ankr.com/flare',
+				chainId: 14,
+				label: 'Flare',
+				currency: 'FLR'
+			},
+			subgraph: {
+				key: 'flare',
+				url: 'https://subgraph.com/flare'
+			}
+		};
+		(OrderbookYaml.prototype.getOrderbookByDeploymentKey as Mock).mockReturnValue({
+			value: orderbookCfg
+		});
+
 		(DotrainOrderGui.prototype.areAllTokensSelected as Mock).mockReturnValue({ value: false });
 		(DotrainOrderGui.prototype.getSelectTokens as Mock).mockReturnValue({ value: [] });
-		(DotrainOrderGui.prototype.getNetworkKey as Mock).mockReturnValue({ value: 'flare' });
 		(DotrainOrderGui.prototype.getCurrentDeployment as Mock).mockReturnValue(mockDeployment);
 		(DotrainOrderGui.prototype.getAllFieldDefinitions as Mock).mockReturnValue({ value: [] });
 		(DotrainOrderGui.prototype.hasAnyDeposit as Mock).mockReturnValue({ value: false });

--- a/packages/ui-components/test-setup.ts
+++ b/packages/ui-components/test-setup.ts
@@ -71,7 +71,6 @@ vi.mock('@rainlanguage/orderbook/js_api', () => {
 	DotrainOrderGui.prototype.saveFieldValue = vi.fn();
 	DotrainOrderGui.prototype.getFieldValue = vi.fn();
 	DotrainOrderGui.prototype.getSelectTokens = vi.fn();
-	DotrainOrderGui.prototype.getNetworkKey = vi.fn();
 	DotrainOrderGui.prototype.getAllTokenInfos = vi.fn();
 	DotrainOrderGui.prototype.getAllFieldDefinitions = vi.fn();
 	DotrainOrderGui.prototype.isSelectTokenSet = vi.fn();
@@ -84,7 +83,11 @@ vi.mock('@rainlanguage/orderbook/js_api', () => {
 	DotrainOrderGui.prototype.serializeState = vi.fn();
 	DotrainOrderGui.prototype.getAllGuiConfig = vi.fn();
 	DotrainOrderGui.prototype.getCurrentDeploymentDetails = vi.fn();
+
+	const OrderbookYaml = vi.fn();
+	OrderbookYaml.prototype.getOrderbookByDeploymentKey = vi.fn();
 	return {
-		DotrainOrderGui
+		DotrainOrderGui,
+		OrderbookYaml
 	};
 });


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

We needed to get an orderbook by a given deployment key to use in DeploymentSteps.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

- Add a new method called `getOrderbookByDeploymentKey`
- Add a new parsing method to get orderbook key for order yaml

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced orderbook configuration retrieval using deployment keys, streamlining the extraction of network and connectivity settings from YAML.
  - Upgraded YAML processing to better distinguish valid inputs from missing or invalid configuration entries, resulting in clearer feedback during deployment.
  
- **Bug Fixes**
  - Removed legacy network key retrieval, reducing inconsistencies in deployment steps and simplifying configuration management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->