### PR TITLE
Update order quotes sdk function to return pre-formetted strings

### DIFF
--- a/crates/common/src/raindex_client/order_quotes.rs
+++ b/crates/common/src/raindex_client/order_quotes.rs
@@ -1,7 +1,32 @@
 use super::*;
 use crate::raindex_client::orders::RaindexOrder;
 use alloy::primitives::U256;
-use rain_orderbook_quote::{get_order_quotes, BatchOrderQuotesResponse};
+use rain_orderbook_quote::{get_order_quotes, BatchOrderQuotesResponse, Pair};
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Tsify)]
+#[serde(rename_all = "camelCase")]
+pub struct RaindexOrderQuotes {
+    pub pair: Pair,
+    pub block_number: Option<u64>,
+    pub data: Option<RaindexOrderQuoteValue>,
+    pub success: bool,
+    pub error: Option<String>,
+}
+impl_wasm_traits!(RaindexOrderQuotes);
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Tsify)]
+#[serde(rename_all = "camelCase")]
+pub struct RaindexOrderQuoteValue {
+    pub max_output: U256,
+    pub formatted_max_output: String,
+    pub max_input: U256,
+    pub formatted_max_input: String,
+    pub ratio: U256,
+    pub formatted_ratio: String,
+    pub inverse_ratio: U256,
+    pub formatted_inverse_ratio: String,
+}
+impl_wasm_traits!(RaindexOrderQuoteValue);
 
 #[wasm_export]
 impl RaindexOrder {

--- a/crates/common/src/raindex_client/vaults.rs
+++ b/crates/common/src/raindex_client/vaults.rs
@@ -503,7 +503,7 @@ impl RaindexVault {
         unchecked_return_type = "AccountBalance"
     )]
     pub async fn get_owner_balance_wasm_binding(&self) -> Result<AccountBalance, RaindexError> {
-        let balance = self.clone().get_owner_balance(self.owner).await?;
+        let balance = self.get_owner_balance(self.owner).await?;
         let decimals = self.token.decimals.try_into()?;
         let account_balance = AccountBalance {
             balance,
@@ -513,7 +513,7 @@ impl RaindexVault {
     }
 }
 impl RaindexVault {
-    pub async fn get_owner_balance(self, owner: Address) -> Result<U256, RaindexError> {
+    pub async fn get_owner_balance(&self, owner: Address) -> Result<U256, RaindexError> {
         let rpcs = {
             let raindex_client = self
                 .raindex_client

--- a/packages/orderbook/test/js_api/raindexClient.test.ts
+++ b/packages/orderbook/test/js_api/raindexClient.test.ts
@@ -6,13 +6,11 @@ import {
 	SgOrder,
 	SgTrade,
 	OrderPerformance,
-	VaultVolume,
 	SgVault,
 	SgTransaction,
 	SgAddOrderWithOrder,
 	SgRemoveOrderWithOrder,
-	Hex,
-	RaindexVaultVolume
+	Hex
 } from '../../dist/cjs';
 import { getLocal } from 'mockttp';
 
@@ -794,13 +792,21 @@ describe('Rain Orderbook JS API Package Bindgen Tests - Raindex Client', async f
 			);
 
 			const result = extractWasmEncodedData(await order.getQuotes());
+
+			assert.equal(result.length, 1);
 			assert.deepEqual(result, [
 				{
 					pair: { pairName: 'WFLR/sFLR', inputIndex: 0, outputIndex: 0 },
 					blockNumber: 1,
 					data: {
 						maxOutput: '0x1',
-						ratio: '0x2'
+						formattedMaxOutput: '0.000000000000000001',
+						maxInput: '0x2',
+						formattedMaxInput: '0.000000000000000000000000000000000002',
+						ratio: '0x2',
+						formattedRatio: '0.000000000000000002',
+						inverseRatio: '0x604be73de4838ad9a5cf8800000000',
+						formattedInverseRatio: '500000000000000000'
 					},
 					success: true,
 					error: undefined

--- a/packages/ui-components/src/__tests__/TanstackOrderQuote.test.ts
+++ b/packages/ui-components/src/__tests__/TanstackOrderQuote.test.ts
@@ -45,7 +45,10 @@ describe('TanstackOrderQuote component', () => {
 					success: true,
 					block_number: '0x123',
 					pair: { pairName: 'ETH/USDT', inputIndex: 0, outputIndex: 1 },
-					data: { maxOutput: '0x158323e942e36d8c', ratio: '0x5b16799fcb6114f7' },
+					data: {
+						formattedMaxOutput: '1.550122181502135692',
+						formattedRatio: '6.563567234157974775'
+					},
 					error: undefined
 				}
 			]
@@ -77,14 +80,14 @@ describe('TanstackOrderQuote component', () => {
 					success: true,
 					block_number: '0x123',
 					pair: { pairName: 'ETH/USDT', inputIndex: 0, outputIndex: 1 },
-					data: { maxOutput: '0x158323e942e36d8c', ratio: '0x5b16799fcb6114f7' },
+					data: { formattedMaxOutput: '1.550122181502135692' },
 					error: undefined
 				},
 				{
 					success: true,
 					block_number: '0x123',
 					pair: { pairName: 'BTC/USDT', inputIndex: 0, outputIndex: 1 },
-					data: { maxOutput: '0x54fa82f5c7001dad', ratio: '0x53e0089714d06709' },
+					data: { formattedMaxOutput: '6.123350635480882605' },
 					error: undefined
 				}
 			]
@@ -96,14 +99,20 @@ describe('TanstackOrderQuote component', () => {
 					success: true,
 					block_number: '0x123',
 					pair: { pairName: 'ETH/USDT', inputIndex: 0, outputIndex: 1 },
-					data: { maxOutput: '0x5282713eceeccb5e', ratio: '0x577fe09a8775137c' },
+					data: {
+						formattedMaxOutput: '5.945438972656012126',
+						formattedRatio: '6.305004957644166012'
+					},
 					error: undefined
 				},
 				{
 					success: true,
 					block_number: '0x123',
 					pair: { pairName: 'BTC/USDT', inputIndex: 0, outputIndex: 1 },
-					data: { maxOutput: '0x5430775053da5e53', ratio: '0x5a01719c871bb83f' },
+					data: {
+						formattedMaxOutput: '6.066479884955967059',
+						formattedRatio: '6.485589855485802559'
+					},
 					error: undefined
 				}
 			]
@@ -190,7 +199,11 @@ describe('TanstackOrderQuote component', () => {
 					success: true,
 					block_number: '0x123',
 					pair: { pairName: 'ETH/USDT', inputIndex: 0, outputIndex: 1 },
-					data: { maxOutput: '0x158323e942e36d8c', ratio: '0x0' },
+					data: {
+						formattedMaxOutput: '1.550122181502135692',
+						formattedRatio: '0',
+						formattedInverseRatio: '0'
+					},
 					error: undefined
 				}
 			]

--- a/packages/ui-components/src/lib/components/detail/TanstackOrderQuote.svelte
+++ b/packages/ui-components/src/lib/components/detail/TanstackOrderQuote.svelte
@@ -7,7 +7,7 @@
 	import { QKEY_ORDER_QUOTE } from '../../queries/keys';
 	import { formatUnits, hexToNumber, isHex } from 'viem';
 	import { createQuery, useQueryClient } from '@tanstack/svelte-query';
-	import type { RaindexOrder } from '@rainlanguage/orderbook';
+	import type { RaindexOrder, RaindexOrderQuote } from '@rainlanguage/orderbook';
 	import {
 		Table,
 		TableBody,
@@ -43,7 +43,7 @@
 		}
 	};
 
-	$: orderQuoteQuery = createQuery<BatchOrderQuotesResponse[]>({
+	$: orderQuoteQuery = createQuery<RaindexOrderQuote[]>({
 		queryKey: [order.id, QKEY_ORDER_QUOTE + order.id],
 		queryFn: async () => {
 			const result = await order.getQuotes(blockNumber);
@@ -112,21 +112,13 @@
 					{#if item.success && item.data}
 						<TableBodyRow data-testid="bodyRow">
 							<TableBodyCell>{item.pair.pairName}</TableBodyCell>
-							<TableBodyCell>{formatUnits(BigInt(item.data.maxOutput), 18)}</TableBodyCell>
+							<TableBodyCell>{item.data.formattedMaxOutput}</TableBodyCell>
 							<TableBodyCell
-								>{formatUnits(BigInt(item.data.ratio), 18)}
-								<span class="text-gray-400"
-									>({BigInt(item.data.ratio) > 0n
-										? formatUnits(10n ** 36n / BigInt(item.data.ratio), 18)
-										: '0'})</span
+								>{item.data.formattedRatio}
+								<span class="text-gray-400">({item.data.formattedInverseRatio})</span
 								></TableBodyCell
 							>
-							<TableBodyCell
-								>{formatUnits(
-									BigInt(item.data.maxOutput) * BigInt(item.data.ratio),
-									36
-								)}</TableBodyCell
-							>
+							<TableBodyCell>{item.data.formattedMaxInput}</TableBodyCell>
 							<TableBodyCell>
 								{#if handleQuoteDebugModal}
 									<button

--- a/packages/ui-components/src/lib/components/detail/TanstackOrderQuote.svelte
+++ b/packages/ui-components/src/lib/components/detail/TanstackOrderQuote.svelte
@@ -3,9 +3,8 @@
 	import { invalidateTanstackQueries } from '$lib/queries/queryClient';
 	import Refresh from '../icon/Refresh.svelte';
 	import EditableSpan from '../EditableSpan.svelte';
-	import { type BatchOrderQuotesResponse } from '@rainlanguage/orderbook';
 	import { QKEY_ORDER_QUOTE } from '../../queries/keys';
-	import { formatUnits, hexToNumber, isHex } from 'viem';
+	import { hexToNumber, isHex } from 'viem';
 	import { createQuery, useQueryClient } from '@tanstack/svelte-query';
 	import type { RaindexOrder, RaindexOrderQuote } from '@rainlanguage/orderbook';
 	import {


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

See issue: https://github.com/rainlanguage/rain.orderbook/issues/1968

This PR updates the return type of the order quotes logic to include pre-formatted strings.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ability to fetch and display user token balances directly from vaults, with both raw and formatted values.
  * Enhanced order quote data to include formatted string outputs and additional computed fields for clearer presentation.

* **Refactor**
  * Updated components and services to use new balance retrieval and formatted quote structures, removing direct blockchain interaction logic from UI components.
  * Centralized balance fetching logic within the vault abstraction for improved maintainability.

* **Bug Fixes**
  * Improved error handling and validation when fetching user balances and displaying order quotes.

* **Tests**
  * Expanded and updated tests to cover new balance and quote formats, ensuring accurate display and behavior across components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->