### PR TITLE
fix debug tab cache

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -48,4 +48,10 @@
     "CI_FORK_SEPOLIA_BLOCK_NUMBER": "",
     "COMMIT_SHA": ""
   },
+  "rust-analyzer.cargo.extraEnv": {
+    "COMMIT_SHA": ""
+  },
+  "rust-analyzer.check.extraEnv": {
+    "COMMIT_SHA": ""
+  }
 }

--- a/crates/cli/src/commands/chart/mod.rs
+++ b/crates/cli/src/commands/chart/mod.rs
@@ -19,8 +19,8 @@ pub struct Chart {
 impl Execute for Chart {
     async fn execute(&self) -> Result<()> {
         let dotrain = read_to_string(self.dotrain_file.clone()).map_err(|e| anyhow!(e))?;
-        let fuzzer = FuzzRunner::new(&dotrain, None, None).await?;
-        let chart_data = fuzzer.make_chart_data().await?;
+        let fuzzer = FuzzRunner::new(None);
+        let chart_data = fuzzer.make_chart_data(&dotrain, None, None).await?;
 
         info!("{:#?}", chart_data);
         Ok(())

--- a/crates/common/src/fuzz/impls.rs
+++ b/crates/common/src/fuzz/impls.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::add_order::ORDERBOOK_ORDER_ENTRYPOINTS;
 use alloy::primitives::private::rand;
+use alloy::primitives::Address;
 use alloy::primitives::U256;
 use alloy::sol_types::SolCall;
 use alloy_ethers_typecast::transaction::{ReadableClientError, ReadableClientHttp};
@@ -8,15 +9,23 @@ use dotrain::{error::ComposeError, RainDocument, Rebind};
 use futures::TryFutureExt;
 use proptest::prelude::RngCore;
 use proptest::test_runner::{RngAlgorithm, TestRng};
+use rain_error_decoding::{AbiDecodeFailedErrors, AbiDecodedErrorType};
 use rain_interpreter_bindings::IInterpreterStoreV1::FullyQualifiedNamespace;
-use rain_interpreter_eval::eval::ForkParseArgs;
-use rain_interpreter_eval::fork::NewForkedEvm;
-pub use rain_interpreter_eval::trace::{RainEvalResultError, RainEvalResults, TraceSearchError};
-use rain_interpreter_eval::{
-    error::ForkCallError, eval::ForkEvalArgs, fork::Forker, trace::RainEvalResult,
+use rain_interpreter_bindings::{
+    DeployerISP::{iInterpreterCall, iStoreCall},
+    IInterpreterV3::eval3Call,
 };
+use rain_interpreter_eval::eval::ForkParseArgs;
+use rain_interpreter_eval::fork::{Forker, NewForkedEvm};
+pub use rain_interpreter_eval::trace::{RainEvalResultError, RainEvalResults, TraceSearchError};
+use rain_interpreter_eval::{error::ForkCallError, eval::ForkEvalArgs, trace::RainEvalResult};
 use rain_orderbook_app_settings::blocks::BlockError;
 use rain_orderbook_app_settings::scenario::ScenarioCfg;
+use rain_orderbook_app_settings::{
+    order::OrderIOCfg,
+    yaml::{dotrain::DotrainYaml, YamlError, YamlParsable},
+};
+use rain_orderbook_bindings::IERC20;
 use std::collections::HashMap;
 use std::sync::Arc;
 use thiserror::Error;
@@ -37,12 +46,16 @@ impl FuzzResult {
     }
 }
 
-#[derive(Clone)]
-pub struct FuzzRunner {
-    pub forker: Forker,
+#[derive(Debug, Clone)]
+pub struct FuzzRunnerInputs {
     pub dotrain: String,
     pub dotrain_yaml: DotrainYaml,
     pub rng: TestRng,
+}
+
+#[derive(Clone)]
+pub struct FuzzRunner {
+    pub forker: Forker,
 }
 
 #[derive(Error, Debug)]
@@ -88,11 +101,19 @@ pub enum FuzzRunnerError {
 }
 
 impl FuzzRunner {
-    pub async fn new(
+    /// Creates a new instance optionally with the given [Forker] instance
+    pub fn new(forker: Option<Forker>) -> FuzzRunner {
+        Self {
+            forker: forker.unwrap_or(Forker::new()),
+        }
+    }
+
+    /// Prepares the given dotrain and settings text inputs consumable values by the FuzzRunner methods
+    pub fn prepare_inputs(
         dotrain: &str,
         settings: Option<String>,
         seed: Option<[u8; 32]>,
-    ) -> Result<Self, FuzzRunnerError> {
+    ) -> Result<FuzzRunnerInputs, FuzzRunnerError> {
         let frontmatter = RainDocument::get_front_matter(dotrain)
             .unwrap_or("")
             .to_string();
@@ -105,21 +126,25 @@ impl FuzzRunner {
 
         let dotrain_yaml = DotrainYaml::new(source, false)?;
 
-        Ok(Self {
-            forker: Forker::new(),
+        Ok(FuzzRunnerInputs {
             dotrain: dotrain.into(),
             dotrain_yaml,
             rng: TestRng::from_seed(RngAlgorithm::ChaCha, &seed.unwrap_or([0; 32])),
         })
     }
 
-    pub async fn run_scenario_by_key(&mut self, key: &str) -> Result<FuzzResult, FuzzRunnerError> {
-        let scenario = self.dotrain_yaml.get_scenario(key)?;
-        self.run_scenario(&scenario).await
+    pub async fn run_scenario_by_key(
+        &mut self,
+        inputs: &mut FuzzRunnerInputs,
+        key: &str,
+    ) -> Result<FuzzResult, FuzzRunnerError> {
+        let scenario = inputs.dotrain_yaml.get_scenario(key)?;
+        self.run_scenario(inputs, &scenario).await
     }
 
     pub async fn run_scenario(
         &mut self,
+        inputs: &mut FuzzRunnerInputs,
         scenario: &ScenarioCfg,
     ) -> Result<FuzzResult, FuzzRunnerError> {
         // If the scenario doesn't have runs, default is 1
@@ -161,7 +186,7 @@ impl FuzzRunner {
         // Create a new RainDocument with the dotrain and the bindings
         // The bindings in the dotrain string are ignored by the RainDocument
         let rain_document = RainDocument::create(
-            self.dotrain.clone(),
+            inputs.dotrain.clone(),
             None,
             None,
             Some(scenario_bindings.clone()),
@@ -177,7 +202,7 @@ impl FuzzRunner {
                 .collect::<Vec<String>>(),
         );
 
-        let dotrain = Arc::new(self.dotrain.clone());
+        let dotrain = Arc::new(inputs.dotrain.clone());
         let mut handles = vec![];
 
         for block_number in blocks {
@@ -196,7 +221,7 @@ impl FuzzRunner {
                 // For each scenario.fuzz_binds, add a random value
                 for elided_binding in elided_binding_keys.as_slice() {
                     let mut val: [u8; 32] = [0; 32];
-                    self.rng.fill_bytes(&mut val);
+                    inputs.rng.fill_bytes(&mut val);
                     let hex = alloy::primitives::hex::encode_prefixed(val);
                     final_bindings.push(Rebind(elided_binding.to_string(), hex));
                 }
@@ -247,16 +272,25 @@ impl FuzzRunner {
         })
     }
 
+    /// Debugs (evals) the given order pair on the self [Forker] instance
     pub async fn run_debug(
         &mut self,
+        inputs: &mut FuzzRunnerInputs,
         block_number: u64,
         input: OrderIOCfg,
         output: OrderIOCfg,
         scenario: &ScenarioCfg,
-    ) -> Result<(String, FuzzResult), FuzzRunnerError> {
+    ) -> Result<
+        (
+            String,
+            FuzzResult,
+            Option<Result<AbiDecodedErrorType, AbiDecodeFailedErrors>>,
+        ),
+        FuzzRunnerError,
+    > {
         let deployer = scenario.deployer.clone();
 
-        // Create a fork with the first block number
+        // Create or select a cached fork
         self.forker
             .add_or_select(
                 NewForkedEvm {
@@ -278,7 +312,7 @@ impl FuzzRunner {
         // Create a new RainDocument with the dotrain and the bindings
         // The bindings in the dotrain string are ignored by the RainDocument
         let rain_document = RainDocument::create(
-            self.dotrain.clone(),
+            inputs.dotrain.clone(),
             None,
             None,
             Some(scenario_bindings.clone()),
@@ -294,10 +328,7 @@ impl FuzzRunner {
                 .collect::<Vec<String>>(),
         );
 
-        let dotrain = Arc::new(self.dotrain.clone());
-        self.forker.roll_fork(Some(block_number), None)?;
-        let fork = Arc::new(self.forker.clone()); // Wrap in Arc for shared ownership
-        let fork_clone = Arc::clone(&fork); // Clone the Arc for each thread
+        let dotrain = Arc::new(inputs.dotrain.clone());
         let elided_binding_keys = Arc::clone(&elided_binding_keys);
         let deployer = Arc::clone(&deployer);
         let scenario_bindings = scenario_bindings.clone();
@@ -308,7 +339,7 @@ impl FuzzRunner {
         // For each scenario.fuzz_binds, add a random value
         for elided_binding in elided_binding_keys.as_slice() {
             let mut val: [u8; 32] = [0; 32];
-            self.rng.fill_bytes(&mut val);
+            inputs.rng.fill_bytes(&mut val);
             let hex = alloy::primitives::hex::encode_prefixed(val);
             final_bindings.push(Rebind(elided_binding.to_string(), hex));
         }
@@ -345,107 +376,106 @@ impl FuzzRunner {
             input_symbol_res.typed_return._0, output_symbol_res.typed_return._0
         );
 
-        let handle = tokio::spawn(async move {
-            final_bindings.extend(scenario_bindings.clone());
+        // let handle = tokio::spawn(async move {
+        final_bindings.extend(scenario_bindings.clone());
 
-            let rainlang_string = RainDocument::compose_text(
-                &dotrain,
-                &ORDERBOOK_ORDER_ENTRYPOINTS,
-                None,
-                Some(final_bindings),
+        let rainlang_string = RainDocument::compose_text(
+            &dotrain,
+            &ORDERBOOK_ORDER_ENTRYPOINTS,
+            None,
+            Some(final_bindings),
+        )
+        .map_err(FuzzRunnerError::ComposeError)?;
+
+        // Create a 5x5 grid of zero values for context - later we'll
+        // replace these with sane values based on Orderbook context
+        let mut context = vec![vec![U256::from(0); 5]; 5];
+        // set random hash for context order hash cell
+        context[1][0] = rand::random();
+
+        // set input values in context
+        // input token
+        context[3][0] = U256::from_be_slice(input_token.address.0.as_slice());
+        // input decimals
+        context[3][1] = U256::from(input_token.decimals.unwrap_or(18));
+        // input vault id
+        context[3][2] = input.vault_id.unwrap_or(U256::from(0));
+        // input vault balance before
+        context[3][3] = U256::from(0);
+
+        // set output values in context
+        // output token
+        context[4][0] = U256::from_be_slice(output_token.address.0.as_slice());
+        // output decimals
+        context[4][1] = U256::from(output_token.decimals.unwrap_or(18));
+        // output vault id
+        context[4][2] = output.vault_id.unwrap_or(U256::from(0));
+        // output vault balance before
+        context[4][3] = U256::from(0);
+
+        let parse_result = self
+            .forker
+            .fork_parse(ForkParseArgs {
+                rainlang_string: rainlang_string.clone(),
+                deployer: deployer.address,
+                decode_errors: true,
+            })
+            .await
+            .map_err(FuzzRunnerError::ForkCallError)?;
+        let store = self
+            .forker
+            .alloy_call(Address::default(), deployer.address, iStoreCall {}, true)
+            .await?
+            .typed_return
+            ._0;
+        let interpreter = self
+            .forker
+            .alloy_call(
+                Address::default(),
+                deployer.address,
+                iInterpreterCall {},
+                true,
             )
-            .map_err(FuzzRunnerError::ComposeError)?;
-
-            // Create a 5x5 grid of zero values for context - later we'll
-            // replace these with sane values based on Orderbook context
-            let mut context = vec![vec![U256::from(0); 5]; 5];
-            // set random hash for context order hash cell
-            context[1][0] = rand::random();
-
-            // set input values in context
-            // input token
-            context[3][0] = U256::from_be_slice(input_token.address.0.as_slice());
-            // input decimals
-            context[3][1] = U256::from(input_token.decimals.unwrap_or(18));
-            // input vault id
-            context[3][2] = input.vault_id.unwrap_or(U256::from(0));
-            // input vault balance before
-            context[3][3] = U256::from(0);
-
-            // set output values in context
-            // output token
-            context[4][0] = U256::from_be_slice(output_token.address.0.as_slice());
-            // output decimals
-            context[4][1] = U256::from(output_token.decimals.unwrap_or(18));
-            // output vault id
-            context[4][2] = output.vault_id.unwrap_or(U256::from(0));
-            // output vault balance before
-            context[4][3] = U256::from(0);
-
-            let parse_result = fork_clone
-                .fork_parse(ForkParseArgs {
-                    rainlang_string: rainlang_string.clone(),
-                    deployer: deployer.address,
-                    decode_errors: true,
-                })
-                .await
-                .map_err(FuzzRunnerError::ForkCallError)?;
-            let store = fork_clone
-                .alloy_call(Address::default(), deployer.address, iStoreCall {}, true)
-                .await?
-                .typed_return
-                ._0;
-            let interpreter = fork_clone
-                .alloy_call(
-                    Address::default(),
-                    deployer.address,
-                    iInterpreterCall {},
-                    true,
-                )
-                .await?
-                .typed_return
-                ._0;
-            let res = fork_clone.call(
-                Address::default().as_slice(),
-                interpreter.as_slice(),
-                &eval3Call {
-                    bytecode: parse_result.typed_return.bytecode,
-                    sourceIndex: U256::from(0),
-                    store,
-                    namespace: FullyQualifiedNamespace::default().into(),
-                    context,
-                    inputs: vec![],
-                }
-                .abi_encode(),
-            )?;
-
-            let mut error = None;
-            if res.exit_reason.is_revert() {
-                error = Some(AbiDecodedErrorType::selector_registry_abi_decode(&res.result).await);
+            .await?
+            .typed_return
+            ._0;
+        let res = self.forker.call(
+            Address::default().as_slice(),
+            interpreter.as_slice(),
+            &eval3Call {
+                bytecode: parse_result.typed_return.bytecode,
+                sourceIndex: U256::from(0),
+                store,
+                namespace: FullyQualifiedNamespace::default().into(),
+                context,
+                inputs: vec![],
             }
+            .abi_encode(),
+        )?;
 
-            Ok::<
-                (
-                    RainEvalResult,
-                    Option<Result<AbiDecodedErrorType, AbiDecodeFailedErrors>>,
-                ),
-                FuzzRunnerError,
-            >((res.into(), error))
-        });
-
-        let (result, _) = handle.await??;
+        let mut error = None;
+        if res.exit_reason.is_revert() {
+            error = Some(AbiDecodedErrorType::selector_registry_abi_decode(&res.result).await);
+        }
 
         Ok((
             pair_symbols,
             FuzzResult {
                 scenario: scenario.key.clone(),
-                runs: vec![result].into(),
+                runs: vec![res.into()].into(),
             },
+            error,
         ))
     }
 
-    pub async fn make_chart_data(&self) -> Result<ChartData, FuzzRunnerError> {
-        let charts = self.dotrain_yaml.get_charts()?;
+    pub async fn make_chart_data(
+        &self,
+        dotrain: &str,
+        settings: Option<String>,
+        seed: Option<[u8; 32]>,
+    ) -> Result<ChartData, FuzzRunnerError> {
+        let mut inputs = Self::prepare_inputs(dotrain, settings, seed)?;
+        let charts = inputs.dotrain_yaml.get_charts()?;
         let mut scenarios_data: HashMap<String, FuzzResultFlat> = HashMap::new();
 
         for (_, chart) in charts.clone() {
@@ -453,7 +483,7 @@ impl FuzzRunner {
             let mut runner = self.clone();
             scenarios_data.entry(scenario_key.clone()).or_insert(
                 runner
-                    .run_scenario_by_key(&scenario_key)
+                    .run_scenario_by_key(&mut inputs, &scenario_key)
                     .await?
                     .flatten_traces()?,
             );
@@ -465,37 +495,112 @@ impl FuzzRunner {
         })
     }
 
+    /// Evals the given dotrain for all the deployments in the given settings and reports the results
     pub async fn make_debug_data(
-        &self,
-        block_number: Option<u64>,
-    ) -> Result<DeploymentDebugData, FuzzRunnerError> {
-        let mut block = block_number.unwrap_or(0);
-        let mut pair_datas: HashMap<String, Vec<DeploymentDebugPairData>> = HashMap::new();
-
-        let deployments_keys = self.dotrain_yaml.get_deployment_keys()?;
+        &mut self,
+        dotrain: &str,
+        settings: Option<String>,
+        seed: Option<[u8; 32]>,
+        block_numbers: Option<HashMap<String, u64>>,
+    ) -> Result<DeploymentsDebugDataMap, FuzzRunnerError> {
+        let mut inputs = Self::prepare_inputs(dotrain, settings, seed)?;
+        let mut data_map: HashMap<String, DeploymentDebugData> = HashMap::new();
+        let deployments_keys = inputs.dotrain_yaml.get_deployment_keys()?;
 
         for deployment_key in deployments_keys {
-            let deployment = self.dotrain_yaml.get_deployment(&deployment_key)?;
+            let mut result = DeploymentDebugData {
+                pairs_data: vec![],
+                block_number: U256::from(0),
+            };
+            let deployment = match inputs.dotrain_yaml.get_deployment(&deployment_key) {
+                Ok(v) => v,
+                Err(e) => {
+                    result.pairs_data.push(DeploymentDebugPairData {
+                        order: "".to_string(),
+                        scenario: "".to_string(),
+                        pair: "".to_string(),
+                        result: None,
+                        error: Some(e.to_string()),
+                    });
+                    data_map.insert(deployment_key.clone(), result);
+                    continue;
+                }
+            };
             let scenario = deployment.scenario.clone();
-
-            if block_number.is_none() {
+            let block_number = if let Some(bn) = block_numbers
+                .as_ref()
+                .unwrap_or(&HashMap::new())
+                .get(&deployment_key)
+            {
+                *bn
+            } else {
                 // Fetch the latest block number
-                block =
-                    ReadableClientHttp::new_from_url(scenario.deployer.network.rpc.to_string())?
-                        .get_block_number()
-                        .await?;
-            }
+                match ReadableClientHttp::new_from_url(scenario.deployer.network.rpc.to_string()) {
+                    Ok(v) => match v.get_block_number().await {
+                        Ok(bn) => bn,
+                        Err(e) => {
+                            result.pairs_data.push(DeploymentDebugPairData {
+                                order: deployment.order.key.clone(),
+                                scenario: scenario.key.clone(),
+                                pair: "".to_string(),
+                                result: None,
+                                error: Some(e.to_string()),
+                            });
+                            data_map.insert(deployment_key.clone(), result);
+                            continue;
+                        }
+                    },
+                    Err(e) => {
+                        result.pairs_data.push(DeploymentDebugPairData {
+                            order: deployment.order.key.clone(),
+                            scenario: scenario.key.clone(),
+                            pair: "".to_string(),
+                            result: None,
+                            error: Some(e.to_string()),
+                        });
+                        data_map.insert(deployment_key.clone(), result);
+                        continue;
+                    }
+                }
+            };
+            result.block_number = U256::from(block_number);
 
-            for input in &deployment.order.inputs {
-                let input_token = input
+            'outter: for input in &deployment.order.inputs {
+                let input_token = match input
                     .token
                     .clone()
-                    .ok_or(FuzzRunnerError::InputTokenNotFound)?;
-                for output in &deployment.order.outputs {
-                    let output_token = output
+                    .ok_or(FuzzRunnerError::InputTokenNotFound)
+                {
+                    Ok(token) => token,
+                    Err(e) => {
+                        result.pairs_data.push(DeploymentDebugPairData {
+                            order: deployment.order.key.clone(),
+                            scenario: scenario.key.clone(),
+                            pair: "".to_string(),
+                            result: None,
+                            error: Some(e.to_string()),
+                        });
+                        continue 'outter;
+                    }
+                };
+                'inner: for output in &deployment.order.outputs {
+                    let output_token = match output
                         .token
                         .clone()
-                        .ok_or(FuzzRunnerError::OutputTokenNotFound)?;
+                        .ok_or(FuzzRunnerError::OutputTokenNotFound)
+                    {
+                        Ok(token) => token,
+                        Err(e) => {
+                            result.pairs_data.push(DeploymentDebugPairData {
+                                order: deployment.order.key.clone(),
+                                scenario: scenario.key.clone(),
+                                pair: "".to_string(),
+                                result: None,
+                                error: Some(e.to_string()),
+                            });
+                            continue 'inner;
+                        }
+                    };
                     if input_token.address != output_token.address {
                         let mut pair_data = DeploymentDebugPairData {
                             order: deployment.order.key.clone(),
@@ -505,43 +610,44 @@ impl FuzzRunner {
                             error: None,
                         };
 
-                        let mut runner = self.clone();
-                        match runner
-                            .run_debug(block, input.clone(), output.clone(), &scenario)
+                        match self
+                            .run_debug(
+                                &mut inputs,
+                                block_number,
+                                input.clone(),
+                                output.clone(),
+                                &scenario,
+                            )
                             .await
                         {
-                            Ok((pair_symbols, fuzz_result)) => match fuzz_result.flatten_traces() {
-                                Ok(fuzz_result) => {
-                                    pair_data.pair = pair_symbols;
-                                    pair_data.result = Some(fuzz_result);
+                            Ok((pair_symbols, fuzz_result, eval_error)) => {
+                                match fuzz_result.flatten_traces() {
+                                    Ok(fuzz_result) => {
+                                        pair_data.pair = pair_symbols;
+                                        pair_data.result = Some(fuzz_result);
+                                        pair_data.error = eval_error.and_then(|v| match v {
+                                            Ok(abi_decoded_error) => {
+                                                Some(abi_decoded_error.to_string())
+                                            }
+                                            Err(e) => Some(e.to_string()),
+                                        });
+                                    }
+                                    Err(e) => {
+                                        pair_data.error = Some(e.to_string());
+                                    }
                                 }
-                                Err(e) => {
-                                    pair_data.error = Some(e.to_string());
-                                }
-                            },
+                            }
                             Err(e) => {
-                                if matches!(e, FuzzRunnerError::ComposeError(_)) {
-                                    return Err(e);
-                                }
                                 pair_data.error = Some(e.to_string());
                             }
                         }
-
-                        pair_datas
-                            .entry(deployment_key.clone())
-                            .or_default()
-                            .push(pair_data);
+                        result.pairs_data.push(pair_data);
                     }
                 }
             }
+            data_map.insert(deployment_key.clone(), result);
         }
-
-        let result = DeploymentDebugData {
-            result: pair_datas,
-            block_number: U256::from(block),
-        };
-
-        Ok(result)
+        Ok(DeploymentsDebugDataMap { data_map })
     }
 }
 
@@ -553,6 +659,45 @@ mod tests {
         providers::{ext::AnvilApi, Provider},
     };
     use rain_orderbook_test_fixtures::LocalEvm;
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+    async fn test_prepare_inputs() {
+        let local_evm = LocalEvm::new().await;
+        let dotrain = format!(
+            r#"
+deployers:
+    some-key:
+        address: {deployer}
+networks:
+    some-key:
+        rpc: {rpc_url}
+        chain-id: 123
+scenarios:
+    some-key:
+        runs: 50
+        bindings:
+            bound: 3
+---
+#bound !bind it
+#fuzzed !fuzz it
+#calculate-io
+a: bound,
+b: fuzzed;
+#handle-io
+:;
+#handle-add-order
+:;"#,
+            rpc_url = local_evm.url(),
+            deployer = local_evm.deployer.address()
+        );
+        let inputs = FuzzRunner::prepare_inputs(&dotrain, None, None).unwrap();
+
+        assert_eq!(inputs.dotrain, dotrain);
+        assert_eq!(
+            inputs.dotrain_yaml.get_scenario_keys().unwrap(),
+            vec!["some-key"]
+        );
+    }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
     async fn test_fuzz_runner() {
@@ -584,10 +729,11 @@ b: fuzzed;
             rpc_url = local_evm.url(),
             deployer = local_evm.deployer.address()
         );
-        let mut runner = FuzzRunner::new(&dotrain, None, None).await.unwrap();
+        let mut runner = FuzzRunner::new(None);
+        let mut inputs = FuzzRunner::prepare_inputs(&dotrain, None, None).unwrap();
 
         let res = runner
-            .run_scenario_by_key("some-key")
+            .run_scenario_by_key(&mut inputs, "some-key")
             .await
             .map_err(|e| println!("{:#?}", e))
             .unwrap();
@@ -633,10 +779,11 @@ _: block-number();
             start_block = start_block_number,
             end_block = last_block_number
         );
-        let mut runner = FuzzRunner::new(&dotrain, None, None).await.unwrap();
+        let mut runner = FuzzRunner::new(None);
+        let mut inputs = FuzzRunner::prepare_inputs(&dotrain, None, None).unwrap();
 
         let res = runner
-            .run_scenario_by_key("some-key")
+            .run_scenario_by_key(&mut inputs, "some-key")
             .await
             .map_err(|e| println!("{:#?}", e))
             .unwrap();
@@ -690,10 +837,11 @@ d: 4;
             rpc_url = local_evm.url(),
             deployer = local_evm.deployer.address()
         );
-        let mut runner = FuzzRunner::new(&dotrain, None, None).await.unwrap();
+        let mut runner = FuzzRunner::new(None);
+        let mut inputs = FuzzRunner::prepare_inputs(&dotrain, None, None).unwrap();
 
         let res = runner
-            .run_scenario_by_key("some-key")
+            .run_scenario_by_key(&mut inputs, "some-key")
             .await
             .map_err(|e| println!("{:#?}", e))
             .unwrap();
@@ -743,10 +891,11 @@ _: context<4 4>();
             rpc_url = local_evm.url(),
             deployer = local_evm.deployer.address()
         );
-        let mut runner = FuzzRunner::new(&dotrain, None, None).await.unwrap();
+        let mut runner = FuzzRunner::new(None);
+        let mut inputs = FuzzRunner::prepare_inputs(&dotrain, None, None).unwrap();
 
         let res = runner
-            .run_scenario_by_key("some-key")
+            .run_scenario_by_key(&mut inputs, "some-key")
             .await
             .map_err(|e| println!("{:#?}", e))
             .unwrap();
@@ -786,10 +935,11 @@ _: context<50 50>();
             rpc_url = local_evm.url(),
             deployer = local_evm.deployer.address()
         );
-        let mut runner = FuzzRunner::new(&dotrain, None, None).await.unwrap();
+        let mut runner = FuzzRunner::new(None);
+        let mut inputs = FuzzRunner::prepare_inputs(&dotrain, None, None).unwrap();
 
         let res = runner
-            .run_scenario_by_key("some-key")
+            .run_scenario_by_key(&mut inputs, "some-key")
             .await
             .map_err(|e| println!("{:#?}", e));
 
@@ -823,10 +973,11 @@ _: context<1 0>();
             rpc_url = local_evm.url(),
             deployer = local_evm.deployer.address()
         );
-        let mut runner = FuzzRunner::new(&dotrain, None, None).await.unwrap();
+        let mut runner = FuzzRunner::new(None);
+        let mut inputs = FuzzRunner::prepare_inputs(&dotrain, None, None).unwrap();
 
         let res = runner
-            .run_scenario_by_key("some-key")
+            .run_scenario_by_key(&mut inputs, "some-key")
             .await
             .map_err(|e| println!("{:#?}", e))
             .unwrap();
@@ -941,15 +1092,15 @@ _: add(something 30);
             wflr_address = wflr_address,
             usdce_address = usdce_address,
         );
-        let runner = FuzzRunner::new(&dotrain, None, None).await.unwrap();
+        let mut runner = FuzzRunner::new(None);
 
         let res = runner
-            .make_debug_data(None)
+            .make_debug_data(&dotrain, None, None, None)
             .await
             .map_err(|e| println!("{:#?}", e))
             .unwrap();
 
-        let result_rows = res.result["sell-wflr"][0]
+        let result_rows = res.data_map["sell-wflr"].pairs_data[0]
             .result
             .as_ref()
             .unwrap()

--- a/crates/common/src/fuzz/mod.rs
+++ b/crates/common/src/fuzz/mod.rs
@@ -1,16 +1,6 @@
-use alloy::primitives::{Address, U256};
-use rain_error_decoding::{AbiDecodeFailedErrors, AbiDecodedErrorType};
-use rain_interpreter_bindings::{
-    DeployerISP::{iInterpreterCall, iStoreCall},
-    IInterpreterV3::eval3Call,
-};
+use alloy::primitives::U256;
 pub use rain_interpreter_eval::trace::*;
-use rain_orderbook_app_settings::{
-    chart::ChartCfg,
-    order::OrderIOCfg,
-    yaml::{dotrain::DotrainYaml, YamlError, YamlParsable},
-};
-use rain_orderbook_bindings::IERC20;
+use rain_orderbook_app_settings::chart::ChartCfg;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -55,9 +45,23 @@ impl_wasm_traits!(FuzzResultFlat);
 #[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(target_family = "wasm", derive(Tsify))]
 #[serde(rename_all = "camelCase")]
+pub struct DeploymentsDebugDataMap {
+    #[cfg_attr(
+        target_family = "wasm",
+        serde(serialize_with = "serialize_hashmap_as_object"),
+        tsify(type = "Record<string, DeploymentDebugData>")
+    )]
+    pub data_map: HashMap<String, DeploymentDebugData>,
+}
+#[cfg(target_family = "wasm")]
+impl_wasm_traits!(DeploymentsDebugDataMap);
+
+#[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(target_family = "wasm", derive(Tsify))]
+#[serde(rename_all = "camelCase")]
 pub struct DeploymentDebugData {
-    pub result: HashMap<String, Vec<DeploymentDebugPairData>>,
-    #[cfg_attr(target_family = "wasm", tsify(type = "string"))]
+    pub pairs_data: Vec<DeploymentDebugPairData>,
+    #[cfg_attr(target_family = "wasm", tsify(type = "`0x${string}`"))]
     pub block_number: U256,
 }
 #[cfg(target_family = "wasm")]

--- a/tauri-app/src-tauri/src/commands/charts.rs
+++ b/tauri-app/src-tauri/src/commands/charts.rs
@@ -1,27 +1,24 @@
+use std::collections::HashMap;
+
 use crate::{error::CommandResult, shared_state::SharedState};
 use rain_orderbook_common::fuzz::*;
 use tauri::State;
 
 #[tauri::command]
-pub async fn make_charts(
-    dotrain: String,
-    shared_state: State<'_, SharedState>,
-) -> CommandResult<ChartData> {
-    let runner = shared_state
-        .get_or_create_fuzz_runner(dotrain, None)
-        .await?;
-    Ok(runner.make_chart_data().await?)
+pub async fn make_charts(dotrain: String) -> CommandResult<ChartData> {
+    let runner = FuzzRunner::new(None);
+    Ok(runner.make_chart_data(&dotrain, None, None).await?)
 }
 
 #[tauri::command]
 pub async fn make_deployment_debug(
     dotrain: String,
     settings: Option<String>,
-    block_number: Option<u64>,
+    block_numbers: Option<HashMap<String, u64>>,
     shared_state: State<'_, SharedState>,
-) -> CommandResult<DeploymentDebugData> {
-    let runner = shared_state
-        .get_or_create_fuzz_runner(dotrain, settings)
-        .await?;
-    Ok(runner.make_debug_data(block_number).await?)
+) -> CommandResult<DeploymentsDebugDataMap> {
+    let mut runner = shared_state.debug_runner.lock().await;
+    Ok(runner
+        .make_debug_data(&dotrain, settings, None, block_numbers)
+        .await?)
 }

--- a/tauri-app/src-tauri/src/shared_state.rs
+++ b/tauri-app/src-tauri/src/shared_state.rs
@@ -1,139 +1,14 @@
-use crate::error::CommandResult;
 use rain_orderbook_common::fuzz::FuzzRunner;
-use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
-#[derive(Default)]
 pub struct SharedState {
-    fuzz_runner: Mutex<HashMap<(String, Option<String>), Arc<FuzzRunner>>>,
+    pub debug_runner: Arc<Mutex<FuzzRunner>>,
 }
-
-impl SharedState {
-    pub async fn get_or_create_fuzz_runner(
-        &self,
-        dotrain: String,
-        settings: Option<String>,
-    ) -> CommandResult<Arc<FuzzRunner>> {
-        let key = (dotrain, settings);
-        let mut cache = self.fuzz_runner.lock().await;
-
-        if let Some(runner) = cache.get(&key) {
-            Ok(runner.clone())
-        } else {
-            let runner = Arc::new(FuzzRunner::new(&key.0, key.1.clone(), None).await?);
-            cache.insert(key, runner.clone());
-            Ok(runner)
+impl Default for SharedState {
+    fn default() -> Self {
+        Self {
+            debug_runner: Arc::new(Mutex::new(FuzzRunner::new(None))),
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::sync::Arc;
-
-    const DOTRAIN1: &str = r#"
-networks:
-  mainnet:
-    rpc_url: "https://mainnet.infura.io/v3/YOUR_INFURA_API_KEY"
-    chain_id: 1
----
-#calculate-io
-_ _: 1 2;
-#handle-io
-:;
-#handle-add-order
-"#;
-    const DOTRAIN2: &str = r#"
-networks:
-  mainnet:
-    rpc_url: https://test.com
-    chain_id: 1
-subgraphs:
-  mainnet:
-    url: https://test.com
----
-#calculate-io
-_ _: 1 2;
-#handle-io
-:;
-#handle-add-order
-"#;
-
-    #[tokio::test]
-    async fn test_shared_state_fuzz_runner_cache_hit() {
-        let shared_state = SharedState::default();
-
-        let runner1 = shared_state
-            .get_or_create_fuzz_runner(DOTRAIN1.to_string(), None)
-            .await
-            .expect("First creation failed");
-
-        let runner2 = shared_state
-            .get_or_create_fuzz_runner(DOTRAIN1.to_string(), None)
-            .await
-            .expect("Second call failed");
-
-        assert!(
-            Arc::ptr_eq(&runner1, &runner2),
-            "Cache miss: Runners should be the same instance"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_shared_state_fuzz_runner_cache_miss_different_script() {
-        let shared_state = SharedState::default();
-
-        let runner1 = shared_state
-            .get_or_create_fuzz_runner(DOTRAIN1.to_string(), None)
-            .await
-            .expect("Runner 1 creation failed");
-        let runner2 = shared_state
-            .get_or_create_fuzz_runner(DOTRAIN2.to_string(), None)
-            .await
-            .expect("Runner 2 creation failed");
-
-        assert!(
-            !Arc::ptr_eq(&runner1, &runner2),
-            "Cache hit: Different scripts should produce different runners"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_shared_state_fuzz_runner_cache_miss_different_settings() {
-        let shared_state = SharedState::default();
-        let settings1 = Some("settings A".to_string());
-        let settings2 = Some("settings B".to_string());
-
-        let runner_none = shared_state
-            .get_or_create_fuzz_runner(DOTRAIN1.to_string(), None)
-            .await
-            .expect("Runner None creation failed");
-        let runner_s1 = shared_state
-            .get_or_create_fuzz_runner(DOTRAIN1.to_string(), settings1.clone())
-            .await
-            .expect("Runner S1 creation failed");
-        let runner_s2 = shared_state
-            .get_or_create_fuzz_runner(DOTRAIN1.to_string(), settings2.clone())
-            .await
-            .expect("Runner S2 creation failed");
-        let runner_s1_again = shared_state
-            .get_or_create_fuzz_runner(DOTRAIN1.to_string(), settings1.clone())
-            .await
-            .expect("Runner S1 again creation failed");
-
-        assert!(
-            !Arc::ptr_eq(&runner_none, &runner_s1),
-            "Cache hit: None vs Some settings"
-        );
-        assert!(
-            !Arc::ptr_eq(&runner_s1, &runner_s2),
-            "Cache hit: Different Some settings"
-        );
-        assert!(
-            Arc::ptr_eq(&runner_s1, &runner_s1_again),
-            "Cache miss: Same Some settings should hit cache"
-        );
     }
 }

--- a/tauri-app/src/lib/services/chart.ts
+++ b/tauri-app/src/lib/services/chart.ts
@@ -1,12 +1,12 @@
-import type { ChartData, DeploymentDebugData } from '@rainlanguage/orderbook';
+import type { ChartData, DeploymentsDebugDataMap } from '@rainlanguage/orderbook';
 import { invoke } from '@tauri-apps/api';
 
 export const makeChartData = async (dotrain: string): Promise<ChartData> =>
   invoke('make_charts', { dotrain });
 
-export const makeDeploymentDebugData = async (
+export const makeDeploymentsDebugDataMap = async (
   dotrain: string,
   settings: string,
-  blockNumber?: number,
-): Promise<DeploymentDebugData> =>
-  invoke('make_deployment_debug', { dotrain, settings, blockNumber });
+  blockNumbers?: Record<string, number>,
+): Promise<DeploymentsDebugDataMap> =>
+  invoke('make_deployment_debug', { dotrain, settings, blockNumbers });


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation
Fixes the cache issue mentioned in #1599 
There were some bugs and issues with the logic/implementation of the debug tab to correctly use and hit foundry cache, this PR fixes that.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
- There was a shared state in tauri source that kept a hash map of detrain + settings string paired with `FuzzRunner` instances, and since `FuzzRunner` has a fresh instance of `Forker`, we never actually reused any forks.
- block numbers coming from GUI were only set to value, yet the inner logic debugs the given detrain for al of the available deployments in the settings, so the provided block number didn't really match with different networks causing issues and bug, we now pass on a map of block numbers for each deployment's network and a column on the GUI debug tab to show block height for each debug row.
- inside `make_debug_data()` method `FuzzRunner`, the forker property was getting cloned for each debug loop iteration, and those forker that cache the calls all go out of scope once the method execution ends, We needed to operate on `&mut self` so the only `Forker` instance is used and caches and never goes out of scope since on tauri it is kept under the `Arc<Mutex>`
- There was incorrect attempt at parallel exec for fork calls, however since now we only have one instance of `Forker` that manages all the forks, and we wanna keep the cache during the program execution, we can't do parallel execution because `Forker` only works on one active fork at a time. (`make_chart_data()` method still operates in parallel because it doesn't need the cache and clones the forker instance for each fuzz run)
- There are some modifications to the `FuzzRunner`, which are removing the detrain and settings text from the props and moving them on to the arguments for the methods, this way a single `FuzzRunner` instance that has a `Forker` prop can operate on many detrains/settings.
- Updated existing tests to work with changes

### GUI Test

https://github.com/user-attachments/assets/18b78cf2-7227-4082-8036-4c8733340d76


<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [ ] ~~unit-tested any new functionality~~
- [x] linked any relevant issues or PRs
- [x] included screenshots (if this involves a front-end change)
