### PR TITLE
fix tauri build CI issue

### DIFF
--- a/.github/workflows/npm-package-release.yml
+++ b/.github/workflows/npm-package-release.yml
@@ -100,29 +100,6 @@ jobs:
           npx prettier --write ./packages/ui-components/package.json
           npm version prerelease --preid alpha --no-git-tag-version  -w @rainlanguage/ui-components
 
-      # sometimes the first or second try to update the version fails (npm bug?) so we retry max 5 times to
-      # make sure it updates the version successfully before proceeding and bail out if it failed to update
-      - name: Update orderbook Dependency Version for ui-components
-        if: ${{ env.OLD_HASH != env.NEW_HASH }}
-        run: |
-          set -e
-          current_version() {
-            jq -r '.dependencies."@rainlanguage/orderbook"' ./packages/ui-components/package.json
-          };
-          count=1;
-          while [[ $(current_version) != "${{ env.NEW_VERSION }}" && $count -le 5 ]]; do
-            echo "Trying to update orderbook dependency of ui-components pkg, attempt $count...";
-            ((count++));
-            npm install -w @rainlanguage/ui-components @rainlanguage/orderbook@=${{ env.NEW_VERSION }} --save-exact;
-            sleep 3;
-          done;
-          if [[ $(current_version) != "${{ env.NEW_VERSION }}" ]]; then
-            echo "Failed to update orderbook dependency version for ui-components after 5 attempts, aborting...";
-            exit 1;
-          else
-            echo "Successfully updated to $(current_version)";
-          fi;
-
       # Commit changes and tag
       - name: Commit And Tag
         if: ${{ env.OLD_HASH != env.NEW_HASH }}

--- a/.github/workflows/npm-package-release.yml
+++ b/.github/workflows/npm-package-release.yml
@@ -93,8 +93,12 @@ jobs:
       - name: Set Version
         if: ${{ env.OLD_HASH != env.NEW_HASH }}
         run: |
-          npm version prerelease --preid alpha --no-git-tag-version -w @rainlanguage/ui-components -w @rainlanguage/orderbook
-          echo "NEW_VERSION=$(jq -r '.version' ./packages/orderbook/package.json)" >> $GITHUB_ENV
+          npm version prerelease --preid alpha --no-git-tag-version  -w @rainlanguage/orderbook
+          NEW_VERSION=$(jq -r '.version' ./packages/orderbook/package.json)
+          echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
+          jq --arg v "$NEW_VERSION" '.dependencies."@rainlanguage/orderbook" = $v' ./packages/ui-components/package.json > tmp.json && mv tmp.json ./packages/ui-components/package.json
+          npx prettier --write ./packages/ui-components/package.json
+          npm version prerelease --preid alpha --no-git-tag-version  -w @rainlanguage/ui-components
 
       # sometimes the first or second try to update the version fails (npm bug?) so we retry max 5 times to
       # make sure it updates the version successfully before proceeding and bail out if it failed to update

--- a/.github/workflows/tauri.yaml
+++ b/.github/workflows/tauri.yaml
@@ -82,10 +82,10 @@ jobs:
       - run: nix develop .#tauri-shell --command npm run svelte-lint-format-check
         working-directory: ./tauri-app
 
-      - run: nix develop .#tauri-shell --command tauri-rs-test
-
-      # remove test artifacts to free up space
-      - run: rm -rf tauri-app/src-tauri/target
-
       - run: nix develop .#tauri-shell --command cargo tauri build --verbose
         working-directory: ./tauri-app
+
+      # remove artifacts to free up space
+      - run: rm -rf tauri-app/src-tauri/target
+
+      - run: nix develop .#tauri-shell --command tauri-rs-test

--- a/.github/workflows/tauri.yaml
+++ b/.github/workflows/tauri.yaml
@@ -82,10 +82,10 @@ jobs:
       - run: nix develop .#tauri-shell --command npm run svelte-lint-format-check
         working-directory: ./tauri-app
 
+      - run: nix develop .#tauri-shell --command tauri-rs-test
+
+      # remove test artifacts to free up space
+      - run: rm -rf tauri-app/src-tauri/target/release
+
       - run: nix develop .#tauri-shell --command cargo tauri build --verbose
         working-directory: ./tauri-app
-
-      # remove artifacts to free up space
-      - run: rm -rf tauri-app/src-tauri/target
-
-      - run: nix develop .#tauri-shell --command tauri-rs-test

--- a/.github/workflows/tauri.yaml
+++ b/.github/workflows/tauri.yaml
@@ -85,7 +85,7 @@ jobs:
       - run: nix develop .#tauri-shell --command tauri-rs-test
 
       # remove test artifacts to free up space
-      - run: rm -rf tauri-app/src-tauri/target/release
+      - run: rm -rf tauri-app/src-tauri/target/debug
 
       - run: nix develop .#tauri-shell --command cargo tauri build --verbose
         working-directory: ./tauri-app

--- a/crates/settings/src/gui.rs
+++ b/crates/settings/src/gui.rs
@@ -294,7 +294,7 @@ impl GuiCfg {
     ) -> Result<bool, YamlError> {
         for document in documents {
             let document_read = document.read().map_err(|_| YamlError::ReadLockError)?;
-            if let Some(gui) = optional_hash(&document_read, "gui") {
+            if let Some(_) = optional_hash(&document_read, "gui") {
                 return Ok(true);
             }
         }

--- a/crates/settings/src/gui.rs
+++ b/crates/settings/src/gui.rs
@@ -294,7 +294,7 @@ impl GuiCfg {
     ) -> Result<bool, YamlError> {
         for document in documents {
             let document_read = document.read().map_err(|_| YamlError::ReadLockError)?;
-            if let Some(_) = optional_hash(&document_read, "gui") {
+            if let Some(gui) = optional_hash(&document_read, "gui") {
                 return Ok(true);
             }
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20965,7 +20965,7 @@
         },
         "packages/orderbook": {
             "name": "@rainlanguage/orderbook",
-            "version": "0.0.1-alpha.60",
+            "version": "0.0.1-alpha.59",
             "license": "LicenseRef-DCL-1.0",
             "dependencies": {
                 "buffer": "6.0.3"
@@ -21078,14 +21078,14 @@
         },
         "packages/ui-components": {
             "name": "@rainlanguage/ui-components",
-            "version": "0.0.1-alpha.60",
+            "version": "0.0.1-alpha.59",
             "license": "LicenseRef-DCL-1.0",
             "dependencies": {
                 "@codemirror/lang-yaml": "6.1.1",
                 "@fontsource/dm-sans": "5.1.0",
                 "@imask/svelte": "7.6.1",
                 "@observablehq/plot": "0.6.16",
-                "@rainlanguage/orderbook": "0.0.1-alpha.60",
+                "@rainlanguage/orderbook": "0.0.1-alpha.59",
                 "@reown/appkit": "1.6.4",
                 "@reown/appkit-adapter-wagmi": "1.6.4",
                 "@sentry/sveltekit": "7.120.0",

--- a/packages/orderbook/package.json
+++ b/packages/orderbook/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@rainlanguage/orderbook",
     "description": "Provides RainLanguage Orderbook rust crates' functionalities in typescript through wasm bindgen",
-    "version": "0.0.1-alpha.60",
+    "version": "0.0.1-alpha.59",
     "license": "LicenseRef-DCL-1.0",
     "author": "Rain Open Source Software Ltd",
     "repository": {

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rainlanguage/ui-components",
-	"version": "0.0.1-alpha.60",
+	"version": "0.0.1-alpha.59",
 	"description": "A component library for building Svelte applications to be used with Raindex.",
 	"license": "LicenseRef-DCL-1.0",
 	"author": "Rain Open Source Software Ltd",
@@ -53,7 +53,7 @@
 		"@fontsource/dm-sans": "5.1.0",
 		"@imask/svelte": "7.6.1",
 		"@observablehq/plot": "0.6.16",
-		"@rainlanguage/orderbook": "0.0.1-alpha.60",
+		"@rainlanguage/orderbook": "0.0.1-alpha.59",
 		"@reown/appkit": "1.6.4",
 		"@reown/appkit-adapter-wagmi": "1.6.4",
 		"@sentry/sveltekit": "7.120.0",


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation
- tauri test job removed test artifacts to free up space, but Frameworks folder in `target` got removed too causing the failed error
- npm job is fine, but a version was skipped, and its not present in npm so causing following releases to fail, the reason why following releases failed is because after updating the version of the pkgs using npm version, it runs the npm install and if the prev version is not present on npmjs registry it errors. but it should not happen.
so we need to update the ob pkg version separate from ui-comp pkg version, and before updating the ui-comp version, set the ob dep version of that to updated version of ob pkg
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [ ] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Chores**
  - Refined the build process to clean up only debug artifacts, ensuring a more efficient build.
  - Streamlined the release workflow to update dependency versions before finalizing package versions.
- **Revert**
  - Rolled back the version numbers for both the order book and UI components packages to a previous, more consistent state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->