### PR TITLE
Add accounts field yaml parsing logic

### DIFF
--- a/crates/settings/src/accounts.rs
+++ b/crates/settings/src/accounts.rs
@@ -1,0 +1,190 @@
+use crate::yaml::{
+    context::Context, default_document, optional_hash, require_string, FieldErrorKind, YamlError,
+    YamlParsableHash,
+};
+use alloy::{hex::FromHexError, primitives::Address};
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::HashMap,
+    str::FromStr,
+    sync::{Arc, RwLock},
+};
+use strict_yaml_rust::StrictYaml;
+use thiserror::Error;
+#[cfg(target_family = "wasm")]
+use wasm_bindgen_utils::{impl_wasm_traits, prelude::*};
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "kebab-case")]
+#[cfg_attr(target_family = "wasm", derive(Tsify))]
+pub struct AccountCfg {
+    #[serde(skip, default = "default_document")]
+    pub document: Arc<RwLock<StrictYaml>>,
+    pub key: String,
+    #[cfg_attr(target_family = "wasm", tsify(type = "string"))]
+    pub address: Address,
+}
+#[cfg(target_family = "wasm")]
+impl_wasm_traits!(AccountCfg);
+
+impl AccountCfg {
+    pub fn validate_address(value: &str) -> Result<Address, ParseAccountCfgError> {
+        Address::from_str(value).map_err(ParseAccountCfgError::AddressParseError)
+    }
+}
+
+impl YamlParsableHash for AccountCfg {
+    fn parse_all_from_yaml(
+        documents: Vec<Arc<RwLock<StrictYaml>>>,
+        _: Option<&Context>,
+    ) -> Result<HashMap<String, AccountCfg>, YamlError> {
+        let mut accounts = HashMap::new();
+
+        for document in documents {
+            let document_read = document.read().map_err(|_| YamlError::ReadLockError)?;
+
+            if let Some(accounts_hash) = optional_hash(&document_read, "accounts") {
+                for (key_yaml, account_yaml) in accounts_hash {
+                    let account_key = key_yaml.as_str().unwrap_or_default().to_string();
+                    let location = "accounts".to_string();
+
+                    let address_str = require_string(account_yaml, None, Some(location.clone()))?;
+                    let address = AccountCfg::validate_address(&address_str).map_err(|e| {
+                        YamlError::Field {
+                            kind: FieldErrorKind::InvalidValue {
+                                field: account_key.to_string(),
+                                reason: e.to_string(),
+                            },
+                            location: location.clone(),
+                        }
+                    })?;
+
+                    let account = AccountCfg {
+                        document: document.clone(),
+                        key: account_key.clone(),
+                        address,
+                    };
+                    if accounts.contains_key(&account_key) {
+                        return Err(YamlError::KeyShadowing(account_key, "accounts".to_string()));
+                    }
+                    accounts.insert(account_key, account);
+                }
+            }
+        }
+
+        Ok(accounts)
+    }
+}
+
+impl Default for AccountCfg {
+    fn default() -> Self {
+        Self {
+            document: Arc::new(RwLock::new(StrictYaml::String("".to_string()))),
+            key: "".to_string(),
+            address: Address::default(),
+        }
+    }
+}
+
+impl PartialEq for AccountCfg {
+    fn eq(&self, other: &Self) -> bool {
+        self.key == other.key && self.address == other.address
+    }
+}
+
+#[derive(Error, Debug, PartialEq)]
+pub enum ParseAccountCfgError {
+    #[error("Failed to parse account address")]
+    AddressParseError(FromHexError),
+}
+
+impl ParseAccountCfgError {
+    pub fn to_readable_msg(&self) -> String {
+        match self {
+            ParseAccountCfgError::AddressParseError(err) =>
+                format!("The account address in your YAML configuration is invalid. Please provide a valid EVM address: '{}'", err),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::yaml::tests::get_document;
+
+    #[test]
+    fn test_parse_accounts_invalid_address() {
+        let error = AccountCfg::parse_all_from_yaml(
+            vec![get_document(
+                r#"
+accounts:
+    name-one: invalid-address
+"#,
+            )],
+            None,
+        )
+        .unwrap_err();
+        assert_eq!(
+            error,
+            YamlError::Field {
+                kind: FieldErrorKind::InvalidValue {
+                    field: "name-one".to_string(),
+                    reason: "Failed to parse account address".to_string(),
+                },
+                location: "accounts".to_string(),
+            }
+        );
+        assert_eq!(
+            error.to_readable_msg(),
+            "Invalid value for field 'name-one' in accounts: Failed to parse account address"
+        );
+    }
+
+    #[test]
+    fn test_parse_accounts_from_yaml_multiple_files() {
+        let yaml_one = r#"
+accounts:
+    name-one: 0x0000000000000000000000000000000000000001
+"#;
+        let yaml_two = r#"
+accounts:
+    name-two: 0x0000000000000000000000000000000000000002
+"#;
+
+        let documents = vec![get_document(yaml_one), get_document(yaml_two)];
+        let accounts = AccountCfg::parse_all_from_yaml(documents, None).unwrap();
+
+        assert_eq!(accounts.len(), 2);
+        assert!(accounts.contains_key("name-one"));
+        assert!(accounts.contains_key("name-two"));
+
+        assert_eq!(
+            accounts.get("name-one").unwrap().address,
+            Address::from_str("0x0000000000000000000000000000000000000001").unwrap()
+        );
+        assert_eq!(
+            accounts.get("name-two").unwrap().address,
+            Address::from_str("0x0000000000000000000000000000000000000002").unwrap()
+        );
+    }
+
+    #[test]
+    fn test_parse_accounts_from_yaml_duplicate_key() {
+        let yaml_one = r#"
+accounts:
+    account: 0x0000000000000000000000000000000000000001
+"#;
+        let yaml_two = r#"
+accounts:
+    account: 0x0000000000000000000000000000000000000002
+"#;
+
+        let documents = vec![get_document(yaml_one), get_document(yaml_two)];
+        let error = AccountCfg::parse_all_from_yaml(documents, None).unwrap_err();
+
+        assert_eq!(
+            error,
+            YamlError::KeyShadowing("account".to_string(), "accounts".to_string())
+        );
+    }
+}

--- a/crates/settings/src/lib.rs
+++ b/crates/settings/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod accounts;
 pub mod blocks;
 pub mod chart;
 pub mod config;

--- a/crates/settings/src/yaml/orderbook.rs
+++ b/crates/settings/src/yaml/orderbook.rs
@@ -1,8 +1,8 @@
 use super::{cache::Cache, *};
 use crate::{
-    metaboard::MetaboardCfg, raindex_version::RaindexVersion, remote_networks::RemoteNetworksCfg,
-    remote_tokens::RemoteTokensCfg, sentry::Sentry, subgraph::SubgraphCfg, DeployerCfg, NetworkCfg,
-    OrderbookCfg, TokenCfg,
+    accounts::AccountCfg, metaboard::MetaboardCfg, raindex_version::RaindexVersion,
+    remote_networks::RemoteNetworksCfg, remote_tokens::RemoteTokensCfg, sentry::Sentry,
+    subgraph::SubgraphCfg, DeployerCfg, NetworkCfg, OrderbookCfg, TokenCfg,
 };
 use alloy::primitives::Address;
 use serde::{
@@ -193,6 +193,18 @@ impl OrderbookYaml {
         let value = RaindexVersion::parse_from_yaml_optional(self.documents[0].clone())?;
         Ok(value)
     }
+
+    pub fn get_account_keys(&self) -> Result<Vec<String>, YamlError> {
+        let accounts = self.get_accounts()?;
+        Ok(accounts.keys().cloned().collect())
+    }
+    pub fn get_accounts(&self) -> Result<HashMap<String, AccountCfg>, YamlError> {
+        let accounts = AccountCfg::parse_all_from_yaml(self.documents.clone(), None)?;
+        Ok(accounts)
+    }
+    pub fn get_account(&self, key: &str) -> Result<AccountCfg, YamlError> {
+        AccountCfg::parse_from_yaml(self.documents.clone(), key, None)
+    }
 }
 
 impl Serialize for OrderbookYaml {
@@ -293,8 +305,8 @@ mod tests {
             address: 0x0000000000000000000000000000000000000002
             network: mainnet
     accounts:
-        admin: 0x4567890123abcdef
-        user: 0x5678901234abcdef
+        admin: 0x0000000000000000000000000000000000000001
+        user: 0x0000000000000000000000000000000000000002
     sentry: true
     raindex-version: 1.0.0
     "#;
@@ -414,6 +426,16 @@ mod tests {
         assert_eq!(
             ob_yaml.get_raindex_version().unwrap(),
             Some("1.0.0".to_string())
+        );
+
+        assert_eq!(ob_yaml.get_account_keys().unwrap().len(), 2);
+        assert_eq!(
+            ob_yaml.get_account("admin").unwrap().address,
+            Address::from_str("0x0000000000000000000000000000000000000001").unwrap()
+        );
+        assert_eq!(
+            ob_yaml.get_account("user").unwrap().address,
+            Address::from_str("0x0000000000000000000000000000000000000002").unwrap()
         );
     }
 


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

See issue: https://github.com/rainlanguage/rain.orderbook/issues/1678

We have implemented strict yaml parsing for all of the other fields and only accounts field remain

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

- Add parsing logic
- Add and update tests

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- ~[ ] included screenshots (if this involves a front-end change)~

fix https://github.com/rainlanguage/rain.orderbook/issues/1678

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for managing account configurations, including retrieving all accounts, individual accounts by key, and listing account keys.
  - Introduced validation for Ethereum addresses in account configurations.
- **Bug Fixes**
  - Improved error handling for invalid or duplicate account keys in configuration files.
- **Tests**
  - Added tests to verify account parsing, address validation, and duplicate key detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->