### PR TITLE
Refactor awaitTransactionIndexing

### DIFF
--- a/packages/ui-components/src/__tests__/awaitTransactionIndexing.test.ts
+++ b/packages/ui-components/src/__tests__/awaitTransactionIndexing.test.ts
@@ -1,21 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import type {
-	SgAddOrderWithOrder,
-	SgRemoveOrderWithOrder,
-	SgTransaction
-} from '@rainlanguage/orderbook';
-import {
-	getTransaction,
-	getTransactionAddOrders,
-	getTransactionRemoveOrders
-} from '@rainlanguage/orderbook';
-import {
-	awaitSubgraphIndexing,
-	getNewOrderConfig,
-	getRemoveOrderConfig,
-	getTransactionConfig,
-	TIMEOUT_ERROR
-} from '$lib/services/awaitTransactionIndexing';
+import type { SgAddOrderWithOrder, SgTransaction } from '@rainlanguage/orderbook';
+import { awaitSubgraphIndexing, TIMEOUT_ERROR } from '$lib/services/awaitTransactionIndexing';
 
 vi.mock('@rainlanguage/orderbook', () => ({
 	getTransaction: vi.fn(),
@@ -37,16 +22,15 @@ describe('subgraphIndexing', () => {
 	});
 
 	it('should resolve with value when data is successfully fetched', async () => {
-		const mockData = { id: 'tx123' };
+		const mockData = { id: 'tx123' } as SgTransaction;
 		mockFetchData.mockResolvedValue({ value: mockData });
 
 		const resultPromise = awaitSubgraphIndexing({
 			subgraphUrl: 'https://test.subgraph.com',
 			txHash: 'tx123',
 			successMessage: 'Transaction confirmed',
-			fetchData: mockFetchData,
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			isSuccess: (data: any) => !!data.id
+			fetchEntityFn: mockFetchData,
+			isSuccess: (data: SgTransaction) => !!data.id
 		});
 
 		await vi.advanceTimersByTimeAsync(1000);
@@ -70,7 +54,7 @@ describe('subgraphIndexing', () => {
 					orderHash: 'order123'
 				}
 			}
-		];
+		] as SgAddOrderWithOrder[];
 
 		mockFetchData.mockResolvedValue({ value: mockOrderData });
 
@@ -79,10 +63,8 @@ describe('subgraphIndexing', () => {
 			txHash: 'tx123',
 			successMessage: 'Order confirmed',
 			network: 'mainnet',
-			fetchData: mockFetchData,
-
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			isSuccess: (data: any) => data.length > 0
+			fetchEntityFn: mockFetchData,
+			isSuccess: (data: SgAddOrderWithOrder[]) => data.length > 0
 		});
 
 		await vi.advanceTimersByTimeAsync(1000);
@@ -103,7 +85,7 @@ describe('subgraphIndexing', () => {
 			successMessage: 'Transaction confirmed',
 			maxAttempts: 5,
 			interval: 500,
-			fetchData: mockFetchData,
+			fetchEntityFn: mockFetchData,
 			isSuccess: () => false
 		});
 
@@ -128,7 +110,7 @@ describe('subgraphIndexing', () => {
 			successMessage: 'Transaction confirmed',
 			maxAttempts: 3,
 			interval: 500,
-			fetchData: mockFetchData,
+			fetchEntityFn: mockFetchData,
 			isSuccess: () => true
 		});
 
@@ -147,7 +129,7 @@ describe('subgraphIndexing', () => {
 	it('should resolve immediately when successful data is found', async () => {
 		mockFetchData
 			.mockResolvedValueOnce({ value: null })
-			.mockResolvedValueOnce({ value: { id: 'tx123' } });
+			.mockResolvedValueOnce({ value: { id: 'tx123' } as SgTransaction });
 
 		const resultPromise = awaitSubgraphIndexing({
 			subgraphUrl: 'https://test.subgraph.com',
@@ -155,9 +137,8 @@ describe('subgraphIndexing', () => {
 			successMessage: 'Transaction confirmed',
 			maxAttempts: 5,
 			interval: 500,
-			fetchData: mockFetchData,
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			isSuccess: (data: any) => !!data?.id
+			fetchEntityFn: mockFetchData,
+			isSuccess: (data: SgTransaction) => !!data?.id
 		});
 
 		await vi.advanceTimersByTimeAsync(500);
@@ -168,55 +149,5 @@ describe('subgraphIndexing', () => {
 		expect(result.value).toBeDefined();
 		expect(result.error).toBeUndefined();
 		expect(mockFetchData).toHaveBeenCalledTimes(2);
-	});
-});
-
-describe('helper functions', () => {
-	it('getTransactionConfig should return correct configuration', () => {
-		const config = getTransactionConfig(
-			'https://test.subgraph.com',
-			'tx123',
-			'Transaction confirmed',
-			'mainnet'
-		);
-
-		expect(config.subgraphUrl).toBe('https://test.subgraph.com');
-		expect(config.txHash).toBe('tx123');
-		expect(config.successMessage).toBe('Transaction confirmed');
-		expect(config.network).toBe('mainnet');
-		expect(config.fetchData).toBe(getTransaction);
-
-		expect(config.isSuccess({ id: 'tx123' } as SgTransaction)).toBe(true);
-		expect(config.isSuccess(null as unknown as SgTransaction)).toBe(false);
-	});
-
-	it('getNewOrderConfig should return correct configuration', () => {
-		const config = getNewOrderConfig(
-			'https://test.subgraph.com',
-			'tx123',
-			'Order added',
-			'testnet'
-		);
-
-		expect(config.subgraphUrl).toBe('https://test.subgraph.com');
-		expect(config.txHash).toBe('tx123');
-		expect(config.successMessage).toBe('Order added');
-		expect(config.network).toBe('testnet');
-		expect(config.fetchData).toBe(getTransactionAddOrders);
-
-		expect(config.isSuccess([{ order: { id: 'order1' } } as SgAddOrderWithOrder])).toBe(true);
-		expect(config.isSuccess([])).toBe(false);
-	});
-
-	it('getRemoveOrderConfig should return correct configuration', () => {
-		const config = getRemoveOrderConfig('https://test.subgraph.com', 'tx123', 'Order removed');
-
-		expect(config.subgraphUrl).toBe('https://test.subgraph.com');
-		expect(config.txHash).toBe('tx123');
-		expect(config.successMessage).toBe('Order removed');
-		expect(config.fetchData).toBe(getTransactionRemoveOrders);
-
-		expect(config.isSuccess([{ order: { id: 'order1' } } as SgRemoveOrderWithOrder])).toBe(true);
-		expect(config.isSuccess([])).toBe(false);
 	});
 });

--- a/packages/ui-components/src/__tests__/transactionStore.test.ts
+++ b/packages/ui-components/src/__tests__/transactionStore.test.ts
@@ -8,12 +8,7 @@ import { waitForTransactionReceipt, sendTransaction, switchChain, type Config } 
 import { getTransaction, type SgVault, type VaultCalldataResult } from '@rainlanguage/orderbook';
 import { getExplorerLink } from '../lib/services/getExplorerLink';
 
-import {
-	awaitSubgraphIndexing,
-	getTransactionConfig,
-	getNewOrderConfig,
-	TIMEOUT_ERROR
-} from '../lib/services/awaitTransactionIndexing';
+import { awaitSubgraphIndexing, TIMEOUT_ERROR } from '../lib/services/awaitTransactionIndexing';
 
 vi.mock('@wagmi/core', () => ({
 	waitForTransactionReceipt: vi.fn(),
@@ -160,20 +155,9 @@ describe('transactionStore', () => {
 			}
 		});
 
-		(getTransactionConfig as Mock).mockReturnValue({
-			subgraphUrl: mockSubgraphUrl,
-			txHash: mockTxHash,
-			successMessage: mockSuccessMessage
-		});
-
 		await awaitTransactionIndexing(mockSubgraphUrl, mockTxHash, mockSuccessMessage);
 
 		expect(awaitSubgraphIndexing).toHaveBeenCalled();
-		expect(getTransactionConfig).toHaveBeenCalledWith(
-			mockSubgraphUrl,
-			mockTxHash,
-			mockSuccessMessage
-		);
 
 		expect(get(transactionStore).status).toBe(TransactionStatus.SUCCESS);
 		expect(get(transactionStore).hash).toBe(mockTxHash);
@@ -187,12 +171,6 @@ describe('transactionStore', () => {
 
 		(awaitSubgraphIndexing as Mock).mockResolvedValue({
 			error: TIMEOUT_ERROR
-		});
-
-		(getTransactionConfig as Mock).mockReturnValue({
-			subgraphUrl: mockSubgraphUrl,
-			txHash: mockTxHash,
-			successMessage: mockSuccessMessage
 		});
 
 		await awaitTransactionIndexing(mockSubgraphUrl, mockTxHash, mockSuccessMessage);
@@ -216,18 +194,9 @@ describe('transactionStore', () => {
 			}
 		});
 
-		(getNewOrderConfig as Mock).mockReturnValue({
-			subgraphUrl: mockSubgraphUrl,
-			txHash: mockTxHash,
-			successMessage: '',
-			network: mockNetwork
-		});
-
 		await awaitNewOrderIndexing(mockSubgraphUrl, mockTxHash, mockNetwork);
 
 		expect(awaitSubgraphIndexing).toHaveBeenCalled();
-		expect(getNewOrderConfig).toHaveBeenCalledWith(mockSubgraphUrl, mockTxHash, '', mockNetwork);
-
 		expect(get(transactionStore).status).toBe(TransactionStatus.SUCCESS);
 		expect(get(transactionStore).hash).toBe(mockTxHash);
 		expect(get(transactionStore).newOrderHash).toBe(mockOrderHash);
@@ -241,13 +210,6 @@ describe('transactionStore', () => {
 
 		(awaitSubgraphIndexing as Mock).mockResolvedValue({
 			error: TIMEOUT_ERROR
-		});
-
-		(getNewOrderConfig as Mock).mockReturnValue({
-			subgraphUrl: mockSubgraphUrl,
-			txHash: mockTxHash,
-			successMessage: '',
-			network: mockNetwork
 		});
 
 		await awaitNewOrderIndexing(mockSubgraphUrl, mockTxHash, mockNetwork);

--- a/packages/ui-components/src/lib/stores/transactionStore.ts
+++ b/packages/ui-components/src/lib/stores/transactionStore.ts
@@ -2,21 +2,22 @@ import { writable } from 'svelte/store';
 import type { Hex } from 'viem';
 import type { Config } from '@wagmi/core';
 import { sendTransaction, switchChain, waitForTransactionReceipt } from '@wagmi/core';
-import type {
-	ApprovalCalldata,
-	RemoveOrderCalldata,
-	SgVault,
-	VaultCalldataResult
+import {
+	getTransaction,
+	getTransactionAddOrders,
+	getTransactionRemoveOrders,
+	type ApprovalCalldata,
+	type RemoveOrderCalldata,
+	type SgAddOrderWithOrder,
+	type SgRemoveOrderWithOrder,
+	type SgTransaction,
+	type SgVault,
+	type VaultCalldataResult
 } from '@rainlanguage/orderbook';
 
 import { getExplorerLink } from '../services/getExplorerLink';
 import type { DeploymentArgs } from '$lib/types/transaction';
-import {
-	awaitSubgraphIndexing,
-	getNewOrderConfig,
-	getRemoveOrderConfig,
-	getTransactionConfig
-} from '$lib/services/awaitTransactionIndexing';
+import { awaitSubgraphIndexing } from '$lib/services/awaitTransactionIndexing';
 
 export const ADDRESS_ZERO = '0x0000000000000000000000000000000000000000';
 export const ONE = BigInt('1000000000000000000');
@@ -126,9 +127,13 @@ const transactionStore = () => {
 			message: 'Waiting for transaction to be indexed...'
 		}));
 
-		const result = await awaitSubgraphIndexing(
-			getTransactionConfig(subgraphUrl, txHash, successMessage)
-		);
+		const result = await awaitSubgraphIndexing({
+			subgraphUrl,
+			txHash,
+			successMessage,
+			fetchEntityFn: getTransaction,
+			isSuccess: (data: SgTransaction) => !!data
+		});
 
 		if (result.error) {
 			return transactionError(TransactionErrorMessage.TIMEOUT);
@@ -146,7 +151,14 @@ const transactionStore = () => {
 			message: 'Waiting for new order to be indexed...'
 		}));
 
-		const result = await awaitSubgraphIndexing(getNewOrderConfig(subgraphUrl, txHash, '', network));
+		const result = await awaitSubgraphIndexing({
+			subgraphUrl,
+			txHash,
+			successMessage: '',
+			network,
+			fetchEntityFn: getTransactionAddOrders,
+			isSuccess: (data: SgAddOrderWithOrder[]) => data?.length > 0
+		});
 
 		if (result.error) {
 			return transactionError(TransactionErrorMessage.TIMEOUT);
@@ -169,9 +181,13 @@ const transactionStore = () => {
 			message: 'Waiting for order removal to be indexed...'
 		}));
 
-		const result = await awaitSubgraphIndexing(
-			getRemoveOrderConfig(subgraphUrl, txHash, 'Order removed successfully')
-		);
+		const result = await awaitSubgraphIndexing({
+			subgraphUrl,
+			txHash,
+			successMessage: 'Order removed successfully',
+			fetchEntityFn: getTransactionRemoveOrders,
+			isSuccess: (data: SgRemoveOrderWithOrder[]) => data?.length > 0
+		});
 
 		if (result.error) {
 			return transactionError(TransactionErrorMessage.TIMEOUT);


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

The config getter is overcomplicated, and should be moved into args for the await function passed from the tranasactionStore.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Closes #1829 
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)
