### PR TITLE
Fix the utils::timestamp::tests module that was overridden by AI

### DIFF
--- a/crates/common/src/utils/timestamp.rs
+++ b/crates/common/src/utils/timestamp.rs
@@ -30,41 +30,100 @@ pub fn format_timestamp_display(timestamp: i64) -> Result<String, FormatTimestam
 
     Ok(timestamp_display)
 }
-#[test]
-fn test_format_bigint_timestamp_display_ok() {
-    // Required to make local timezone deterministic
-    // NOTE: Setting TZ affects global state.
-    std::env::set_var("TZ", "CET");
 
-    let timestamp = "1746537612".to_string();
-    let result = format_bigint_timestamp_display(timestamp.clone());
-    assert_eq!(result, Ok("2025-05-06 03:20:12 PM".to_string()));
+#[cfg(test)]
+mod tests {
+    use core::num::IntErrorKind;
 
-    let timestamp_i64 = timestamp.parse::<i64>().unwrap();
-    let result = format_timestamp_display(timestamp_i64);
-    assert_eq!(result, Ok("2025-05-06 03:20:12 PM".to_string()));
+    use super::*;
 
-    // Required to make local timezone deterministic
-    // NOTE: Setting TZ affects global state.
-    std::env::set_var("TZ", "EST");
+    #[test]
+    fn test_format_bigint_timestamp_display_err_parse_int_err() {
+        let timestamp = "".to_string();
+        let result = format_bigint_timestamp_display(timestamp);
+        assert!(matches!(
+            result,
+            Err(FormatTimestampDisplayError::ParseIntError(err)) if err.kind() == &IntErrorKind::Empty
+        ));
 
-    let timestamp = "970676358".to_string();
-    let result = format_bigint_timestamp_display(timestamp.clone());
-    assert_eq!(result, Ok("2000-10-04 06:19:18 PM".to_string()));
+        let timestamp = "171502440000000000.0".to_string();
+        let result = format_bigint_timestamp_display(timestamp);
+        assert!(matches!(
+            result,
+            Err(FormatTimestampDisplayError::ParseIntError(err)) if err.kind() == &IntErrorKind::InvalidDigit
+        ));
 
-    let timestamp_i64 = timestamp.parse::<i64>().unwrap();
-    let result = format_timestamp_display(timestamp_i64);
-    assert_eq!(result, Ok("2000-10-04 06:19:18 PM".to_string()));
+        let timestamp = format!("{}", i128::from(i64::MAX) + 1);
+        let result = format_bigint_timestamp_display(timestamp);
+        assert!(matches!(
+            result,
+            Err(FormatTimestampDisplayError::ParseIntError(err)) if err.kind() == &IntErrorKind::PosOverflow
+        ));
 
-    // Test earliest valid timestamp (close to Unix epoch minimum)
-    // January 1, 1970 (plus some seconds to be safe)
-    let earliest_valid = "86400".to_string(); // 1 day after epoch
-    let result = format_bigint_timestamp_display(earliest_valid.clone());
-    assert!(result.is_ok());
+        let timestamp = format!("{}", i128::from(i64::MIN) - 1);
+        let result = format_bigint_timestamp_display(timestamp);
+        assert!(matches!(
+            result,
+            Err(FormatTimestampDisplayError::ParseIntError(err)) if err.kind() == &IntErrorKind::NegOverflow
+        ));
+    }
 
-    // Test latest reasonably valid timestamp
-    // December 31, 2099 (arbitrary future date that should be valid)
-    let future_valid = "4102444800".to_string();
-    let result = format_bigint_timestamp_display(future_valid.clone());
-    assert!(result.is_ok());
+    #[test]
+    fn test_format_bigint_timestamp_display_err_invalid_timestamp() {
+        // Test case for timestamp that would result in days < i32::MIN
+        let timestamp = format!("{}", i64::MIN);
+        let result = format_bigint_timestamp_display(timestamp);
+        assert!(matches!(
+            result,
+            Err(FormatTimestampDisplayError::InvalidTimestamp(t)) if t == i64::MIN
+        ));
+
+        // Test case for timestamp that would result in days > i32::MAX
+        // This is a timestamp that would be far in the future
+        let timestamp = format!("{}", i64::MAX);
+        let result = format_bigint_timestamp_display(timestamp);
+        assert!(matches!(
+            result,
+            Err(FormatTimestampDisplayError::InvalidTimestamp(t)) if t == i64::MAX
+        ));
+    }
+
+    #[test]
+    fn test_format_bigint_timestamp_display_ok() {
+        // Required to make local timezone deterministic
+        // NOTE: Setting TZ affects global state.
+        std::env::set_var("TZ", "CET");
+
+        let timestamp = "1746537612".to_string();
+        let result = format_bigint_timestamp_display(timestamp.clone());
+        assert_eq!(result, Ok("2025-05-06 03:20:12 PM".to_string()));
+
+        let timestamp_i64 = timestamp.parse::<i64>().unwrap();
+        let result = format_timestamp_display(timestamp_i64);
+        assert_eq!(result, Ok("2025-05-06 03:20:12 PM".to_string()));
+
+        // Required to make local timezone deterministic
+        // NOTE: Setting TZ affects global state.
+        std::env::set_var("TZ", "EST");
+
+        let timestamp = "970676358".to_string();
+        let result = format_bigint_timestamp_display(timestamp.clone());
+        assert_eq!(result, Ok("2000-10-04 06:19:18 PM".to_string()));
+
+        let timestamp_i64 = timestamp.parse::<i64>().unwrap();
+        let result = format_timestamp_display(timestamp_i64);
+        assert_eq!(result, Ok("2000-10-04 06:19:18 PM".to_string()));
+
+        // Test earliest valid timestamp (close to Unix epoch minimum)
+        // January 1, 1970 (plus some seconds to be safe)
+        let earliest_valid = "86400".to_string(); // 1 day after epoch
+        let result = format_bigint_timestamp_display(earliest_valid.clone());
+        assert!(result.is_ok());
+
+        // Test latest reasonably valid timestamp
+        // December 31, 2099 (arbitrary future date that should be valid)
+        let future_valid = "4102444800".to_string();
+        let result = format_bigint_timestamp_display(future_valid.clone());
+        assert!(result.is_ok());
+    }
 }


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

AI overwrote the tests module for [this issue](https://github.com/rainlanguage/rain.orderbook/issues/1622) in [this commit](https://github.com/rainlanguage/rain.orderbook/commit/2c4eabc2be6d7c90681097265913a96bf5bf1dcf). See [this PR](https://github.com/rainlanguage/rain.orderbook/pull/1741) for original review.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Bring back the tests module

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [X] made this PR as small as possible
- [X] unit-tested any new functionality
- [X] linked any relevant issues or PRs
- [X] included screenshots (if this involves a front-end change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved and expanded test coverage for timestamp formatting, including additional error cases and more granular test functions for better reliability and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->