### PR TITLE
handleRainlangExtension in tauri-app /add route

### DIFF
--- a/tauri-app/src/lib/__tests__/handleRainlangExtension.test.ts
+++ b/tauri-app/src/lib/__tests__/handleRainlangExtension.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi, type Mock } from 'vitest';
+import { createRainlangExtension } from '../services/handleRainlangExtension';
+import { RawRainlangExtension } from 'codemirror-rainlang';
+
+vi.mock('codemirror-rainlang', () => ({
+  RawRainlangExtension: vi.fn(),
+}));
+
+vi.mock('@rainlanguage/ui-components', async () => {
+  const actual = await vi.importActual("@rainlanguage/ui-components");
+  return {
+    ...actual,
+    promiseTimeout: vi.fn().mockResolvedValue([])
+  };
+});
+
+describe('createRainlangExtension', () => {
+  it('should create a RawRainlangExtension instance', () => {
+    createRainlangExtension({}, undefined);
+    expect(RawRainlangExtension as Mock).toHaveBeenCalled();
+  });
+}); 

--- a/tauri-app/src/lib/services/handleRainlangExtension.ts
+++ b/tauri-app/src/lib/services/handleRainlangExtension.ts
@@ -1,0 +1,46 @@
+import { RawRainlangExtension, type Problem } from 'codemirror-rainlang';
+import { promiseTimeout } from '@rainlanguage/ui-components';
+import { problemsCallback } from '$lib/services/langServices';
+import { mergeDotrainConfigWithSettingsProblems } from '$lib/services/configCodemirrorProblems';
+import type { ScenarioCfg } from '@rainlanguage/orderbook';
+
+export function createRainlangExtension(
+  bindings: Record<string, string>,
+  deploymentScenario: ScenarioCfg | undefined,
+) {
+  return new RawRainlangExtension({
+    diagnostics: async (text) => {
+      let configProblems: Problem[] = [];
+      let problems: Problem[] = [];
+      try {
+        // get problems with merging settings config with frontmatter
+        configProblems = await mergeDotrainConfigWithSettingsProblems(text.text);
+      } catch (e) {
+        configProblems = [
+          {
+            msg: e as string,
+            position: [0, 0],
+            code: 9,
+          },
+        ];
+      }
+      try {
+        // get problems with dotrain
+        problems = await promiseTimeout(
+          problemsCallback(text, bindings, deploymentScenario?.deployer.address),
+          5000,
+          'failed to parse on native parser',
+        );
+      } catch (e) {
+        problems = [
+          {
+            msg: e as string,
+            position: [0, 0],
+            code: 9,
+          },
+        ];
+      }
+      return [...configProblems, ...problems];
+    },
+  });
+} 


### PR DESCRIPTION
Move construction of RawRainlangExtension from tauri app /add route +page.svelte into seperate files.

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)
