### PR TITLE
Add catch-all error route for failing to fetch config settings

### DIFF
--- a/packages/ui-components/src/lib/types/appStores.ts
+++ b/packages/ui-components/src/lib/types/appStores.ts
@@ -1,5 +1,6 @@
 import type { Readable, Writable } from 'svelte/store';
 import type { ConfigSource, OrderbookConfigSource } from '@rainlanguage/orderbook';
+import type { OrderbookCfgRef } from '../../../dist';
 export interface AppStoresInterface {
 	settings: Writable<ConfigSource | undefined>;
 	activeSubgraphs: Writable<Record<string, string>>;
@@ -17,4 +18,5 @@ export interface AppStoresInterface {
 		[k: string]: string;
 	}>;
 	showMyItemsOnly: Writable<boolean>;
+	activeNetworkOrderbooks: Readable<Record<OrderbookCfgRef, OrderbookConfigSource>>;
 }

--- a/packages/webapp/src/lib/__mocks__/stores.ts
+++ b/packages/webapp/src/lib/__mocks__/stores.ts
@@ -8,7 +8,8 @@ export const initialPageState = {
 		stores: { settings: {} },
 		dotrain: 'some dotrain content',
 		deployment: { key: 'deploy-key' },
-		strategyDetail: {}
+		strategyDetail: {},
+		errorMessage: ''
 	},
 	url: new URL('http://localhost:3000/deploy'),
 	params: {},

--- a/packages/webapp/src/lib/components/ErrorPage.svelte
+++ b/packages/webapp/src/lib/components/ErrorPage.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+	import { page } from '$app/stores';
+</script>
+
+<div class="error-container mx-auto my-10 flex max-w-xl flex-col gap-4 p-2 text-center">
+	<h1 class="text-2xl font-bold text-red-600">An Error Occurred</h1>
+	<p>
+		We encountered a problem loading the application configuration. Please try again later or
+		<a href="https://t.me/rainlanguage" target="_blank" class="text-blue-500 hover:underline"
+			>contact support</a
+		>.
+	</p>
+
+	{#if $page.data?.errorMessage}
+		<div class="error-details rounded border border-red-400 bg-red-100 p-4 text-left text-red-700">
+			<h2 class="font-semibold">Error Details:</h2>
+			<pre class="whitespace-pre-wrap break-words">{$page.data.errorMessage}</pre>
+		</div>
+	{/if}
+
+	<a href="/" class="text-blue-500 hover:underline">Go to Homepage</a>
+</div>

--- a/packages/webapp/src/lib/components/ErrorPage.svelte
+++ b/packages/webapp/src/lib/components/ErrorPage.svelte
@@ -2,7 +2,10 @@
 	import { page } from '$app/stores';
 </script>
 
-<div class="error-container mx-auto my-10 flex max-w-xl flex-col gap-4 p-2 text-center">
+<div
+	data-testid="error-page"
+	class="error-container mx-auto my-10 flex max-w-xl flex-col gap-4 p-2 text-center"
+>
 	<h1 class="text-2xl font-bold text-red-600">An Error Occurred</h1>
 	<p>
 		We encountered a problem loading the application configuration. Please try again later or

--- a/packages/webapp/src/routes/+layout.svelte
+++ b/packages/webapp/src/routes/+layout.svelte
@@ -15,9 +15,13 @@
 	import { WalletProvider } from '@rainlanguage/ui-components';
 	import { signerAddress } from '$lib/stores/wagmi';
 	import { settings as cachedSettings } from '$lib/stores/settings';
+	import ErrorPage from '$lib/components/ErrorPage.svelte';
 
-	const { settings } = $page.data.stores;
-	cachedSettings.set(settings);
+	const { stores, errorMessage } = $page.data;
+
+	$: if (stores?.settings) {
+		cachedSettings.set(stores.settings);
+	}
 
 	// Query client for caching
 	const queryClient = new QueryClient({
@@ -63,6 +67,8 @@
 		<LoadingWrapper>
 			{#if $page.url.pathname === '/'}
 				<Homepage {colorTheme} />
+			{:else if errorMessage}
+				<ErrorPage />
 			{:else}
 				<div
 					data-testid="layout-container"

--- a/packages/webapp/src/routes/layout.test.ts
+++ b/packages/webapp/src/routes/layout.test.ts
@@ -28,7 +28,6 @@ vi.mock('@rainlanguage/ui-components', async (importOriginal) => {
 	const MockWalletProvider = (await import('../lib/__mocks__/MockComponent.svelte')).default;
 	return {
 		...(await importOriginal()),
-
 		WalletProvider: MockWalletProvider
 	};
 });
@@ -135,5 +134,19 @@ describe('Layout component', () => {
 			value: originalNavigator,
 			writable: true
 		});
+	});
+
+	it('displays an error page if the page.error is set', async () => {
+		mockPageStore.mockSetSubscribeValue({
+			...initialPageState,
+			data: {
+				...initialPageState.data,
+				errorMessage: 'Test error'
+			}
+		});
+		render(Layout);
+
+		expect(screen.getByText('Test error')).toBeInTheDocument();
+		expect(screen.getByTestId('error-page')).toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

There is no error handling for a failed fetch call to the settings.json (soon to be settings.yml). This issue was flagged by a private file path being used in #1689.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Add a catch-all error page for handling a failed fetch in layout load.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)
