### PR TITLE
Test common::rainlang

### DIFF
--- a/crates/common/src/fuzz/impls.rs
+++ b/crates/common/src/fuzz/impls.rs
@@ -969,10 +969,7 @@ _: context<50 50>();
         let mut runner = FuzzRunner::new(None);
         let mut context = FuzzRunnerContext::new(&dotrain, None, None).unwrap();
 
-        let res = runner
-            .run_scenario_by_key(&mut context, "some-key")
-            .await
-            .map_err(|e| println!("{:#?}", e));
+        let res = runner.run_scenario_by_name("some-key").await;
 
         assert!(res.is_err());
     }

--- a/crates/common/src/fuzz/impls.rs
+++ b/crates/common/src/fuzz/impls.rs
@@ -969,7 +969,7 @@ _: context<50 50>();
         let mut runner = FuzzRunner::new(None);
         let mut context = FuzzRunnerContext::new(&dotrain, None, None).unwrap();
 
-        let res = runner.run_scenario_by_name("some-key").await;
+        let res = runner.run_scenario_by_key(&mut context, "some-key").await;
 
         assert!(res.is_err());
     }

--- a/crates/common/src/rainlang.rs
+++ b/crates/common/src/rainlang.rs
@@ -214,14 +214,15 @@ mod fork_parse {
             Some(b) => b,
             None => {
                 let client = ReadableClientHttp::new_from_url(rpc_url.to_string())?;
-
                 client.get_block_number().await?
             }
         };
+
         let args = NewForkedEvm {
             fork_url: rpc_url.to_owned(),
             fork_block_number: Some(block_number_val),
         };
+
         let mut forker = FORKER.lock().await;
         forker.add_or_select(args, None).await?;
 
@@ -233,5 +234,116 @@ mod fork_parse {
         let result = forker.fork_parse(parse_args).await?;
 
         Ok(result.raw.result.0)
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use alloy::primitives::hex::encode_prefixed;
+        use httpmock::MockServer;
+        use std::str::FromStr;
+
+        use super::*;
+
+        #[tokio::test]
+        async fn test_parse_rainlang_on_fork() {
+            let mainnet_deployer =
+                Address::from_str("0xd19581a021f4704ad4eBfF68258e7A0a9DB1CD77").unwrap();
+
+            let server = MockServer::start();
+
+            server.mock(|when, then| {
+                when.path("/rpc").body_contains("eth_gasPrice");
+
+                then.status(200)
+                    .header("content-type", "application/json")
+                    .body(r#"{ "jsonrpc": "2.0", "id": 1, "result": "0x198542e9" }"#);
+            });
+
+            server.mock(|when, then| {
+                when.path("/rpc").body_contains("eth_chainId");
+
+                then.status(200)
+                    .header("content-type", "application/json")
+                    .body(r#"{ "jsonrpc": "2.0", "id": 1, "result": "0x1" }"#);
+            });
+
+            server.mock(|when, then| {
+                when.path("/rpc").body_contains("eth_getBlockByNumber");
+
+                then.status(200)
+                    .header("content-type", "application/json")
+                    .body(r#"{
+                        "jsonrpc": "2.0",
+                        "id": 1,
+                        "result": {
+                            "difficulty": "0x1913ff69551dac",
+                            "extraData": "0xe4b883e5bda9e7a59ee4bb99e9b1bc000921",
+                            "gasLimit": "0xe4e1b2",
+                            "gasUsed": "0xe4d737",
+                            "hash": "0xa917fcc721a5465a484e9be17cda0cc5493933dd3bc70c9adbee192cb419c9d7",
+                            "logsBloom": "0x00af00124b82093253a6960ab5a003170000318c0a00c18d418505009c10c905810e05d4a4511044b6245a062122010233958626c80039250781851410a468418101040c0100f178088a4e89000140e00001880c1c601413ac47bc5882854701180b9404422202202521584000808843030a552488a80e60c804c8d8004d0480422585320e068028d2e190508130022600024a51c116151a07612040081000088ba5c891064920a846b36288a40280820212b20940280056b233060818988945f33460426105024024040923447ad1102000028b8f0e001e810021031840a2801831a0113b003a5485843004c10c4c10d6a04060a84d88500038ab10875a382c",
+                            "miner": "0x829bd824b016326a401d083b33d092293333a830",
+                            "mixHash": "0x7d416c4a24dc3b43898040ea788922d8563d44a5193e6c4a1d9c70990775c879",
+                            "nonce": "0xe6e41732385c71d6",
+                            "number": "0xc5043f",
+                            "parentHash": "0xd1c4628a6710d8dec345e5bca6b8093abf3f830516e05e36f419f993334d10ef",
+                            "receiptsRoot": "0x7eadd994da137c7720fe2bf2935220409ed23a06ec6470ffd2d478e41af0255b",
+                            "sha3Uncles": "0x7d9ce61d799ddcb5dfe1644ec7224ae7018f24ecb682f077b4c477da192e8553",
+                            "size": "0xa244",
+                            "stateRoot": "0x6350d0454245fb410fc0fb93f6648c5b9047a6081441e36f0ff3ab259c9a47f0",
+                            "timestamp": "0x6100bc82",
+                            "transactions": [
+                                "0x23e3362a76c8b9370dc65bac8eb1cda1d408ac238a466cfe690248025254bf52",
+                                "0x4594fadbfa1b5ec0f3a0a13dd1d0ab42d176efd91ef14f6fcb84e9d06b02a159",
+                                "0xdf8d8677c9cd5f81d8ee3663a4a64ce7fe93d35fcb46004529e77394630f8e11"
+                            ],
+                            "transactionsRoot": "0xa17c2a87a6ff2fd790d517e48279e02f2e092a05309300c976363e47e0012672",
+                            "uncles": [
+                            "0xd3946359c70281162cf00c8164d99ca14801e8008715cb1fad93b9cecaf9f7d8"
+                            ]
+                        }
+                    }"#);
+            });
+
+            server.mock(|when, then| {
+                when.path("/rpc").matches(|req| {
+                    match req.body.as_ref() {
+                        Some(body) => {
+                            println!("Received request:\n{}\n", String::from_utf8_lossy(body));
+                        }
+                        None => println!("Received request with no body"),
+                    }
+                    true
+                });
+
+                then.status(500);
+            });
+
+            let block_number = 12911679;
+
+            let rainlang = r"
+some front matter
+---
+/** this is test */
+
+#const-binding 4e18
+#elided-binding ! this elided, rebind before use
+#exp-binding
+_: opcode-1(0xabcd 456);
+";
+
+            let bytes = parse_rainlang_on_fork(
+                rainlang,
+                &server.url("/rpc"),
+                Some(block_number),
+                mainnet_deployer,
+            )
+            .await
+            .unwrap();
+
+            let expected = "0x";
+
+            assert_eq!(encode_prefixed(&bytes), expected);
+        }
     }
 }

--- a/crates/common/src/rainlang.rs
+++ b/crates/common/src/rainlang.rs
@@ -239,111 +239,109 @@ mod fork_parse {
     #[cfg(test)]
     mod tests {
         use alloy::primitives::hex::encode_prefixed;
-        use httpmock::MockServer;
-        use std::str::FromStr;
+        use std::collections::HashMap;
 
         use super::*;
+        use crate::add_order::ORDERBOOK_ORDER_ENTRYPOINTS;
+        use rain_orderbook_test_fixtures::LocalEvm;
 
-        #[tokio::test]
-        async fn test_parse_rainlang_on_fork() {
-            let mainnet_deployer =
-                Address::from_str("0xd19581a021f4704ad4eBfF68258e7A0a9DB1CD77").unwrap();
+        #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+        async fn test_parse_rainlang_on_fork_ok() {
+            let local_evm = LocalEvm::new().await;
+            let deployer = *local_evm.deployer.address();
+            let rpc_url = local_evm.url();
 
-            let server = MockServer::start();
-
-            server.mock(|when, then| {
-                when.path("/rpc").body_contains("eth_gasPrice");
-
-                then.status(200)
-                    .header("content-type", "application/json")
-                    .body(r#"{ "jsonrpc": "2.0", "id": 1, "result": "0x198542e9" }"#);
-            });
-
-            server.mock(|when, then| {
-                when.path("/rpc").body_contains("eth_chainId");
-
-                then.status(200)
-                    .header("content-type", "application/json")
-                    .body(r#"{ "jsonrpc": "2.0", "id": 1, "result": "0x1" }"#);
-            });
-
-            server.mock(|when, then| {
-                when.path("/rpc").body_contains("eth_getBlockByNumber");
-
-                then.status(200)
-                    .header("content-type", "application/json")
-                    .body(r#"{
-                        "jsonrpc": "2.0",
-                        "id": 1,
-                        "result": {
-                            "difficulty": "0x1913ff69551dac",
-                            "extraData": "0xe4b883e5bda9e7a59ee4bb99e9b1bc000921",
-                            "gasLimit": "0xe4e1b2",
-                            "gasUsed": "0xe4d737",
-                            "hash": "0xa917fcc721a5465a484e9be17cda0cc5493933dd3bc70c9adbee192cb419c9d7",
-                            "logsBloom": "0x00af00124b82093253a6960ab5a003170000318c0a00c18d418505009c10c905810e05d4a4511044b6245a062122010233958626c80039250781851410a468418101040c0100f178088a4e89000140e00001880c1c601413ac47bc5882854701180b9404422202202521584000808843030a552488a80e60c804c8d8004d0480422585320e068028d2e190508130022600024a51c116151a07612040081000088ba5c891064920a846b36288a40280820212b20940280056b233060818988945f33460426105024024040923447ad1102000028b8f0e001e810021031840a2801831a0113b003a5485843004c10c4c10d6a04060a84d88500038ab10875a382c",
-                            "miner": "0x829bd824b016326a401d083b33d092293333a830",
-                            "mixHash": "0x7d416c4a24dc3b43898040ea788922d8563d44a5193e6c4a1d9c70990775c879",
-                            "nonce": "0xe6e41732385c71d6",
-                            "number": "0xc5043f",
-                            "parentHash": "0xd1c4628a6710d8dec345e5bca6b8093abf3f830516e05e36f419f993334d10ef",
-                            "receiptsRoot": "0x7eadd994da137c7720fe2bf2935220409ed23a06ec6470ffd2d478e41af0255b",
-                            "sha3Uncles": "0x7d9ce61d799ddcb5dfe1644ec7224ae7018f24ecb682f077b4c477da192e8553",
-                            "size": "0xa244",
-                            "stateRoot": "0x6350d0454245fb410fc0fb93f6648c5b9047a6081441e36f0ff3ab259c9a47f0",
-                            "timestamp": "0x6100bc82",
-                            "transactions": [
-                                "0x23e3362a76c8b9370dc65bac8eb1cda1d408ac238a466cfe690248025254bf52",
-                                "0x4594fadbfa1b5ec0f3a0a13dd1d0ab42d176efd91ef14f6fcb84e9d06b02a159",
-                                "0xdf8d8677c9cd5f81d8ee3663a4a64ce7fe93d35fcb46004529e77394630f8e11"
-                            ],
-                            "transactionsRoot": "0xa17c2a87a6ff2fd790d517e48279e02f2e092a05309300c976363e47e0012672",
-                            "uncles": [
-                            "0xd3946359c70281162cf00c8164d99ca14801e8008715cb1fad93b9cecaf9f7d8"
-                            ]
-                        }
-                    }"#);
-            });
-
-            server.mock(|when, then| {
-                when.path("/rpc").matches(|req| {
-                    match req.body.as_ref() {
-                        Some(body) => {
-                            println!("Received request:\n{}\n", String::from_utf8_lossy(body));
-                        }
-                        None => println!("Received request with no body"),
-                    }
-                    true
-                });
-
-                then.status(500);
-            });
-
-            let block_number = 12911679;
-
-            let rainlang = r"
+            let dotrain = r"
 some front matter
 ---
-/** this is test */
+#key1 !Test binding
+#calculate-io
+_ _: 0 0;
+#handle-io
+:;
+#handle-add-order
+_ _: 1 2;
+"
+            .trim_start();
 
-#const-binding 4e18
-#elided-binding ! this elided, rebind before use
-#exp-binding
-_: opcode-1(0xabcd 456);
-";
-
-            let bytes = parse_rainlang_on_fork(
-                rainlang,
-                &server.url("/rpc"),
-                Some(block_number),
-                mainnet_deployer,
+            let rainlang = super::super::compose_to_rainlang(
+                dotrain.to_string(),
+                HashMap::new(),
+                &ORDERBOOK_ORDER_ENTRYPOINTS,
             )
-            .await
             .unwrap();
 
-            let expected = "0x";
+            let bytes = parse_rainlang_on_fork(&rainlang, &rpc_url, None, deployer)
+                .await
+                .unwrap();
+
+            let expected = "0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000075000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000015020000000c020200020110000001100000000000000000000000000000000000";
 
             assert_eq!(encode_prefixed(&bytes), expected);
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+        async fn test_parse_rainlang_on_fork_err_parsing_dotrain_instead_of_rainlang() {
+            let local_evm = LocalEvm::new().await;
+            let deployer = *local_evm.deployer.address();
+            let rpc_url = local_evm.url();
+
+            let dotrain = r"
+some front matter
+---
+#key1 !Test binding
+#calculate-io
+_ _: 0 0;
+#handle-io
+:;
+#handle-add-order
+_ _: 1 2;
+";
+
+            let err = parse_rainlang_on_fork(&dotrain, &rpc_url, None, deployer)
+                .await
+                .unwrap_err();
+
+            assert!(matches!(
+                err,
+                ForkParseError::ForkCallReverted(AbiDecodedErrorType::Known { name, .. }) if name == "UnexpectedLHSChar"
+            ));
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+        async fn test_parse_rainlang_on_fork_err_invalid_url() {
+            let rpc_url = "http://localhost:1";
+            let deployer = Address::ZERO;
+
+            let dotrain = r"
+some front matter
+---
+#key1 !Test binding
+#calculate-io
+_ _: 0 0;
+#handle-io
+:;
+#handle-add-order
+_ _: 1 2;
+"
+            .trim_start();
+
+            let rainlang = super::super::compose_to_rainlang(
+                dotrain.to_string(),
+                HashMap::new(),
+                &ORDERBOOK_ORDER_ENTRYPOINTS,
+            )
+            .unwrap();
+
+            let err = parse_rainlang_on_fork(&rainlang, &rpc_url, None, deployer)
+                .await
+                .unwrap_err();
+
+            assert!(matches!(
+                err,
+                ForkParseError::ReadableClientError(ReadableClientError::ReadBlockNumberError(err_msg))
+                if err_msg == "error sending request for url (http://localhost:1/): error trying to connect: tcp connect error: Connection refused (os error 61)"
+            ));
         }
     }
 }

--- a/crates/common/src/rainlang.rs
+++ b/crates/common/src/rainlang.rs
@@ -299,7 +299,7 @@ _ _: 0 0;
 _ _: 1 2;
 ";
 
-            let err = parse_rainlang_on_fork(&dotrain, &rpc_url, None, deployer)
+            let err = parse_rainlang_on_fork(dotrain, &rpc_url, None, deployer)
                 .await
                 .unwrap_err();
 


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

- `common::rainlang` is missing tests
- `compose_to_rainlang` sets 32 bytes of zeros for elided bindings

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

- Add unit tests
- Remove the default rebinding for elided bindings in `compose_to_rainlang`

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [X] made this PR as small as possible
- [X] unit-tested any new functionality
- [X] linked any relevant issues or PRs
- [X] included screenshots (if this involves a front-end change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in test scenarios by simplifying how errors are surfaced.  
- **Refactor**
	- Streamlined the process for composing rainlang strings by removing unnecessary logic for handling elided bindings.  
- **Tests**
	- Added comprehensive unit and async tests for rainlang composition and parsing, including various success and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->