### PR TITLE
Refactor OrderbookYaml class constructor

### DIFF
--- a/crates/js_api/src/yaml/mod.rs
+++ b/crates/js_api/src/yaml/mod.rs
@@ -14,11 +14,6 @@ use wasm_bindgen_utils::prelude::*;
 pub struct OrderbookYaml {
     yaml: OrderbookYamlCfg,
 }
-impl PartialEq for OrderbookYaml {
-    fn eq(&self, other: &Self) -> bool {
-        std::ptr::eq(&self.yaml, &other.yaml)
-    }
-}
 
 #[wasm_export]
 impl OrderbookYaml {
@@ -205,17 +200,6 @@ mod tests {
                     .to_readable_msg()
                     .contains("There was an error processing the YAML configuration"));
             }
-        }
-    }
-
-    #[wasm_bindgen_test]
-    fn test_orderbook_yaml_invalid_with_validation_disabled() {
-        let result = OrderbookYaml::new(vec![get_invalid_yaml()], Some(false));
-        if let Err(err) = result {
-            assert!(err.to_string().contains("Orderbook yaml error"));
-            assert!(err
-                .to_readable_msg()
-                .contains("There was an error processing the YAML configuration"));
         }
     }
 }

--- a/packages/orderbook/test/js_api/orderbookYaml.test.ts
+++ b/packages/orderbook/test/js_api/orderbookYaml.test.ts
@@ -164,12 +164,10 @@ orderbooks:
 		});
 
 		it('should succeed construction but fail usage with invalid YAML when validation is disabled', async function () {
-			const result = OrderbookYaml.new([INVALID_YAML], false);
-			if (result.error) expect.fail(`Construction should succeed when validation is disabled, actual error: ${result.error.msg}`);
-			
-			// However, using the OrderbookYaml should still fail due to missing references
-			const orderbookYaml = extractWasmEncodedData<OrderbookYaml>(result);
-			const orderbookResult = orderbookYaml.getOrderbookByAddress('0xc95A5f8eFe14d7a20BD2E5BAFEC4E71f8Ce0B9A6');
+			const orderbookYaml = buildYaml(INVALID_YAML, false);
+			const orderbookResult = orderbookYaml.getOrderbookByAddress(
+				'0xc95A5f8eFe14d7a20BD2E5BAFEC4E71f8Ce0B9A6'
+			);
 			if (!orderbookResult.error) expect.fail('Expected error when using invalid YAML');
 			expect(orderbookResult.error.msg).toContain('Orderbook yaml error');
 		});

--- a/packages/orderbook/test/js_api/orderbookYaml.test.ts
+++ b/packages/orderbook/test/js_api/orderbookYaml.test.ts
@@ -85,13 +85,15 @@ const extractWasmEncodedData = <T>(result: WasmEncodedResult<T>, errorMessage?: 
 
 describe('Rain Orderbook JS API Package Bindgen Tests - Settings', async function () {
 	it('should create a new settings object', async function () {
-		const orderbookYaml = new OrderbookYaml([YAML_WITHOUT_ORDERBOOK]);
+		const orderbookYamlResult = OrderbookYaml.new([YAML_WITHOUT_ORDERBOOK]);
+		const orderbookYaml = extractWasmEncodedData<OrderbookYaml>(orderbookYamlResult);
 		assert.ok(orderbookYaml);
 	});
 
 	describe('orderbook tests', async function () {
 		it('should get the orderbook', async function () {
-			const orderbookYaml = new OrderbookYaml([YAML_WITHOUT_ORDERBOOK]);
+			const orderbookYamlResult = OrderbookYaml.new([YAML_WITHOUT_ORDERBOOK]);
+			const orderbookYaml = extractWasmEncodedData<OrderbookYaml>(orderbookYamlResult);
 
 			const orderbook = extractWasmEncodedData<OrderbookCfg>(
 				orderbookYaml.getOrderbookByAddress('0xc95A5f8eFe14d7a20BD2E5BAFEC4E71f8Ce0B9A6')
@@ -115,6 +117,63 @@ describe('Rain Orderbook JS API Package Bindgen Tests - Settings', async functio
 			expect(result.error.readableMsg).toBe(
 				'There was an error processing the YAML configuration. Please check the YAML file for any issues. Error: "Key \'0x0000000000000000000000000000000000000000\' not found"'
 			);
+		});
+	});
+
+	describe('validation tests', async function () {
+		const INVALID_YAML = `
+networks:
+    some-network:
+        rpc: http://localhost:8085/rpc-url
+        chain-id: 123
+        network-id: 123
+        currency: ETH
+
+orderbooks:
+    some-orderbook:
+        address: 0xc95A5f8eFe14d7a20BD2E5BAFEC4E71f8Ce0B9A6
+        network: nonexistent-network
+        subgraph: nonexistent-subgraph
+`;
+
+		it('should succeed with valid YAML and validation enabled', async function () {
+			const result = OrderbookYaml.new([YAML_WITHOUT_ORDERBOOK], true);
+			const orderbookYaml = extractWasmEncodedData<OrderbookYaml>(result);
+			assert.ok(orderbookYaml);
+		});
+
+		it('should succeed with valid YAML and validation disabled', async function () {
+			const result = OrderbookYaml.new([YAML_WITHOUT_ORDERBOOK], false);
+			const orderbookYaml = extractWasmEncodedData<OrderbookYaml>(result);
+			assert.ok(orderbookYaml);
+		});
+
+		it('should succeed with valid YAML and default validation', async function () {
+			const result = OrderbookYaml.new([YAML_WITHOUT_ORDERBOOK]);
+			const orderbookYaml = extractWasmEncodedData<OrderbookYaml>(result);
+			assert.ok(orderbookYaml);
+		});
+
+		it('should fail with invalid YAML and validation enabled', async function () {
+			const result = OrderbookYaml.new([INVALID_YAML], true);
+			if (!result.error) expect.fail('Expected validation error with invalid YAML');
+			expect(result.error.msg).toContain('Orderbook yaml error');
+			expect(result.error.readableMsg).toContain(
+				'There was an error processing the YAML configuration'
+			);
+		});
+
+		it('should test behavior with invalid YAML and validation disabled', async function () {
+			const result = OrderbookYaml.new([INVALID_YAML], false);
+			if (result.error) {
+				expect(result.error.msg).toContain('Orderbook yaml error');
+				expect(result.error.readableMsg).toContain(
+					'There was an error processing the YAML configuration'
+				);
+			} else {
+				const orderbookYaml = extractWasmEncodedData<OrderbookYaml>(result);
+				assert.ok(orderbookYaml);
+			}
 		});
 	});
 });


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

See issue: https://github.com/rainlanguage/rain.orderbook/issues/1856

Our sdk classes can now return an instance using a constructor. `OrderbookYaml` was missing this and this PR adds that support

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)

fix https://github.com/rainlanguage/rain.orderbook/issues/1856
fix https://github.com/rainlanguage/rain.orderbook/issues/1853

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Added the ability to enable or disable YAML validation when creating an orderbook configuration.
- **Bug Fixes**
	- Improved error handling for invalid YAML inputs, providing clearer error messages during validation.
- **Tests**
	- Expanded test coverage to include scenarios with invalid YAML and different validation settings.
	- Updated existing tests to reflect changes in the orderbook configuration creation process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->