### PR TITLE
Add validation support for field values and deposits in gui sdk

### DIFF
--- a/crates/js_api/src/gui/deposits.rs
+++ b/crates/js_api/src/gui/deposits.rs
@@ -121,7 +121,7 @@ impl DotrainOrderGui {
     ///
     /// ```javascript
     /// // Save a custom deposit amount
-    /// const result = gui.saveDeposit("usdc", "1000.50");
+    /// const result = await gui.saveDeposit("usdc", "1000.50");
     /// if (result.error) {
     ///   console.error("Deposit error:", result.error.readableMsg);
     ///   return;

--- a/crates/js_api/src/gui/field_values.rs
+++ b/crates/js_api/src/gui/field_values.rs
@@ -77,6 +77,10 @@ impl DotrainOrderGui {
     ) -> Result<(), GuiError> {
         let field_definition = self.get_field_definition(&binding)?;
 
+        if let Some(validation) = &field_definition.validation {
+            validation::validate_field_value(&field_definition.name, &value, validation)?;
+        }
+
         let value = match field_definition.presets.as_ref() {
             Some(presets) => match presets.iter().position(|p| p.value == value) {
                 Some(index) => field_values::PairValue {
@@ -469,6 +473,7 @@ mod tests {
             ])),
             default: Some(String::from("some-default-value")),
             show_custom_field: None,
+            validation: None,
         }
     }
 
@@ -496,6 +501,7 @@ mod tests {
             ])),
             default: None,
             show_custom_field: Some(true),
+            validation: None,
         }
     }
 

--- a/crates/js_api/src/gui/field_values.rs
+++ b/crates/js_api/src/gui/field_values.rs
@@ -400,7 +400,9 @@ impl DotrainOrderGui {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::gui::tests::initialize_gui;
+    use crate::gui::tests::{initialize_gui, initialize_validation_gui};
+    use crate::gui::validation;
+    use rain_orderbook_app_settings::spec_version::SpecVersion;
     use wasm_bindgen_test::wasm_bindgen_test;
 
     #[wasm_bindgen_test]
@@ -591,5 +593,472 @@ mod tests {
             .unwrap();
         let res = gui.check_field_values();
         assert!(res.is_ok());
+    }
+
+    #[wasm_bindgen_test]
+    async fn test_save_field_value_number_minimum_maximum() {
+        let mut gui = initialize_validation_gui().await;
+
+        let result = gui.save_field_value("price-field".to_string(), "50.00".to_string());
+        assert!(result.is_ok());
+
+        let result = gui.save_field_value("price-field".to_string(), "5.00".to_string());
+        match result {
+            Err(GuiError::ValidationError(validation::GuiValidationError::BelowMinimum {
+                name,
+                value,
+                minimum,
+            })) => {
+                assert_eq!(name, "Price Field");
+                assert_eq!(value, "5.00");
+                assert_eq!(minimum, "10");
+            }
+            _ => panic!("Expected BelowMinimum error"),
+        }
+
+        let result = gui.save_field_value("price-field".to_string(), "1500.00".to_string());
+        match result {
+            Err(GuiError::ValidationError(validation::GuiValidationError::AboveMaximum {
+                name,
+                value,
+                maximum,
+            })) => {
+                assert_eq!(name, "Price Field");
+                assert_eq!(value, "1500.00");
+                assert_eq!(maximum, "1000");
+            }
+            _ => panic!("Expected AboveMaximum error"),
+        }
+
+        let result = gui.save_field_value("price-field".to_string(), "10".to_string());
+        assert!(result.is_ok());
+
+        let result = gui.save_field_value("price-field".to_string(), "1000".to_string());
+        assert!(result.is_ok());
+    }
+
+    #[wasm_bindgen_test]
+    async fn test_save_field_value_number_multiple_of() {
+        let mut gui = initialize_validation_gui().await;
+
+        let result = gui.save_field_value("price-field".to_string(), "99.99".to_string());
+        assert!(result.is_ok());
+
+        let result = gui.save_field_value("price-field".to_string(), "99.999".to_string());
+        match result {
+            Err(GuiError::ValidationError(validation::GuiValidationError::NotMultipleOf {
+                name,
+                value,
+                multiple_of,
+            })) => {
+                assert_eq!(name, "Price Field");
+                assert_eq!(value, "99.999");
+                assert_eq!(multiple_of, "0.01");
+            }
+            _ => panic!("Expected NotMultipleOf error"),
+        }
+    }
+
+    #[wasm_bindgen_test]
+    async fn test_save_field_value_number_exclusive_bounds() {
+        let mut gui = initialize_validation_gui().await;
+
+        let result = gui.save_field_value("quantity-field".to_string(), "0".to_string());
+        match result {
+            Err(GuiError::ValidationError(
+                validation::GuiValidationError::BelowExclusiveMinimum {
+                    name,
+                    value,
+                    exclusive_minimum,
+                },
+            )) => {
+                assert_eq!(name, "Quantity Field");
+                assert_eq!(value, "0");
+                assert_eq!(exclusive_minimum, "0");
+            }
+            _ => panic!("Expected BelowExclusiveMinimum error"),
+        }
+
+        let result = gui.save_field_value("quantity-field".to_string(), "0.001".to_string());
+        assert!(result.is_ok());
+
+        let result = gui.save_field_value("quantity-field".to_string(), "100000".to_string());
+        match result {
+            Err(GuiError::ValidationError(
+                validation::GuiValidationError::AboveExclusiveMaximum {
+                    name,
+                    value,
+                    exclusive_maximum,
+                },
+            )) => {
+                assert_eq!(name, "Quantity Field");
+                assert_eq!(value, "100000");
+                assert_eq!(exclusive_maximum, "100000");
+            }
+            _ => panic!("Expected AboveExclusiveMaximum error"),
+        }
+
+        let result = gui.save_field_value("quantity-field".to_string(), "99999.999".to_string());
+        assert!(result.is_ok());
+    }
+
+    #[wasm_bindgen_test]
+    async fn test_save_field_value_number_complex_constraints() {
+        let mut gui = initialize_validation_gui().await;
+
+        let result = gui.save_field_value("percentage-field".to_string(), "50.5".to_string());
+        assert!(result.is_ok());
+
+        let result = gui.save_field_value("percentage-field".to_string(), "50.55".to_string());
+        assert!(matches!(
+            result,
+            Err(GuiError::ValidationError(
+                validation::GuiValidationError::NotMultipleOf { .. }
+            ))
+        ));
+
+        let result = gui.save_field_value("percentage-field".to_string(), "0".to_string());
+        assert!(result.is_ok());
+
+        let result = gui.save_field_value("percentage-field".to_string(), "100".to_string());
+        assert!(result.is_ok());
+    }
+
+    #[wasm_bindgen_test]
+    async fn test_save_field_value_number_invalid_formats() {
+        let mut gui = initialize_validation_gui().await;
+
+        let result = gui.save_field_value("simple-number".to_string(), "".to_string());
+        match result {
+            Err(GuiError::ValidationError(validation::GuiValidationError::InvalidNumber {
+                name,
+                value,
+            })) => {
+                assert_eq!(name, "Simple Number");
+                assert_eq!(value, "");
+            }
+            _ => panic!("Expected InvalidNumber error"),
+        }
+
+        let result = gui.save_field_value("simple-number".to_string(), "abc".to_string());
+        assert!(matches!(
+            result,
+            Err(GuiError::ValidationError(
+                validation::GuiValidationError::InvalidNumber { .. }
+            ))
+        ));
+
+        let result = gui.save_field_value("simple-number".to_string(), "12.34.56".to_string());
+        assert!(matches!(
+            result,
+            Err(GuiError::ValidationError(
+                validation::GuiValidationError::InvalidNumber { .. }
+            ))
+        ));
+
+        let result = gui.save_field_value("simple-number".to_string(), "1e10".to_string());
+        assert!(matches!(
+            result,
+            Err(GuiError::ValidationError(
+                validation::GuiValidationError::InvalidNumber { .. }
+            ))
+        ));
+
+        let result = gui.save_field_value("simple-number".to_string(), "١٢٣".to_string());
+        assert!(matches!(
+            result,
+            Err(GuiError::ValidationError(
+                validation::GuiValidationError::InvalidNumber { .. }
+            ))
+        ));
+    }
+
+    #[wasm_bindgen_test]
+    async fn test_save_field_value_string_length_constraints() {
+        let mut gui = initialize_validation_gui().await;
+
+        let result = gui.save_field_value("username-field".to_string(), "john_doe".to_string());
+        assert!(result.is_ok());
+
+        let result = gui.save_field_value("username-field".to_string(), "jo".to_string());
+        match result {
+            Err(GuiError::ValidationError(validation::GuiValidationError::StringTooShort {
+                name,
+                length,
+                minimum,
+            })) => {
+                assert_eq!(name, "Username");
+                assert_eq!(length, 2);
+                assert_eq!(minimum, 3);
+            }
+            _ => panic!("Expected StringTooShort error"),
+        }
+
+        let result = gui.save_field_value(
+            "username-field".to_string(),
+            "this_username_is_way_too_long".to_string(),
+        );
+        match result {
+            Err(GuiError::ValidationError(validation::GuiValidationError::StringTooLong {
+                name,
+                length,
+                maximum,
+            })) => {
+                assert_eq!(name, "Username");
+                assert_eq!(length, 29);
+                assert_eq!(maximum, 20);
+            }
+            _ => panic!("Expected StringTooLong error"),
+        }
+
+        let result = gui.save_field_value("username-field".to_string(), "abc".to_string());
+        assert!(result.is_ok());
+
+        let result = gui.save_field_value("username-field".to_string(), "a".repeat(20));
+        assert!(result.is_ok());
+    }
+
+    #[wasm_bindgen_test]
+    async fn test_save_field_value_string_edge_cases() {
+        let mut gui = initialize_validation_gui().await;
+
+        let result = gui.save_field_value("description-field".to_string(), "".to_string());
+        assert!(result.is_ok());
+
+        let result = gui.save_field_value("code-field".to_string(), "".to_string());
+        assert!(matches!(
+            result,
+            Err(GuiError::ValidationError(
+                validation::GuiValidationError::StringTooShort { .. }
+            ))
+        ));
+
+        let result = gui.save_field_value("description-field".to_string(), "a".repeat(500));
+        assert!(result.is_ok());
+
+        let result = gui.save_field_value("description-field".to_string(), "a".repeat(501));
+        assert!(matches!(
+            result,
+            Err(GuiError::ValidationError(
+                validation::GuiValidationError::StringTooLong { .. }
+            ))
+        ));
+
+        let result =
+            gui.save_field_value("username-field".to_string(), "🦀🦀🦀rust🦀🦀🦀".to_string());
+        assert!(matches!(
+            result,
+            Err(GuiError::ValidationError(
+                validation::GuiValidationError::StringTooLong { .. }
+            ))
+        ));
+
+        let result = gui.save_field_value(
+            "any-string".to_string(),
+            "Any value at all!@#$%^&*()".to_string(),
+        );
+        assert!(result.is_ok());
+    }
+
+    #[wasm_bindgen_test]
+    async fn test_save_field_value_boolean() {
+        let mut gui = initialize_validation_gui().await;
+
+        let result = gui.save_field_value("enabled-field".to_string(), "1".to_string());
+        assert!(result.is_ok());
+
+        let result = gui.save_field_value("enabled-field".to_string(), "0".to_string());
+        assert!(result.is_ok());
+
+        let test_cases = vec![
+            "True", "FALSE", "yes", "no", "true", "false", "on", "off", "", " true", "true ",
+        ];
+
+        for test_value in test_cases {
+            let result = gui.save_field_value("enabled-field".to_string(), test_value.to_string());
+            match result {
+                Err(GuiError::ValidationError(
+                    validation::GuiValidationError::InvalidBoolean { name, value },
+                )) => {
+                    assert_eq!(name, "Enabled");
+                    assert_eq!(value, test_value);
+                }
+                _ => panic!("Expected InvalidBoolean error for value: {}", test_value),
+            }
+        }
+    }
+
+    #[wasm_bindgen_test]
+    async fn test_save_field_value_preset_with_validation() {
+        let mut gui = initialize_validation_gui().await;
+
+        let result = gui.save_field_value("preset-number-field".to_string(), "100".to_string());
+        assert!(result.is_ok());
+        let field_value = gui
+            .get_field_value("preset-number-field".to_string())
+            .unwrap();
+        assert!(field_value.is_preset);
+        assert_eq!(field_value.value, "100");
+
+        let result = gui.save_field_value("preset-number-field".to_string(), "120".to_string());
+        assert!(result.is_ok());
+        let field_value = gui
+            .get_field_value("preset-number-field".to_string())
+            .unwrap();
+        assert!(!field_value.is_preset);
+        assert_eq!(field_value.value, "120");
+
+        let result = gui.save_field_value("preset-number-field".to_string(), "125".to_string());
+        assert!(matches!(
+            result,
+            Err(GuiError::ValidationError(
+                validation::GuiValidationError::NotMultipleOf { .. }
+            ))
+        ));
+
+        let result = gui.save_field_value("preset-number-field".to_string(), "5".to_string());
+        assert!(matches!(
+            result,
+            Err(GuiError::ValidationError(
+                validation::GuiValidationError::BelowMinimum { .. }
+            ))
+        ));
+    }
+
+    #[wasm_bindgen_test]
+    async fn test_save_field_value_string_preset_with_validation() {
+        let mut gui = initialize_validation_gui().await;
+
+        let result = gui.save_field_value("preset-string-field".to_string(), "alpha".to_string());
+        assert!(result.is_ok());
+        let field_value = gui
+            .get_field_value("preset-string-field".to_string())
+            .unwrap();
+        assert!(field_value.is_preset);
+
+        let result = gui.save_field_value("preset-string-field".to_string(), "custom".to_string());
+        assert!(result.is_ok());
+        let field_value = gui
+            .get_field_value("preset-string-field".to_string())
+            .unwrap();
+        assert!(!field_value.is_preset);
+
+        let result = gui.save_field_value("preset-string-field".to_string(), "xyz".to_string());
+        assert!(matches!(
+            result,
+            Err(GuiError::ValidationError(
+                validation::GuiValidationError::StringTooShort { .. }
+            ))
+        ));
+
+        let result = gui.save_field_value(
+            "preset-string-field".to_string(),
+            "verylongvalue".to_string(),
+        );
+        assert!(matches!(
+            result,
+            Err(GuiError::ValidationError(
+                validation::GuiValidationError::StringTooLong { .. }
+            ))
+        ));
+    }
+
+    #[wasm_bindgen_test]
+    async fn test_save_field_value_no_validation() {
+        let mut gui = initialize_validation_gui().await;
+
+        let test_values = vec![
+            "123",
+            "abc",
+            "true",
+            "false",
+            "",
+            "!@#$%^&*()",
+            "very long string with many characters",
+            "0",
+            "🦀 Rust 🦀",
+        ];
+
+        for value in test_values {
+            let result = gui.save_field_value("no-validation-field".to_string(), value.to_string());
+            assert!(result.is_ok(), "Failed to save value: {}", value);
+
+            let field_value = gui
+                .get_field_value("no-validation-field".to_string())
+                .unwrap();
+            assert_eq!(field_value.value, value);
+        }
+    }
+
+    #[wasm_bindgen_test]
+    async fn test_save_field_values_batch_with_validation() {
+        let mut gui = initialize_validation_gui().await;
+
+        let valid_batch = vec![
+            FieldValuePair {
+                binding: "price-field".to_string(),
+                value: "100.00".to_string(),
+            },
+            FieldValuePair {
+                binding: "username-field".to_string(),
+                value: "valid_user".to_string(),
+            },
+            FieldValuePair {
+                binding: "enabled-field".to_string(),
+                value: "1".to_string(),
+            },
+        ];
+
+        let result = gui.save_field_values(valid_batch);
+        assert!(result.is_ok());
+
+        let invalid_batch = vec![
+            FieldValuePair {
+                binding: "price-field".to_string(),
+                value: "100.00".to_string(),
+            },
+            FieldValuePair {
+                binding: "username-field".to_string(),
+                value: "ab".to_string(), // Too short
+            },
+            FieldValuePair {
+                binding: "enabled-field".to_string(),
+                value: "true".to_string(),
+            },
+        ];
+
+        let result = gui.save_field_values(invalid_batch);
+        assert!(matches!(
+            result,
+            Err(GuiError::ValidationError(
+                validation::GuiValidationError::StringTooShort { .. }
+            ))
+        ));
+
+        let field_result = gui.get_field_value("price-field".to_string());
+        assert!(field_result.is_ok());
+    }
+
+    #[wasm_bindgen_test]
+    async fn test_very_precise_decimal_validation() {
+        let mut gui = initialize_validation_gui().await;
+
+        let result = gui.save_field_value(
+            "simple-number".to_string(),
+            "0.123456789012345678".to_string(),
+        );
+        assert!(result.is_ok());
+
+        let result = gui.save_field_value("price-field".to_string(), "999.99".to_string());
+        assert!(result.is_ok());
+
+        let result =
+            gui.save_field_value("price-field".to_string(), "100.00000000000001".to_string());
+        assert!(matches!(
+            result,
+            Err(GuiError::ValidationError(
+                validation::GuiValidationError::NotMultipleOf { .. }
+            ))
+        ));
     }
 }

--- a/crates/js_api/src/gui/mod.rs
+++ b/crates/js_api/src/gui/mod.rs
@@ -28,6 +28,7 @@ mod field_values;
 mod order_operations;
 mod select_tokens;
 mod state_management;
+mod validation;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Tsify)]
 pub struct TokenInfo {
@@ -673,6 +674,8 @@ pub enum GuiError {
     SerdeWasmBindgenError(#[from] serde_wasm_bindgen::Error),
     #[error(transparent)]
     YamlError(#[from] YamlError),
+    #[error(transparent)]
+    ValidationError(#[from] validation::GuiValidationError),
 }
 
 impl GuiError {
@@ -751,6 +754,7 @@ impl GuiError {
             GuiError::SerdeWasmBindgenError(err) =>
                 format!("Data serialization error: {}", err),
             GuiError::YamlError(err) => format!("YAML configuration error: {}", err),
+            GuiError::ValidationError(err) => format!("Validation error: {}", err),
         }
     }
 }

--- a/crates/js_api/src/gui/mod.rs
+++ b/crates/js_api/src/gui/mod.rs
@@ -1081,7 +1081,36 @@ gui:
           description: Field without any validation
           
       deposits:
+        # Deposit with minimum amount validation
         - token: token1
+          validation:
+            minimum: "100"
+        
+        # Deposit with maximum amount validation
+        - token: token2
+          validation:
+            maximum: "10000"
+        
+        # Deposit with exclusive bounds
+        - token: token3
+          validation:
+            exclusive-minimum: "0"
+            exclusive-maximum: "50000"
+        
+        # Deposit with all constraints
+        - token: token4
+          validation:
+            minimum: "10"
+            maximum: "1000"
+            multiple-of: "5"
+        
+        # Deposit with multiple-of constraint only
+        - token: token5
+          validation:
+            multiple-of: "0.1"
+        
+        # Deposit without validation
+        - token: token6
 networks:
     test-network:
         rpcs:
@@ -1107,6 +1136,36 @@ tokens:
         decimals: 6
         label: Token 1
         symbol: T1
+    token2:
+        network: test-network
+        address: 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48
+        decimals: 6
+        label: Token 2
+        symbol: T2
+    token3:
+        network: test-network
+        address: 0xdAC17F958D2ee523a2206206994597C13D831ec7
+        decimals: 6
+        label: Token 3
+        symbol: T3
+    token4:
+        network: test-network
+        address: 0x6B175474E89094C44Da98b954EedeAC495271d0F
+        decimals: 18
+        label: Token 4
+        symbol: T4
+    token5:
+        network: test-network
+        address: 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984
+        decimals: 18
+        label: Token 5
+        symbol: T5
+    token6:
+        network: test-network
+        address: 0x2b591e99afE9f32eAA6214f7B7629768c40Eeb39
+        decimals: 8
+        label: Token 6
+        symbol: T6
 scenarios:
     test-scenario:
         deployer: test-deployer

--- a/crates/js_api/src/gui/mod.rs
+++ b/crates/js_api/src/gui/mod.rs
@@ -961,6 +961,184 @@ _ _: 0 0;
         )
     }
 
+    pub fn get_yaml_with_validation() -> String {
+        format!(
+            r#"
+version: {spec_version}
+gui:
+  name: Validation Test
+  description: Test deployment with various validation rules
+  deployments:
+    validation-deployment:
+      name: Validation Test Deployment
+      description: Testing all validation scenarios
+      fields:
+        # Number validation tests
+        - binding: price-field
+          name: Price Field
+          description: Field with number validation
+          validation:
+            type: number
+            minimum: "10"
+            maximum: "1000"
+            multiple-of: "0.01"
+        
+        - binding: quantity-field
+          name: Quantity Field
+          description: Field with exclusive bounds
+          validation:
+            type: number
+            exclusive-minimum: "0"
+            exclusive-maximum: "100000"
+        
+        - binding: percentage-field
+          name: Percentage Field
+          description: Field with all number constraints
+          validation:
+            type: number
+            minimum: "0"
+            maximum: "100"
+            exclusive-maximum: "101"
+            multiple-of: "0.1"
+        
+        - binding: simple-number
+          name: Simple Number
+          description: Number field with no constraints
+          validation:
+            type: number
+        
+        # String validation tests
+        - binding: username-field
+          name: Username
+          description: Field with string length validation
+          validation:
+            type: string
+            min-length: 3
+            max-length: 20
+        
+        - binding: description-field
+          name: Description
+          description: Field with only max length
+          validation:
+            type: string
+            max-length: 500
+        
+        - binding: code-field
+          name: Code
+          description: Field with only min length
+          validation:
+            type: string
+            min-length: 5
+        
+        - binding: any-string
+          name: Any String
+          description: String field with no constraints
+          validation:
+            type: string
+        
+        # Boolean validation test
+        - binding: enabled-field
+          name: Enabled
+          description: Boolean field
+          validation:
+            type: boolean
+        
+        # Fields with presets and validation
+        - binding: preset-number-field
+          name: Preset Number
+          description: Number field with presets and validation
+          presets:
+            - name: "Low"
+              value: "50"
+            - name: "Medium"
+              value: "100"
+            - name: "High"
+              value: "150"
+          validation:
+            type: number
+            minimum: "10"
+            maximum: "200"
+            multiple-of: "10"
+        
+        - binding: preset-string-field
+          name: Preset String
+          description: String field with presets and validation
+          presets:
+            - name: "Option A"
+              value: "alpha"
+            - name: "Option B"
+              value: "beta"
+            - name: "Option C"
+              value: "gamma"
+          validation:
+            type: string
+            min-length: 4
+            max-length: 10
+        
+        # Field without validation
+        - binding: no-validation-field
+          name: No Validation
+          description: Field without any validation
+          
+      deposits:
+        - token: token1
+networks:
+    test-network:
+        rpcs:
+            - http://localhost:8085
+        chain-id: 1
+        network-id: 1
+        currency: ETH
+subgraphs:
+    test-sg: https://test.subgraph.com
+deployers:
+    test-deployer:
+        network: test-network
+        address: 0xF14E09601A47552De6aBd3A0B165607FaFd2B5Ba
+orderbooks:
+    test-orderbook:
+        address: 0xc95A5f8eFe14d7a20BD2E5BAFEC4E71f8Ce0B9A6
+        network: test-network
+        subgraph: test-sg
+tokens:
+    token1:
+        network: test-network
+        address: 0xc2132d05d31c914a87c6611c10748aeb04b58e8f
+        decimals: 6
+        label: Token 1
+        symbol: T1
+scenarios:
+    test-scenario:
+        deployer: test-deployer
+        bindings:
+            test: 1
+orders:
+    test-order:
+      inputs:
+        - token: token1
+          vault-id: 1
+      outputs:
+        - token: token1
+          vault-id: 1
+      deployer: test-deployer
+      orderbook: test-orderbook
+deployments:
+    validation-deployment:
+        scenario: test-scenario
+        order: test-order
+---
+#test !
+#calculate-io
+_ _: 0 0;
+#handle-io
+:;
+#handle-add-order
+:;
+"#,
+            spec_version = SpecVersion::current()
+        )
+    }
+
     pub async fn initialize_gui(deployment_name: Option<String>) -> DotrainOrderGui {
         DotrainOrderGui::new_with_deployment(
             get_yaml(),
@@ -975,6 +1153,16 @@ _ _: 0 0;
         DotrainOrderGui::new_with_deployment(
             get_yaml(),
             "select-token-deployment".to_string(),
+            None,
+        )
+        .await
+        .unwrap()
+    }
+
+    pub async fn initialize_validation_gui() -> DotrainOrderGui {
+        DotrainOrderGui::new_with_deployment(
+            get_yaml_with_validation(),
+            "validation-deployment".to_string(),
             None,
         )
         .await

--- a/crates/js_api/src/gui/order_operations.rs
+++ b/crates/js_api/src/gui/order_operations.rs
@@ -740,6 +740,7 @@ mod tests {
         }
 
         gui.save_deposit("token1".to_string(), "1200".to_string())
+            .await
             .unwrap();
 
         let res = gui.generate_deposit_calldatas().await.unwrap();
@@ -754,6 +755,7 @@ mod tests {
         }
 
         gui.save_deposit("token1".to_string(), "0".to_string())
+            .await
             .unwrap();
 
         let res = gui.generate_deposit_calldatas().await.unwrap();

--- a/crates/js_api/src/gui/state_management.rs
+++ b/crates/js_api/src/gui/state_management.rs
@@ -424,6 +424,7 @@ mod tests {
             "TKN3".to_string(),
         );
         gui.save_deposit("token3".to_string(), "100".to_string())
+            .await
             .unwrap();
         gui.save_field_value("binding-1".to_string(), "100".to_string())
             .unwrap();
@@ -521,6 +522,7 @@ mod tests {
         assert_eq!(callback_called, JsValue::from_bool(false));
 
         gui.save_deposit("token1".to_string(), "100".to_string())
+            .await
             .unwrap();
         gui.save_field_value("binding-1".to_string(), "100".to_string())
             .unwrap();

--- a/crates/js_api/src/gui/validation.rs
+++ b/crates/js_api/src/gui/validation.rs
@@ -1,0 +1,1023 @@
+use alloy::primitives::{
+    utils::{parse_units, ParseUnits},
+    U256,
+};
+use rain_orderbook_app_settings::gui::{DepositValidationCfg, FieldValueValidationCfg};
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum GuiValidationError {
+    #[error("Invalid number for {name}: {value}")]
+    InvalidNumber { name: String, value: String },
+
+    #[error("{name} value {value} is less than minimum {minimum}")]
+    BelowMinimum {
+        name: String,
+        value: String,
+        minimum: String,
+    },
+
+    #[error("{name} value {value} is less than or equal to {exclusive_minimum}")]
+    BelowExclusiveMinimum {
+        name: String,
+        value: String,
+        exclusive_minimum: String,
+    },
+
+    #[error("{name} value {value} is greater than maximum {maximum}")]
+    AboveMaximum {
+        name: String,
+        value: String,
+        maximum: String,
+    },
+
+    #[error("{name} value {value} is greater than or equal to {exclusive_maximum}")]
+    AboveExclusiveMaximum {
+        name: String,
+        value: String,
+        exclusive_maximum: String,
+    },
+
+    #[error("{name} value {value} is not a multiple of {multiple_of}")]
+    NotMultipleOf {
+        name: String,
+        value: String,
+        multiple_of: String,
+    },
+
+    #[error("{name} length {length} is less than minimum {minimum}")]
+    StringTooShort {
+        name: String,
+        length: u64,
+        minimum: u64,
+    },
+
+    #[error("{name} length {length} exceeds maximum {maximum}")]
+    StringTooLong {
+        name: String,
+        length: u64,
+        maximum: u64,
+    },
+
+    #[error("{name} value '{value}' is not a valid boolean (must be 'true' or 'false')")]
+    InvalidBoolean { name: String, value: String },
+}
+
+pub fn validate_field_value(
+    field_name: &str,
+    value: &str,
+    validation: &FieldValueValidationCfg,
+) -> Result<(), GuiValidationError> {
+    match validation {
+        FieldValueValidationCfg::Number {
+            minimum,
+            exclusive_minimum,
+            maximum,
+            exclusive_maximum,
+            multiple_of,
+        } => validate_number(
+            field_name,
+            value,
+            18,
+            minimum,
+            exclusive_minimum,
+            maximum,
+            exclusive_maximum,
+            multiple_of,
+        ),
+        FieldValueValidationCfg::String {
+            min_length,
+            max_length,
+        } => validate_string(field_name, value, min_length, max_length),
+        FieldValueValidationCfg::Boolean => validate_boolean(field_name, value),
+    }
+}
+
+/// Validates a deposit amount against its validation configuration
+pub fn validate_deposit_amount(
+    token_name: &str,
+    amount: &str,
+    validation: &DepositValidationCfg,
+    decimals: u8,
+) -> Result<(), GuiValidationError> {
+    validate_number(
+        token_name,
+        amount,
+        decimals,
+        &validation.minimum,
+        &validation.exclusive_minimum,
+        &validation.maximum,
+        &validation.exclusive_maximum,
+        &validation.multiple_of,
+    )
+}
+
+fn validate_number(
+    name: &str,
+    value: &str,
+    decimals: u8,
+    minimum: &Option<String>,
+    exclusive_minimum: &Option<String>,
+    maximum: &Option<String>,
+    exclusive_maximum: &Option<String>,
+    multiple_of: &Option<String>,
+) -> Result<(), GuiValidationError> {
+    // Check for empty string explicitly
+    if value.is_empty() {
+        return Err(GuiValidationError::InvalidNumber {
+            name: name.to_string(),
+            value: value.to_string(),
+        });
+    }
+
+    // Parse the value as a decimal number (accepting string input)
+    let parsed_value =
+        parse_units(value, decimals).map_err(|_| GuiValidationError::InvalidNumber {
+            name: name.to_string(),
+            value: value.to_string(),
+        })?;
+
+    // Validate minimum (inclusive)
+    if let Some(min) = minimum {
+        let min_value =
+            parse_units(min, decimals).map_err(|_| GuiValidationError::InvalidNumber {
+                name: name.to_string(),
+                value: min.clone(),
+            })?;
+        // Compare ParseUnits values directly
+        if parsed_value < min_value {
+            return Err(GuiValidationError::BelowMinimum {
+                name: name.to_string(),
+                value: value.to_string(),
+                minimum: min.clone(),
+            });
+        }
+    }
+
+    // Validate exclusive minimum
+    if let Some(exclusive_min) = exclusive_minimum {
+        let exclusive_min_value = parse_units(exclusive_min, decimals).map_err(|_| {
+            GuiValidationError::InvalidNumber {
+                name: name.to_string(),
+                value: exclusive_min.clone(),
+            }
+        })?;
+        // Compare ParseUnits values directly
+        if parsed_value <= exclusive_min_value {
+            return Err(GuiValidationError::BelowExclusiveMinimum {
+                name: name.to_string(),
+                value: value.to_string(),
+                exclusive_minimum: exclusive_min.clone(),
+            });
+        }
+    }
+
+    // Validate maximum (inclusive)
+    if let Some(max) = maximum {
+        let max_value =
+            parse_units(max, decimals).map_err(|_| GuiValidationError::InvalidNumber {
+                name: name.to_string(),
+                value: max.clone(),
+            })?;
+        // Compare ParseUnits values directly
+        if parsed_value > max_value {
+            return Err(GuiValidationError::AboveMaximum {
+                name: name.to_string(),
+                value: value.to_string(),
+                maximum: max.clone(),
+            });
+        }
+    }
+
+    // Validate exclusive maximum
+    if let Some(exclusive_max) = exclusive_maximum {
+        let exclusive_max_value = parse_units(exclusive_max, decimals).map_err(|_| {
+            GuiValidationError::InvalidNumber {
+                name: name.to_string(),
+                value: exclusive_max.clone(),
+            }
+        })?;
+        // Compare ParseUnits values directly
+        if parsed_value >= exclusive_max_value {
+            return Err(GuiValidationError::AboveExclusiveMaximum {
+                name: name.to_string(),
+                value: value.to_string(),
+                exclusive_maximum: exclusive_max.clone(),
+            });
+        }
+    }
+
+    // Validate multiple_of
+    if let Some(multiple) = multiple_of {
+        let multiple_value =
+            parse_units(multiple, decimals).map_err(|_| GuiValidationError::InvalidNumber {
+                name: name.to_string(),
+                value: multiple.clone(),
+            })?;
+        // Extract U256 values from ParseUnits for comparison
+        let multiple_u256 = match multiple_value {
+            ParseUnits::U256(v) => v,
+            _ => {
+                return Err(GuiValidationError::InvalidNumber {
+                    name: name.to_string(),
+                    value: multiple.clone(),
+                })
+            }
+        };
+        let parsed_u256 = match parsed_value {
+            ParseUnits::U256(v) => v,
+            _ => {
+                return Err(GuiValidationError::InvalidNumber {
+                    name: name.to_string(),
+                    value: value.to_string(),
+                })
+            }
+        };
+        if multiple_u256 > U256::ZERO && parsed_u256 % multiple_u256 != U256::ZERO {
+            return Err(GuiValidationError::NotMultipleOf {
+                name: name.to_string(),
+                value: value.to_string(),
+                multiple_of: multiple.clone(),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_string(
+    name: &str,
+    value: &str,
+    min_length: &Option<u64>,
+    max_length: &Option<u64>,
+) -> Result<(), GuiValidationError> {
+    let length = value.len() as u64;
+
+    if let Some(min) = min_length {
+        if length < *min {
+            return Err(GuiValidationError::StringTooShort {
+                name: name.to_string(),
+                length,
+                minimum: *min,
+            });
+        }
+    }
+
+    if let Some(max) = max_length {
+        if length > *max {
+            return Err(GuiValidationError::StringTooLong {
+                name: name.to_string(),
+                length,
+                maximum: *max,
+            });
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_boolean(name: &str, value: &str) -> Result<(), GuiValidationError> {
+    match value {
+        "true" | "false" => Ok(()),
+        _ => Err(GuiValidationError::InvalidBoolean {
+            name: name.to_string(),
+            value: value.to_string(),
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rain_orderbook_app_settings::gui::FieldValueValidationCfg;
+    use wasm_bindgen_test::wasm_bindgen_test;
+
+    // Number validation tests
+    #[wasm_bindgen_test]
+    fn test_validate_number_minimum() {
+        let result = validate_number(
+            "Test Field",
+            "5",
+            18,
+            &Some("10".to_string()),
+            &None,
+            &None,
+            &None,
+            &None,
+        );
+        match &result {
+            Err(GuiValidationError::BelowMinimum {
+                name,
+                value,
+                minimum,
+            }) => {
+                assert_eq!(name, "Test Field");
+                assert_eq!(value, "5");
+                assert_eq!(minimum, "10");
+            }
+            _ => panic!("Expected BelowMinimum error"),
+        }
+
+        let result = validate_number(
+            "Test Field",
+            "10",
+            18,
+            &Some("10".to_string()),
+            &None,
+            &None,
+            &None,
+            &None,
+        );
+        assert!(result.is_ok());
+
+        let result = validate_number(
+            "Test Field",
+            "15",
+            18,
+            &Some("10".to_string()),
+            &None,
+            &None,
+            &None,
+            &None,
+        );
+        assert!(result.is_ok());
+    }
+
+    #[wasm_bindgen_test]
+    fn test_validate_number_exclusive_minimum() {
+        let result = validate_number(
+            "Price",
+            "10",
+            18,
+            &None,
+            &Some("10".to_string()),
+            &None,
+            &None,
+            &None,
+        );
+        match &result {
+            Err(GuiValidationError::BelowExclusiveMinimum {
+                name,
+                value,
+                exclusive_minimum,
+            }) => {
+                assert_eq!(name, "Price");
+                assert_eq!(value, "10");
+                assert_eq!(exclusive_minimum, "10");
+            }
+            _ => panic!("Expected BelowExclusiveMinimum error"),
+        }
+
+        let result = validate_number(
+            "Price",
+            "10.1",
+            18,
+            &None,
+            &Some("10".to_string()),
+            &None,
+            &None,
+            &None,
+        );
+        assert!(result.is_ok());
+    }
+
+    #[wasm_bindgen_test]
+    fn test_validate_number_maximum() {
+        let result = validate_number(
+            "Amount",
+            "101",
+            18,
+            &None,
+            &None,
+            &Some("100".to_string()),
+            &None,
+            &None,
+        );
+        match &result {
+            Err(GuiValidationError::AboveMaximum {
+                name,
+                value,
+                maximum,
+            }) => {
+                assert_eq!(name, "Amount");
+                assert_eq!(value, "101");
+                assert_eq!(maximum, "100");
+            }
+            _ => panic!("Expected AboveMaximum error"),
+        }
+
+        let result = validate_number(
+            "Amount",
+            "100",
+            18,
+            &None,
+            &None,
+            &Some("100".to_string()),
+            &None,
+            &None,
+        );
+        assert!(result.is_ok());
+
+        let result = validate_number(
+            "Amount",
+            "99.9",
+            18,
+            &None,
+            &None,
+            &Some("100".to_string()),
+            &None,
+            &None,
+        );
+        assert!(result.is_ok());
+    }
+
+    #[wasm_bindgen_test]
+    fn test_validate_number_exclusive_maximum() {
+        let result = validate_number(
+            "Token Amount",
+            "100",
+            18,
+            &None,
+            &None,
+            &None,
+            &Some("100".to_string()),
+            &None,
+        );
+        match &result {
+            Err(GuiValidationError::AboveExclusiveMaximum {
+                name,
+                value,
+                exclusive_maximum,
+            }) => {
+                assert_eq!(name, "Token Amount");
+                assert_eq!(value, "100");
+                assert_eq!(exclusive_maximum, "100");
+            }
+            _ => panic!("Expected AboveExclusiveMaximum error"),
+        }
+
+        let result = validate_number(
+            "Token Amount",
+            "99.999",
+            18,
+            &None,
+            &None,
+            &None,
+            &Some("100".to_string()),
+            &None,
+        );
+        assert!(result.is_ok());
+    }
+
+    #[wasm_bindgen_test]
+    fn test_validate_number_multiple_of() {
+        let result = validate_number(
+            "Step Size",
+            "7",
+            18,
+            &None,
+            &None,
+            &None,
+            &None,
+            &Some("5".to_string()),
+        );
+        match &result {
+            Err(GuiValidationError::NotMultipleOf {
+                name,
+                value,
+                multiple_of,
+            }) => {
+                assert_eq!(name, "Step Size");
+                assert_eq!(value, "7");
+                assert_eq!(multiple_of, "5");
+            }
+            _ => panic!("Expected NotMultipleOf error"),
+        }
+
+        let result = validate_number(
+            "Step Size",
+            "10",
+            18,
+            &None,
+            &None,
+            &None,
+            &None,
+            &Some("5".to_string()),
+        );
+        assert!(result.is_ok());
+
+        let result = validate_number(
+            "Step Size",
+            "0",
+            18,
+            &None,
+            &None,
+            &None,
+            &None,
+            &Some("5".to_string()),
+        );
+        assert!(result.is_ok());
+
+        // Test with decimal multiples
+        let result = validate_number(
+            "Price Step",
+            "1.05",
+            18,
+            &None,
+            &None,
+            &None,
+            &None,
+            &Some("0.01".to_string()),
+        );
+        assert!(result.is_ok());
+
+        let result = validate_number(
+            "Price Step",
+            "1.055",
+            18,
+            &None,
+            &None,
+            &None,
+            &None,
+            &Some("0.01".to_string()),
+        );
+        match &result {
+            Err(GuiValidationError::NotMultipleOf { .. }) => {}
+            _ => panic!("Expected NotMultipleOf error for decimal mismatch"),
+        }
+    }
+
+    #[wasm_bindgen_test]
+    fn test_validate_number_combined_constraints() {
+        // Test with all constraints
+        let result = validate_number(
+            "Complex Field",
+            "50",
+            18,
+            &Some("10".to_string()),  // minimum
+            &None,                    // exclusive_minimum
+            &Some("100".to_string()), // maximum
+            &None,                    // exclusive_maximum
+            &Some("10".to_string()),  // multiple_of
+        );
+        assert!(result.is_ok());
+
+        // Violate minimum
+        let result = validate_number(
+            "Complex Field",
+            "5",
+            18,
+            &Some("10".to_string()),
+            &None,
+            &Some("100".to_string()),
+            &None,
+            &Some("5".to_string()),
+        );
+        assert!(matches!(
+            result,
+            Err(GuiValidationError::BelowMinimum { .. })
+        ));
+
+        // Violate maximum
+        let result = validate_number(
+            "Complex Field",
+            "105",
+            18,
+            &Some("10".to_string()),
+            &None,
+            &Some("100".to_string()),
+            &None,
+            &Some("5".to_string()),
+        );
+        assert!(matches!(
+            result,
+            Err(GuiValidationError::AboveMaximum { .. })
+        ));
+
+        // Violate multiple_of
+        let result = validate_number(
+            "Complex Field",
+            "53",
+            18,
+            &Some("10".to_string()),
+            &None,
+            &Some("100".to_string()),
+            &None,
+            &Some("10".to_string()),
+        );
+        assert!(matches!(
+            result,
+            Err(GuiValidationError::NotMultipleOf { .. })
+        ));
+    }
+
+    #[wasm_bindgen_test]
+    fn test_validate_number_parsing() {
+        // Valid decimal inputs
+        let result = validate_number("Test Field", "100.5", 18, &None, &None, &None, &None, &None);
+        assert!(result.is_ok());
+
+        let result = validate_number(
+            "Test Field",
+            "0.000001",
+            18,
+            &None,
+            &None,
+            &None,
+            &None,
+            &None,
+        );
+        assert!(result.is_ok());
+
+        let result = validate_number(
+            "Test Field",
+            "123456789.123456789",
+            18,
+            &None,
+            &None,
+            &None,
+            &None,
+            &None,
+        );
+        assert!(result.is_ok());
+
+        // Invalid inputs
+        let result = validate_number(
+            "Test Field",
+            "not a number",
+            18,
+            &None,
+            &None,
+            &None,
+            &None,
+            &None,
+        );
+        match &result {
+            Err(GuiValidationError::InvalidNumber { name, value }) => {
+                assert_eq!(name, "Test Field");
+                assert_eq!(value, "not a number");
+            }
+            _ => panic!("Expected InvalidNumber error"),
+        }
+
+        let result = validate_number(
+            "Test Field",
+            "12.34.56",
+            18,
+            &None,
+            &None,
+            &None,
+            &None,
+            &None,
+        );
+        assert!(matches!(
+            result,
+            Err(GuiValidationError::InvalidNumber { .. })
+        ));
+
+        let result = validate_number("Test Field", "", 18, &None, &None, &None, &None, &None);
+        assert!(matches!(
+            result,
+            Err(GuiValidationError::InvalidNumber { .. })
+        ));
+
+        let result = validate_number("Test Field", "1e18", 18, &None, &None, &None, &None, &None);
+        assert!(matches!(
+            result,
+            Err(GuiValidationError::InvalidNumber { .. })
+        ))
+    }
+
+    #[wasm_bindgen_test]
+    fn test_validate_number_decimals() {
+        // Test with different decimal places
+        let result = validate_number(
+            "USDC Amount",
+            "100.123456",
+            6,
+            &None,
+            &None,
+            &None,
+            &None,
+            &None,
+        );
+        assert!(result.is_ok());
+
+        let result = validate_number(
+            "ETH Amount",
+            "1.123456789012345678",
+            18,
+            &None,
+            &None,
+            &None,
+            &None,
+            &None,
+        );
+        assert!(result.is_ok());
+
+        let result = validate_number(
+            "BTC Amount",
+            "0.12345678",
+            8,
+            &None,
+            &None,
+            &None,
+            &None,
+            &None,
+        );
+        assert!(result.is_ok());
+    }
+
+    #[wasm_bindgen_test]
+    fn test_validate_number_edge_cases() {
+        // Zero value
+        let result = validate_number("Amount", "0", 18, &None, &None, &None, &None, &None);
+        assert!(result.is_ok());
+
+        // Very small number
+        let result = validate_number(
+            "Amount",
+            "0.000000000000000001",
+            18,
+            &None,
+            &None,
+            &None,
+            &None,
+            &None,
+        );
+        assert!(result.is_ok());
+
+        // Very large number
+        let result = validate_number(
+            "Amount",
+            "999999999999999999999999999",
+            18,
+            &None,
+            &None,
+            &None,
+            &None,
+            &None,
+        );
+        assert!(result.is_ok());
+
+        // Multiple of zero should be handled gracefully
+        let result = validate_number(
+            "Amount",
+            "100",
+            18,
+            &None,
+            &None,
+            &None,
+            &None,
+            &Some("0".to_string()),
+        );
+        assert!(result.is_ok()); // Any number is a multiple of 0 (handled by checking multiple_u256 > U256::ZERO)
+    }
+
+    // String validation tests
+    #[wasm_bindgen_test]
+    fn test_validate_string_length() {
+        let result = validate_string("Username", "hello", &Some(10), &None);
+        match &result {
+            Err(GuiValidationError::StringTooShort {
+                name,
+                length,
+                minimum,
+            }) => {
+                assert_eq!(name, "Username");
+                assert_eq!(*length, 5);
+                assert_eq!(*minimum, 10);
+            }
+            _ => panic!("Expected StringTooShort error"),
+        }
+
+        let result = validate_string("Username", "hello world", &Some(5), &Some(20));
+        assert!(result.is_ok());
+
+        let result = validate_string("Username", "hello world", &Some(11), &None);
+        assert!(result.is_ok());
+
+        let result = validate_string("Description", &"a".repeat(100), &None, &Some(50));
+        match &result {
+            Err(GuiValidationError::StringTooLong {
+                name,
+                length,
+                maximum,
+            }) => {
+                assert_eq!(name, "Description");
+                assert_eq!(*length, 100);
+                assert_eq!(*maximum, 50);
+            }
+            _ => panic!("Expected StringTooLong error"),
+        }
+    }
+
+    #[wasm_bindgen_test]
+    fn test_validate_string_edge_cases() {
+        // Empty string
+        let result = validate_string("Field", "", &None, &None);
+        assert!(result.is_ok());
+
+        let result = validate_string("Field", "", &Some(1), &None);
+        assert!(matches!(
+            result,
+            Err(GuiValidationError::StringTooShort { .. })
+        ));
+
+        // Exact length boundaries
+        let result = validate_string("Field", "12345", &Some(5), &Some(5));
+        assert!(result.is_ok());
+
+        // Unicode characters (length is in bytes for Rust strings)
+        let result = validate_string("Field", "🦀", &Some(4), &None);
+        assert!(result.is_ok()); // Emoji is 4 bytes
+
+        let result = validate_string("Field", "🦀", &Some(5), &None);
+        assert!(matches!(
+            result,
+            Err(GuiValidationError::StringTooShort { .. })
+        ));
+    }
+
+    // Boolean validation tests
+    #[wasm_bindgen_test]
+    fn test_validate_boolean() {
+        let result = validate_boolean("Enable Feature", "true");
+        assert!(result.is_ok());
+
+        let result = validate_boolean("Enable Feature", "false");
+        assert!(result.is_ok());
+
+        let result = validate_boolean("Enable Feature", "yes");
+        match &result {
+            Err(GuiValidationError::InvalidBoolean { name, value }) => {
+                assert_eq!(name, "Enable Feature");
+                assert_eq!(value, "yes");
+            }
+            _ => panic!("Expected InvalidBoolean error"),
+        }
+
+        let result = validate_boolean("Enable Feature", "True");
+        assert!(matches!(
+            result,
+            Err(GuiValidationError::InvalidBoolean { .. })
+        ));
+
+        let result = validate_boolean("Enable Feature", "FALSE");
+        assert!(matches!(
+            result,
+            Err(GuiValidationError::InvalidBoolean { .. })
+        ));
+
+        let result = validate_boolean("Enable Feature", "1");
+        assert!(matches!(
+            result,
+            Err(GuiValidationError::InvalidBoolean { .. })
+        ));
+
+        let result = validate_boolean("Enable Feature", "0");
+        assert!(matches!(
+            result,
+            Err(GuiValidationError::InvalidBoolean { .. })
+        ));
+
+        let result = validate_boolean("Enable Feature", "");
+        assert!(matches!(
+            result,
+            Err(GuiValidationError::InvalidBoolean { .. })
+        ));
+    }
+
+    // Field value validation tests
+    #[wasm_bindgen_test]
+    fn test_validate_field_value_number() {
+        let validation = FieldValueValidationCfg::Number {
+            minimum: Some("10".to_string()),
+            exclusive_minimum: None,
+            maximum: Some("100".to_string()),
+            exclusive_maximum: None,
+            multiple_of: Some("5".to_string()),
+        };
+
+        let result = validate_field_value("Price Field", "50", &validation);
+        assert!(result.is_ok());
+
+        let result = validate_field_value("Price Field", "5", &validation);
+        assert!(matches!(
+            result,
+            Err(GuiValidationError::BelowMinimum { .. })
+        ));
+
+        let result = validate_field_value("Price Field", "102", &validation);
+        assert!(matches!(
+            result,
+            Err(GuiValidationError::AboveMaximum { .. })
+        ));
+
+        let result = validate_field_value("Price Field", "33", &validation);
+        assert!(matches!(
+            result,
+            Err(GuiValidationError::NotMultipleOf { .. })
+        ));
+    }
+
+    #[wasm_bindgen_test]
+    fn test_validate_field_value_string() {
+        let validation = FieldValueValidationCfg::String {
+            min_length: Some(3),
+            max_length: Some(10),
+        };
+
+        let result = validate_field_value("Name Field", "hello", &validation);
+        assert!(result.is_ok());
+
+        let result = validate_field_value("Name Field", "hi", &validation);
+        assert!(matches!(
+            result,
+            Err(GuiValidationError::StringTooShort { .. })
+        ));
+
+        let result = validate_field_value("Name Field", "hello world!", &validation);
+        assert!(matches!(
+            result,
+            Err(GuiValidationError::StringTooLong { .. })
+        ));
+    }
+
+    #[wasm_bindgen_test]
+    fn test_validate_field_value_boolean() {
+        let validation = FieldValueValidationCfg::Boolean;
+
+        let result = validate_field_value("Toggle Field", "true", &validation);
+        assert!(result.is_ok());
+
+        let result = validate_field_value("Toggle Field", "false", &validation);
+        assert!(result.is_ok());
+
+        let result = validate_field_value("Toggle Field", "maybe", &validation);
+        assert!(matches!(
+            result,
+            Err(GuiValidationError::InvalidBoolean { .. })
+        ));
+    }
+
+    // Deposit amount validation tests
+    #[wasm_bindgen_test]
+    fn test_validate_deposit_amount() {
+        let validation = DepositValidationCfg {
+            minimum: Some("0.01".to_string()),
+            exclusive_minimum: None,
+            maximum: Some("1000000".to_string()),
+            exclusive_maximum: None,
+            multiple_of: None,
+        };
+
+        let result = validate_deposit_amount("USDC", "100.50", &validation, 6);
+        assert!(result.is_ok());
+
+        let result = validate_deposit_amount("USDC", "0.001", &validation, 6);
+        match &result {
+            Err(GuiValidationError::BelowMinimum { name, .. }) => {
+                assert_eq!(name, "USDC");
+            }
+            _ => panic!("Expected BelowMinimum error"),
+        }
+
+        let result = validate_deposit_amount("USDC", "1000001", &validation, 6);
+        assert!(matches!(
+            result,
+            Err(GuiValidationError::AboveMaximum { .. })
+        ));
+    }
+
+    #[wasm_bindgen_test]
+    fn test_validate_deposit_amount_with_different_decimals() {
+        let validation = DepositValidationCfg {
+            minimum: Some("0.000001".to_string()),
+            exclusive_minimum: None,
+            maximum: Some("21000000".to_string()),
+            exclusive_maximum: None,
+            multiple_of: None,
+        };
+
+        // Test with 18 decimals (ETH)
+        let result = validate_deposit_amount("Ethereum", "0.000000000000000001", &validation, 18);
+        assert!(matches!(
+            result,
+            Err(GuiValidationError::BelowMinimum { .. })
+        ));
+
+        let result = validate_deposit_amount("Ethereum", "0.000001", &validation, 18);
+        assert!(result.is_ok());
+
+        // Test with 8 decimals (BTC)
+        let result = validate_deposit_amount("Bitcoin", "0.00000001", &validation, 8);
+        assert!(matches!(
+            result,
+            Err(GuiValidationError::BelowMinimum { .. })
+        ));
+
+        let result = validate_deposit_amount("Bitcoin", "0.000001", &validation, 8);
+        assert!(result.is_ok());
+    }
+}

--- a/packages/orderbook/test/js_api/gui.test.ts
+++ b/packages/orderbook/test/js_api/gui.test.ts
@@ -662,7 +662,7 @@ describe('Rain Orderbook JS API Package Bindgen Tests - Gui', async function () 
 		it('should add deposit', async () => {
 			assert.equal(extractWasmEncodedData<boolean>(gui.hasAnyDeposit()), false);
 
-			gui.saveDeposit('token1', '50.6');
+			await gui.saveDeposit('token1', '50.6');
 			const deposits = extractWasmEncodedData<TokenDeposit[]>(gui.getDeposits());
 			assert.equal(deposits.length, 1);
 
@@ -675,8 +675,8 @@ describe('Rain Orderbook JS API Package Bindgen Tests - Gui', async function () 
 		});
 
 		it('should update deposit', async () => {
-			gui.saveDeposit('token1', '50.6');
-			gui.saveDeposit('token1', '100.6');
+			await gui.saveDeposit('token1', '50.6');
+			await gui.saveDeposit('token1', '100.6');
 			const deposits = extractWasmEncodedData<TokenDeposit[]>(gui.getDeposits());
 			assert.equal(deposits.length, 1);
 			assert.equal(deposits[0].amount, '100.6');
@@ -697,7 +697,7 @@ describe('Rain Orderbook JS API Package Bindgen Tests - Gui', async function () 
 		});
 
 		it('should remove deposit', async () => {
-			gui.saveDeposit('token1', '50.6');
+			await gui.saveDeposit('token1', '50.6');
 			const deposits = extractWasmEncodedData<TokenDeposit[]>(gui.getDeposits());
 			assert.equal(deposits.length, 1);
 
@@ -705,9 +705,9 @@ describe('Rain Orderbook JS API Package Bindgen Tests - Gui', async function () 
 			const depositsAfterRemove = extractWasmEncodedData<TokenDeposit[]>(gui.getDeposits());
 			assert.equal(depositsAfterRemove.length, 0);
 
-			gui.saveDeposit('token1', '50.6');
+			await gui.saveDeposit('token1', '50.6');
 			assert.equal(extractWasmEncodedData<TokenDeposit[]>(gui.getDeposits()).length, 1);
-			gui.saveDeposit('token1', '');
+			await gui.saveDeposit('token1', '');
 			assert.equal(extractWasmEncodedData<TokenDeposit[]>(gui.getDeposits()).length, 0);
 
 			assert.equal(stateUpdateCallback.mock.calls.length, 4);
@@ -991,8 +991,8 @@ ${dotrain}`;
 				extractWasmEncodedData<GuiFieldDefinitionCfg>(gui.getFieldDefinition('test-binding'))
 					.presets?.[0].value || ''
 			);
-			gui.saveDeposit('token1', '50.6');
-			gui.saveDeposit('token2', '100');
+			await gui.saveDeposit('token1', '50.6');
+			await gui.saveDeposit('token2', '100');
 			gui.removeSelectToken('token1');
 			await gui.saveSelectToken('token1', '0x6666666666666666666666666666666666666666');
 			gui.setVaultId(true, 0, '666');
@@ -1166,7 +1166,7 @@ ${dotrain}`;
 					'0x0000000000000000000000000000000000000000000000000000000000000001'
 				);
 
-			gui.saveDeposit('token2', '200');
+			await gui.saveDeposit('token2', '200');
 
 			const allowances = extractWasmEncodedData<TokenAllowance[]>(
 				await gui.checkAllowances('0x1234567890abcdef1234567890abcdef12345678')
@@ -1184,8 +1184,8 @@ ${dotrain}`;
 					'0x00000000000000000000000000000000000000000000003635C9ADC5DEA00000'
 				);
 
-			gui.saveDeposit('token1', '1000');
-			gui.saveDeposit('token2', '5000');
+			await gui.saveDeposit('token1', '1000');
+			await gui.saveDeposit('token2', '5000');
 
 			const result = extractWasmEncodedData<ApprovalCalldataResult>(
 				await gui.generateApprovalCalldatas('0x1234567890abcdef1234567890abcdef12345678')
@@ -1234,8 +1234,8 @@ ${dotrain}`;
 					'0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000021234000000000000000000000000000000000000000000000000000000000000'
 				);
 
-			gui.saveDeposit('token1', '1000');
-			gui.saveDeposit('token2', '5000');
+			await gui.saveDeposit('token1', '1000');
+			await gui.saveDeposit('token2', '5000');
 
 			const result = extractWasmEncodedData<DepositCalldataResult>(
 				await gui.generateDepositCalldatas()
@@ -1354,8 +1354,8 @@ ${dotrain}`;
 					'0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000021234000000000000000000000000000000000000000000000000000000000000'
 				);
 
-			gui.saveDeposit('token1', '1000');
-			gui.saveDeposit('token2', '5000');
+			await gui.saveDeposit('token1', '1000');
+			await gui.saveDeposit('token2', '5000');
 
 			gui.saveFieldValue('test-binding', '0xbeef');
 
@@ -1399,8 +1399,8 @@ ${dotrain}`;
 			gui.removeFieldValue('test-binding');
 			assert.deepEqual(extractWasmEncodedData<FieldValue[]>(gui.getAllFieldValues()), []);
 
-			gui.saveDeposit('token1', '1000');
-			gui.saveDeposit('token2', '5000');
+			await gui.saveDeposit('token1', '1000');
+			await gui.saveDeposit('token2', '5000');
 
 			const calldata = extractWasmEncodedData<string>(
 				await gui.generateDepositAndAddOrderCalldatas()
@@ -1457,8 +1457,8 @@ ${dotrainWithoutVaultIds}`;
 					'0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000021234000000000000000000000000000000000000000000000000000000000000'
 				);
 
-			gui.saveDeposit('token1', '1000');
-			gui.saveDeposit('token2', '5000');
+			await gui.saveDeposit('token1', '1000');
+			await gui.saveDeposit('token2', '5000');
 
 			gui.saveFieldValue('test-binding', '0');
 
@@ -1556,8 +1556,8 @@ ${dotrainWithoutVaultIds}`;
 			let result = await DotrainOrderGui.newWithDeployment(testDotrain, 'other-deployment');
 			const gui = extractWasmEncodedData(result);
 
-			gui.saveDeposit('token1', '1000');
-			gui.saveDeposit('token2', '5000');
+			await gui.saveDeposit('token1', '1000');
+			await gui.saveDeposit('token2', '5000');
 
 			let result1 = await gui.generateAddOrderCalldata();
 			if (result1.error) {
@@ -1691,8 +1691,8 @@ ${dotrainWithoutVaultIds}`;
 					'0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000e000000000000000000000000000000000000000000000000000000000000001a000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000120000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000754656b656e203200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000025432000000000000000000000000000000000000000000000000000000000000'
 				);
 
-			gui.saveDeposit('token1', '0');
-			gui.saveDeposit('token2', '0');
+			await gui.saveDeposit('token1', '0');
+			await gui.saveDeposit('token2', '0');
 			const calldatas = extractWasmEncodedData<DepositCalldataResult>(
 				await gui.generateDepositCalldatas()
 			);
@@ -1725,7 +1725,7 @@ ${dotrainWithoutVaultIds}`;
 					'0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000021234000000000000000000000000000000000000000000000000000000000000'
 				);
 
-			gui.saveDeposit('token2', '5000');
+			await gui.saveDeposit('token2', '5000');
 			gui.saveFieldValue('test-binding', '10');
 
 			let result = extractWasmEncodedData<DeploymentTransactionArgs>(

--- a/packages/ui-components/src/lib/components/deployment/DepositInput.svelte
+++ b/packages/ui-components/src/lib/components/deployment/DepositInput.svelte
@@ -54,10 +54,10 @@
 		}
 	};
 
-	function handlePresetClick(preset: string) {
+	async function handlePresetClick(preset: string) {
 		if (deposit.token?.key) {
 			inputValue = preset;
-			gui.saveDeposit(deposit.token?.key, preset);
+			await gui.saveDeposit(deposit.token?.key, preset);
 
 			try {
 				currentDeposit = getCurrentDeposit();
@@ -67,11 +67,11 @@
 		}
 	}
 
-	function handleInput(e: Event) {
+	async function handleInput(e: Event) {
 		if (deposit.token?.key) {
 			if (e.currentTarget instanceof HTMLInputElement) {
 				inputValue = e.currentTarget.value;
-				gui.saveDeposit(deposit.token.key, e.currentTarget.value);
+				await gui.saveDeposit(deposit.token.key, e.currentTarget.value);
 				try {
 					currentDeposit = getCurrentDeposit();
 				} catch (e) {


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

See issue: https://github.com/rainlanguage/rain.orderbook/issues/1472

We've written the spec for validation logic in the gui sdk but haven't implemented it. This PR aims to implement that logic.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

- Add the new validation structs for field values and deposits
- Update the parsing logic for gui yaml to also parse the validation fields
- Add a new file for writing the validation logic
- Update save methods for field values and deposits
- Update function signature in UI components
- Update tests

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possiblez
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)

fix https://github.com/rainlanguage/rain.orderbook/issues/1472