### PR TITLE
Add withdraw all buttons on Vaults and Order Details pages

### DIFF
--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -18,6 +18,7 @@ pub mod types;
 pub mod unit_tests;
 pub mod utils;
 pub mod withdraw;
+pub mod withdraw_multiple;
 pub use dotrain;
 pub use dotrain_lsp;
 #[cfg(test)]

--- a/crates/common/src/raindex_client/mod.rs
+++ b/crates/common/src/raindex_client/mod.rs
@@ -34,6 +34,7 @@ pub mod remove_orders;
 pub mod trades;
 pub mod transactions;
 pub mod vaults;
+pub mod vaults_list;
 
 #[derive(Serialize, Deserialize, Debug, Clone, Tsify)]
 pub struct ChainIds(#[tsify(type = "number[]")] pub Vec<u32>);

--- a/crates/common/src/raindex_client/orders.rs
+++ b/crates/common/src/raindex_client/orders.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::raindex_client::vaults_list::VaultsList;
 use crate::{
     meta::TryDecodeRainlangSource,
     raindex_client::{
@@ -139,6 +140,31 @@ impl RaindexOrder {
     pub fn trades_count(&self) -> u16 {
         self.trades_count
     }
+
+    fn get_io_by_type(&self, vault_type: RaindexVaultType) -> Vec<RaindexVault> {
+        let vaults = self.vaults();
+        vaults
+            .iter()
+            .filter(|v| matches!(v.vault_type(), Some(vault_type)))
+            .cloned()
+            .collect()
+    }
+    #[wasm_bindgen(getter = vaultsList, unchecked_return_type = "VaultsList")]
+    pub fn vaults_list(&self) -> VaultsList {
+        VaultsList::new(self.vaults())
+    }
+    #[wasm_bindgen(getter = inputsList, unchecked_return_type = "VaultsList")]
+    pub fn inputs_list(&self) -> VaultsList {
+        VaultsList::new(self.get_io_by_type(RaindexVaultType::Input))
+    }
+    #[wasm_bindgen(getter = outputsList, unchecked_return_type = "VaultsList")]
+    pub fn outputs_list(&self) -> VaultsList {
+        VaultsList::new(self.get_io_by_type(RaindexVaultType::Output))
+    }
+    #[wasm_bindgen(getter = inputsOutputsList, unchecked_return_type = "VaultsList")]
+    pub fn inputs_outputs_list(&self) -> VaultsList {
+        VaultsList::new(self.get_io_by_type(RaindexVaultType::InputOutput))
+    }
 }
 #[cfg(not(target_family = "wasm"))]
 impl RaindexOrder {
@@ -186,6 +212,27 @@ impl RaindexOrder {
     }
     pub fn trades_count(&self) -> u16 {
         self.trades_count
+    }
+
+    fn get_io_by_type(&self, vault_type: RaindexVaultType) -> Vec<RaindexVault> {
+        let vaults = self.vaults();
+        vaults
+            .iter()
+            .filter(|v| matches!(v.vault_type(), Some(vault_type)))
+            .cloned()
+            .collect()
+    }
+    pub fn vaults_list(&self) -> VaultsList {
+        VaultsList::new(self.vaults())
+    }
+    pub fn inputs_list(&self) -> VaultsList {
+        VaultsList::new(self.get_io_by_type(RaindexVaultType::Input))
+    }
+    pub fn outputs_list(&self) -> VaultsList {
+        VaultsList::new(self.get_io_by_type(RaindexVaultType::Output))
+    }
+    pub fn inputs_outputs_list(&self) -> VaultsList {
+        VaultsList::new(self.get_io_by_type(RaindexVaultType::InputOutput))
     }
 }
 

--- a/crates/common/src/raindex_client/vaults_list.rs
+++ b/crates/common/src/raindex_client/vaults_list.rs
@@ -1,0 +1,487 @@
+#[cfg(not(target_family = "wasm"))]
+use alloy::primitives::U256;
+use alloy::{primitives::Bytes, sol_types::SolValue};
+use rain_orderbook_bindings::OrderBook::multicallCall;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use wasm_bindgen_utils::prelude::*;
+
+use crate::raindex_client::vaults::RaindexVault;
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[wasm_bindgen]
+pub struct VaultsList(Vec<RaindexVault>);
+
+impl VaultsList {
+    pub fn new(vaults: Vec<RaindexVault>) -> Self {
+        Self(vaults)
+    }
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+    pub fn get_vaults(&self) -> &Vec<RaindexVault> {
+        &self.0
+    }
+
+    pub fn get_withdrawable_vaults(&self) -> Vec<&RaindexVault> {
+        self.0
+            .iter()
+            .filter(|vault| {
+                #[cfg(target_family = "wasm")]
+                {
+                    // Use formatted_balance for checking non-zero balance in WASM
+                    !vault.formatted_balance().is_empty() && vault.formatted_balance() != "0"
+                }
+                #[cfg(not(target_family = "wasm"))]
+                {
+                    vault.balance() > U256::ZERO
+                }
+            })
+            .collect()
+    }
+    pub async fn get_withdraw_calldata(&self) -> Result<Bytes, VaultsListError> {
+        let mut calldatas: Vec<Bytes> = Vec::new();
+        let vaults_to_withdraw: Vec<&RaindexVault> = self.get_withdrawable_vaults();
+
+        for vault in vaults_to_withdraw {
+            let amount = {
+                #[cfg(target_family = "wasm")]
+                {
+                    vault.formatted_balance()
+                }
+                #[cfg(not(target_family = "wasm"))]
+                {
+                    vault.balance().to_string()
+                }
+            };
+
+            match vault.get_withdraw_calldata(amount).await {
+                Ok(calldata) => calldatas.push(calldata),
+                Err(e) => return Err(VaultsListError::WithdrawMulticallError(e.to_readable_msg())),
+            }
+        }
+
+        let multicall = multicallCall { data: calldatas };
+        let encoded = multicall.data.abi_encode();
+        Ok(encoded.into())
+    }
+}
+
+#[wasm_export]
+impl VaultsList {
+    /// Creates a new VaultsList from an array of RaindexVault objects
+    ///
+    /// ## Examples
+    ///
+    /// ```javascript
+    /// const vaultsList = VaultsList.new([vault1, vault2, vault3]);
+    /// ```
+    #[wasm_export(
+        js_name = "new",
+        return_description = "A new VaultsList instance",
+        preserve_js_class
+    )]
+    pub fn new_wasm(
+        #[wasm_export(param_description = "Array of RaindexVault objects")] vaults: Vec<
+            RaindexVault,
+        >,
+    ) -> Result<VaultsList, VaultsListError> {
+        Ok(Self::new(vaults))
+    }
+
+    /// Creates a VaultsList from a JavaScript array using from() pattern
+    ///
+    /// ## Examples
+    ///
+    /// ```javascript
+    /// const vaultsList = VaultsList.from([vault1, vault2, vault3]);
+    /// ```
+    #[wasm_export(
+        js_name = "from",
+        return_description = "A new VaultsList instance",
+        preserve_js_class
+    )]
+    pub fn from_wasm(
+        #[wasm_export(param_description = "Array of RaindexVault objects")] vaults: Vec<
+            RaindexVault,
+        >,
+    ) -> Result<VaultsList, VaultsListError> {
+        Ok(Self::new(vaults))
+    }
+
+    /// Returns the number of vaults in the list
+    ///
+    /// ## Examples
+    ///
+    /// ```javascript
+    /// const count = vaultsList.length;
+    /// console.log(`Found ${count} vaults`);
+    /// ```
+    #[wasm_export(
+        js_name = "length",
+        getter,
+        return_description = "Number of vaults in the list",
+        unchecked_return_type = "number"
+    )]
+    pub fn length_wasm(&self) -> Result<u32, VaultsListError> {
+        Ok(self.len() as u32)
+    }
+
+    /// Checks if the vaults list is empty
+    ///
+    /// ## Examples
+    ///
+    /// ```javascript
+    /// if (vaultsList.isEmpty) {
+    ///   console.log("No vaults found");
+    /// }
+    /// ```
+    #[wasm_export(
+        js_name = "isEmpty",
+        getter,
+        return_description = "True if the list is empty",
+        unchecked_return_type = "boolean"
+    )]
+    pub fn is_empty_wasm(&self) -> Result<bool, VaultsListError> {
+        Ok(self.is_empty())
+    }
+
+    /// Returns all vaults in the list
+    ///
+    /// ## Examples
+    ///
+    /// ```javascript
+    /// const allVaults = vaultsList.getVaults();
+    /// allVaults.forEach(vault => {
+    ///   console.log(`Vault ID: ${vault.id}, Balance: ${vault.formattedBalance}`);
+    /// });
+    /// ```
+    #[wasm_export(
+        js_name = "getVaults",
+        return_description = "Array of all vaults",
+        unchecked_return_type = "RaindexVault[]",
+        preserve_js_class
+    )]
+    pub fn get_vaults_wasm(&self) -> Result<Vec<RaindexVault>, VaultsListError> {
+        Ok(self.get_vaults().clone())
+    }
+
+    /// Returns only vaults that have a balance greater than zero
+    ///
+    /// ## Examples
+    ///
+    /// ```javascript
+    /// const withdrawableVaults = vaultsList.getWithdrawableVaults();
+    /// console.log(`${withdrawableVaults.length} vaults can be withdrawn from`);
+    /// ```
+    #[wasm_export(
+        js_name = "getWithdrawableVaults",
+        return_description = "Array of vaults with non-zero balance",
+        unchecked_return_type = "RaindexVault[]",
+        preserve_js_class
+    )]
+    pub fn get_withdrawable_vaults_wasm(&self) -> Result<Vec<RaindexVault>, VaultsListError> {
+        Ok(self
+            .get_withdrawable_vaults()
+            .into_iter()
+            .cloned()
+            .collect())
+    }
+
+    /// Generates multicall withdraw calldata for all withdrawable vaults
+    ///
+    /// Creates a single transaction that can withdraw from multiple vaults
+    /// at once, optimizing gas costs and transaction efficiency.
+    ///
+    /// ## Examples
+    ///
+    /// ```javascript
+    /// const result = await vaultsList.getWithdrawCalldata();
+    /// if (result.error) {
+    ///   console.error("Error generating calldata:", result.error.readableMsg);
+    ///   return;
+    /// }
+    /// const calldata = result.value;
+    /// // Use calldata for transaction
+    /// ```
+    #[wasm_export(
+        js_name = "getWithdrawCalldata",
+        return_description = "Encoded multicall calldata for withdrawing from all vaults",
+        unchecked_return_type = "Hex",
+        preserve_js_class
+    )]
+    pub async fn get_withdraw_calldata_wasm(&self) -> Result<String, VaultsListError> {
+        let calldata = self.get_withdraw_calldata().await?;
+        Ok(calldata.to_string())
+    }
+}
+
+#[derive(Error, Debug, Clone)]
+pub enum VaultsListError {
+    #[error("Failed to get withdraw multicall: {0}")]
+    WithdrawMulticallError(String),
+}
+
+impl VaultsListError {
+    pub fn to_readable_msg(&self) -> String {
+        match self {
+            VaultsListError::WithdrawMulticallError(err) => {
+                format!("Failed to generate withdraw multicall: {}", err)
+            }
+        }
+    }
+}
+
+impl From<VaultsListError> for JsValue {
+    fn from(value: VaultsListError) -> Self {
+        JsError::new(&value.to_string()).into()
+    }
+}
+
+impl From<VaultsListError> for WasmEncodedError {
+    fn from(value: VaultsListError) -> Self {
+        WasmEncodedError {
+            msg: value.to_string(),
+            readable_msg: value.to_readable_msg(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(not(target_family = "wasm"))]
+    mod non_wasm_tests {
+        use super::*;
+        use crate::raindex_client::{tests::get_test_yaml, RaindexClient};
+        use httpmock::MockServer;
+        use serde_json::{json, Value};
+
+        fn get_vault1_json() -> Value {
+            json!({
+              "id": "0x0123",
+              "owner": "0x0000000000000000000000000000000000000000",
+              "vaultId": "0x10",
+              "balance": "0x00",
+              "token": {
+                "id": "token1",
+                "address": "0x1d80c49bbbcd1c0911346656b529df9e5c2f783d",
+                "name": "Token 1",
+                "symbol": "TKN1",
+                "decimals": "18"
+              },
+              "orderbook": {
+                "id": "0x0000000000000000000000000000000000000000"
+              },
+              "ordersAsOutput": [],
+              "ordersAsInput": [],
+              "balanceChanges": []
+            })
+        }
+
+        fn get_vault2_json() -> Value {
+            json!({
+                "id": "0x0234",
+                "owner": "0x0000000000000000000000000000000000000000",
+                "vaultId": "0x20",
+                "balance": "0x20",
+                "token": {
+                    "id": "token2",
+                    "address": "0x12e605bc104e93b45e1ad99f9e555f659051c2bb",
+                    "name": "Token 2",
+                    "symbol": "TKN2",
+                    "decimals": "18"
+                },
+                "orderbook": {
+                    "id": "0x0000000000000000000000000000000000000000"
+                },
+                "ordersAsOutput": [],
+                "ordersAsInput": [],
+                "balanceChanges": []
+            })
+        }
+
+        async fn get_vaults() -> Vec<RaindexVault> {
+            let sg_server = MockServer::start_async().await;
+            sg_server.mock(|when, then| {
+                when.path("/sg1");
+                then.status(200).json_body_obj(&json!({
+                    "data": {
+                        "vaults": [get_vault1_json()]
+                    }
+                }));
+            });
+            sg_server.mock(|when, then| {
+                when.path("/sg2");
+                then.status(200).json_body_obj(&json!({
+                    "data": {
+                        "vaults": [get_vault2_json()]
+                    }
+                }));
+            });
+
+            let raindex_client = RaindexClient::new(
+                vec![get_test_yaml(
+                    &sg_server.url("/sg1"),
+                    &sg_server.url("/sg2"),
+                    // not used
+                    &sg_server.url("/rpc1"),
+                    &sg_server.url("/rpc2"),
+                )],
+                None,
+            )
+            .unwrap();
+            let vaults = raindex_client.get_vaults(None, None, None).await.unwrap();
+            vaults
+        }
+
+        #[tokio::test]
+        async fn test_get_vaults_not_empty() {
+            let vaults_list = VaultsList::new(get_vaults().await);
+            assert_eq!(vaults_list.len(), 2);
+        }
+
+        #[tokio::test]
+        async fn test_get_withdrawable_vaults() {
+            let vaults_list = VaultsList::new(get_vaults().await);
+            let withdrawable_vaults = vaults_list.get_withdrawable_vaults();
+            assert_eq!(withdrawable_vaults.len(), 1);
+            assert!(withdrawable_vaults[0].id().to_string() == "0x0234"); // vault2 has non-zero balance
+        }
+
+        #[tokio::test]
+        async fn test_get_withdraw_calldata() {
+            let vaults_list = VaultsList::new(get_vaults().await);
+
+            let result = vaults_list.get_withdraw_calldata().await;
+            let calldata = result.unwrap();
+            assert!(!calldata.is_empty());
+            assert!(calldata.len() > 2); // should contain vault2's ID
+        }
+    }
+
+    #[test]
+    fn test_vaults_list_new_empty() {
+        let vaults_list = VaultsList::new(vec![]);
+
+        assert_eq!(vaults_list.len(), 0);
+        assert!(vaults_list.is_empty());
+    }
+
+    #[test]
+    fn test_get_vaults_empty() {
+        let vaults_list = VaultsList::new(vec![]);
+        assert_eq!(vaults_list.len(), 0);
+    }
+
+    #[test]
+    fn test_vaults_list_error_readable_msg() {
+        let error = VaultsListError::WithdrawMulticallError("test error".to_string());
+        let readable_msg = error.to_readable_msg();
+        assert_eq!(
+            readable_msg,
+            "Failed to generate withdraw multicall: test error"
+        );
+    }
+
+    #[test]
+    fn test_vaults_list_error_display() {
+        let error = VaultsListError::WithdrawMulticallError("test error".to_string());
+        let display_msg = format!("{}", error);
+        assert_eq!(display_msg, "Failed to get withdraw multicall: test error");
+    }
+
+    #[test]
+    fn test_vaults_list_error_to_wasm_encoded_error() {
+        let error = VaultsListError::WithdrawMulticallError("test error".to_string());
+        let wasm_error: WasmEncodedError = error.into();
+        assert_eq!(
+            wasm_error.msg,
+            "Failed to get withdraw multicall: test error"
+        );
+        assert_eq!(
+            wasm_error.readable_msg,
+            "Failed to generate withdraw multicall: test error"
+        );
+    }
+
+    #[cfg(target_family = "wasm")]
+    #[test]
+    fn test_vaults_list_error_to_js_value() {
+        let error = VaultsListError::WithdrawMulticallError("test error".to_string());
+        let js_value: JsValue = error.into();
+        // Just test that conversion doesn't panic
+        assert!(!js_value.is_null());
+    }
+
+    #[cfg(target_family = "wasm")]
+    mod wasm_tests {
+        use super::*;
+
+        #[tokio::test]
+        async fn test_wasm_new_empty() {
+            let result = VaultsList::new_wasm(vec![]);
+            assert!(result.is_ok());
+
+            let vaults_list = result.unwrap();
+            assert_eq!(vaults_list.len(), 0);
+        }
+
+        #[tokio::test]
+        async fn test_wasm_from_empty() {
+            let result = VaultsList::from_wasm(vec![]);
+            let vaults_list = result.unwrap();
+            assert_eq!(vaults_list.len(), 0);
+        }
+
+        #[tokio::test]
+        async fn test_wasm_length_empty() {
+            let vaults_list = VaultsList::new(vec![]);
+            let result = vaults_list.length_wasm();
+            assert_eq!(result.unwrap(), 0);
+        }
+
+        #[tokio::test]
+        async fn test_wasm_is_empty() {
+            let empty_list = VaultsList::new(vec![]);
+            let result = empty_list.is_empty_wasm();
+            assert!(result.is_ok());
+            assert!(result.unwrap());
+        }
+
+        #[tokio::test]
+        async fn test_wasm_get_vaults_empty() {
+            let vaults_list = VaultsList::new(vec![]);
+            let result = vaults_list.get_vaults_wasm();
+            assert!(result.is_ok());
+
+            let retrieved_vaults = result.unwrap();
+            assert_eq!(retrieved_vaults.len(), 0);
+        }
+
+        #[tokio::test]
+        async fn test_wasm_get_withdrawable_vaults_empty() {
+            let vaults_list = VaultsList::new(vec![]);
+            let result = vaults_list.get_withdrawable_vaults_wasm();
+            let withdrawable = result.unwrap();
+            assert_eq!(withdrawable.len(), 0);
+        }
+
+        #[tokio::test]
+        async fn test_wasm_get_withdraw_calldata_empty() {
+            let vaults_list = VaultsList::new(vec![]);
+
+            let result = vaults_list.get_withdraw_calldata_wasm().await;
+            assert!(result.is_ok());
+
+            // Should return valid calldata even for empty list
+            let calldata = result.unwrap();
+            assert!(!calldata.is_empty());
+            assert!(calldata.starts_with("0x"));
+        }
+    }
+}

--- a/crates/common/src/transaction.rs
+++ b/crates/common/src/transaction.rs
@@ -4,6 +4,7 @@ use rain_math_float::FloatError;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+pub const TRANSACTION_CONFIRMATIONS: u8 = 4;
 #[cfg(not(target_family = "wasm"))]
 use alloy::{
     network::AnyNetwork,

--- a/crates/common/src/withdraw.rs
+++ b/crates/common/src/withdraw.rs
@@ -36,7 +36,9 @@ impl WithdrawArgs {
         transaction_args: TransactionArgs,
         transaction_status_changed: S,
     ) -> Result<(), WritableTransactionExecuteError> {
-        let (ledger_client, _) = transaction_args.clone().try_into_ledger_client().await?;
+        use crate::transaction::TRANSACTION_CONFIRMATIONS;
+
+        let ledger_client = transaction_args.clone().try_into_ledger_client().await?;
 
         let withdraw_call: withdraw3Call = self.clone().into();
         let params = transaction_args.try_into_write_contract_parameters(
@@ -44,9 +46,14 @@ impl WithdrawArgs {
             transaction_args.orderbook_address,
         )?;
 
-        WriteTransaction::new(ledger_client, params, 4, transaction_status_changed)
-            .execute()
-            .await?;
+        WriteTransaction::new(
+            ledger_client.client,
+            params,
+            TRANSACTION_CONFIRMATIONS,
+            transaction_status_changed,
+        )
+        .execute()
+        .await?;
 
         Ok(())
     }

--- a/crates/common/src/withdraw_multiple.rs
+++ b/crates/common/src/withdraw_multiple.rs
@@ -1,0 +1,126 @@
+#[cfg(not(target_family = "wasm"))]
+use crate::transaction::TransactionArgs;
+use crate::transaction::WritableTransactionExecuteError;
+use crate::withdraw::WithdrawArgs;
+use alloy::primitives::Bytes;
+use alloy::sol_types::SolCall;
+#[cfg(not(target_family = "wasm"))]
+use alloy_ethers_typecast::transaction::{WriteTransaction, WriteTransactionStatus};
+use rain_orderbook_bindings::OrderBook::multicallCall;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Deserialize, Serialize, Debug)]
+pub struct WithdrawMultipleArgs(pub Vec<WithdrawArgs>);
+
+impl WithdrawMultipleArgs {
+    /// Execute OrderbookV3 withdraw call
+    #[cfg(not(target_family = "wasm"))]
+    pub async fn execute<S: Fn(WriteTransactionStatus<multicallCall>)>(
+        &self,
+        transaction_args: TransactionArgs,
+        transaction_status_changed: S,
+    ) -> Result<(), WritableTransactionExecuteError> {
+        let ledger_client = transaction_args.clone().try_into_ledger_client().await?;
+
+        let withdraw_call = self.get_multicall().await?;
+        let params = transaction_args.try_into_write_contract_parameters(
+            withdraw_call,
+            transaction_args.orderbook_address,
+        )?;
+
+        WriteTransaction::new(ledger_client.client, params, 4, transaction_status_changed)
+            .execute()
+            .await?;
+
+        Ok(())
+    }
+
+    pub async fn get_multicall(&self) -> Result<multicallCall, WritableTransactionExecuteError> {
+        let mut withdraw_calldatas = Vec::new();
+        for args in &self.0 {
+            let withdraw_call: Bytes = args.get_withdraw_calldata().await?.into();
+            withdraw_calldatas.push(withdraw_call);
+        }
+
+        let multicall = multicallCall {
+            data: withdraw_calldatas,
+        };
+        Ok(multicall)
+    }
+
+    pub async fn get_calldata(&self) -> Result<Vec<u8>, WritableTransactionExecuteError> {
+        let multicall = self.get_multicall().await?;
+        let encoded = multicall.abi_encode();
+        Ok(encoded)
+    }
+}
+
+#[cfg(all(test, not(target_family = "wasm")))]
+mod tests {
+    use super::*;
+    use alloy::primitives::{Address, U256};
+    use alloy_ethers_typecast::gas_fee_middleware::GasFeeSpeed;
+    use std::str::FromStr;
+
+    #[tokio::test]
+    async fn test_get_calldata() {
+        let withdraw_1 = WithdrawArgs {
+            token: Address::from_str("0x1234567890abcdef1234567890abcdef12345678").unwrap(),
+            vault_id: U256::from(42),
+            target_amount: U256::from(100),
+        };
+        let withdraw_2 = WithdrawArgs {
+            token: Address::from_str("0xabcdef1234567890abcdef1234567890abcdef12").unwrap(),
+            vault_id: U256::from(84),
+            target_amount: U256::from(200),
+        };
+
+        let multi = WithdrawMultipleArgs(vec![withdraw_1.clone(), withdraw_2.clone()]);
+        let calldata = multi.get_calldata().await.unwrap();
+
+        let expected_calldata = multicallCall {
+            data: vec![
+                withdraw_1.get_withdraw_calldata().await.unwrap().into(),
+                withdraw_2.get_withdraw_calldata().await.unwrap().into(),
+            ],
+        }
+        .abi_encode();
+
+        assert_eq!(calldata, expected_calldata);
+    }
+
+    #[tokio::test]
+    async fn test_withdraw_call_try_into_write_contract_parameters() {
+        let args = TransactionArgs {
+            rpcs: vec!["http://test.com".to_string()],
+            orderbook_address: Address::ZERO,
+            derivation_index: Some(0_usize),
+            chain_id: Some(1),
+            max_priority_fee_per_gas: Some(U256::from(200)),
+            max_fee_per_gas: Some(U256::from(100)),
+            gas_fee_speed: Some(GasFeeSpeed::Fast),
+        };
+
+        let withdraw_1 = WithdrawArgs {
+            token: Address::from_str("0x1234567890abcdef1234567890abcdef12345678").unwrap(),
+            vault_id: U256::from(42),
+            target_amount: U256::from(100),
+        };
+        let withdraw_2 = WithdrawArgs {
+            token: Address::from_str("0xabcdef1234567890abcdef1234567890abcdef12").unwrap(),
+            vault_id: U256::from(84),
+            target_amount: U256::from(200),
+        };
+
+        let multi = WithdrawMultipleArgs(vec![withdraw_1.clone(), withdraw_2.clone()]);
+        let call = multi.get_multicall().await.unwrap();
+
+        let params = args
+            .try_into_write_contract_parameters(call.clone(), Address::ZERO)
+            .unwrap();
+        assert_eq!(params.address, Address::ZERO);
+        assert_eq!(params.call, call);
+        assert_eq!(params.max_priority_fee_per_gas, Some(U256::from(200)));
+        assert_eq!(params.max_fee_per_gas, Some(U256::from(100)));
+    }
+}

--- a/crates/common/src/withdraw_multiple.rs
+++ b/crates/common/src/withdraw_multiple.rs
@@ -20,6 +20,8 @@ impl WithdrawMultipleArgs {
         transaction_args: TransactionArgs,
         transaction_status_changed: S,
     ) -> Result<(), WritableTransactionExecuteError> {
+        use crate::transaction::TRANSACTION_CONFIRMATIONS;
+
         let ledger_client = transaction_args.clone().try_into_ledger_client().await?;
 
         let withdraw_call = self.get_multicall().await?;
@@ -28,9 +30,14 @@ impl WithdrawMultipleArgs {
             transaction_args.orderbook_address,
         )?;
 
-        WriteTransaction::new(ledger_client.client, params, 4, transaction_status_changed)
-            .execute()
-            .await?;
+        WriteTransaction::new(
+            ledger_client.client,
+            params,
+            TRANSACTION_CONFIRMATIONS,
+            transaction_status_changed,
+        )
+        .execute()
+        .await?;
 
         Ok(())
     }

--- a/crates/js_api/src/gui/mod.rs
+++ b/crates/js_api/src/gui/mod.rs
@@ -33,6 +33,7 @@ use wasm_bindgen_utils::{impl_wasm_traits, prelude::*, wasm_export};
 
 mod deposits;
 mod field_values;
+mod multicall;
 mod order_operations;
 mod select_tokens;
 mod state_management;
@@ -651,6 +652,8 @@ pub enum GuiError {
     TokenNotInSelectTokens(String),
     #[error("JavaScript error: {0}")]
     JsError(String),
+    #[error("Invalid calldata: {0}")]
+    InvalidCalldata(String),
     #[error(transparent)]
     DotrainOrderError(#[from] DotrainOrderError),
     #[error(transparent)]
@@ -740,6 +743,8 @@ impl GuiError {
                 format!("The token '{}' is not in the list of selectable tokens defined in the YAML configuration.", token),
             GuiError::JsError(msg) =>
                 format!("A JavaScript error occurred: {}", msg),
+            GuiError::InvalidCalldata(msg) =>
+                format!("Invalid calldata: {}", msg),
             GuiError::DotrainOrderError(err) =>
                 format!("Order configuration error in YAML: {}", err),
             GuiError::ParseGuiConfigSourceError(err) =>
@@ -1804,3 +1809,6 @@ networks:
         }
     }
 }
+
+// Re-export multicall operations
+pub use multicall::*;

--- a/crates/js_api/src/gui/mod.rs
+++ b/crates/js_api/src/gui/mod.rs
@@ -33,7 +33,6 @@ use wasm_bindgen_utils::{impl_wasm_traits, prelude::*, wasm_export};
 
 mod deposits;
 mod field_values;
-mod multicall;
 mod order_operations;
 mod select_tokens;
 mod state_management;
@@ -1809,6 +1808,3 @@ networks:
         }
     }
 }
-
-// Re-export multicall operations
-pub use multicall::*;

--- a/crates/js_api/src/gui/multicall.rs
+++ b/crates/js_api/src/gui/multicall.rs
@@ -1,0 +1,70 @@
+use super::*;
+use alloy::{hex::FromHex, primitives::Bytes, sol_types::SolCall};
+use rain_orderbook_bindings::OrderBook::multicallCall;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Tsify)]
+pub struct MulticallCalldataResult(#[tsify(type = "string")] Bytes);
+impl_wasm_traits!(MulticallCalldataResult);
+
+/// Generates multicall calldata from an array of individual calldatas.
+///
+/// Takes an array of hex-encoded calldata strings and combines them into a single
+/// multicall transaction that executes all of them atomically.
+///
+/// ## Examples
+///
+/// ```javascript
+/// // Get individual calldatas (withdrawals, deposits, etc.)
+/// const calldatas = await Promise.all([
+///   vault1.getWithdrawCalldata(amount1),
+///   vault2.getWithdrawCalldata(amount2),
+///   // ... more calldatas
+/// ]);
+///
+/// // Extract values and handle errors
+/// const calldata_values = calldatas.map(result => {
+///   if (result.error) throw new Error(result.error.readableMsg);
+///   return result.value;
+/// });
+///
+/// // Generate multicall
+/// const result = await generateMulticallCalldata(calldata_values);
+/// if (result.error) {
+///   console.error("Error:", result.error.readableMsg);
+///   return;
+/// }
+/// const multicallCalldata = result.value;
+/// // Use multicallCalldata for transaction
+/// ```
+#[wasm_export(
+    js_name = "generateMulticallCalldata",
+    return_description = "Multicall calldata for executing all provided calldatas atomically"
+)]
+pub fn generate_multicall_calldata(
+    #[wasm_export(param_description = "Array of hex-encoded calldata strings to combine")]
+    calldatas: Vec<String>,
+) -> Result<MulticallCalldataResult, GuiError> {
+    if calldatas.is_empty() {
+        return Err(GuiError::InvalidCalldata(
+            "No calldatas provided".to_string(),
+        ));
+    }
+
+    let mut calls = Vec::new();
+
+    for (index, calldata_str) in calldatas.iter().enumerate() {
+        let calldata_bytes = Bytes::from_hex(calldata_str).map_err(|e| {
+            GuiError::InvalidCalldata(format!(
+                "Failed to parse calldata at index {}: {}",
+                index, e
+            ))
+        })?;
+        calls.push(calldata_bytes);
+    }
+
+    let multicall = multicallCall { data: calls };
+    let encoded = multicall.abi_encode();
+
+    Ok(MulticallCalldataResult(Bytes::from(encoded)))
+}

--- a/crates/js_api/src/lib.rs
+++ b/crates/js_api/src/lib.rs
@@ -3,6 +3,8 @@ pub mod bindings;
 #[cfg(target_family = "wasm")]
 pub mod gui;
 #[cfg(target_family = "wasm")]
+pub mod multicall;
+#[cfg(target_family = "wasm")]
 pub mod yaml;
 
 // re-export other crates to include their wasm bindings as single export point

--- a/crates/js_api/src/multicall.rs
+++ b/crates/js_api/src/multicall.rs
@@ -68,3 +68,39 @@ pub fn generate_multicall_calldata(
 
     Ok(MulticallCalldataResult(Bytes::from(encoded)))
 }
+
+//
+// Errors
+//
+#[derive(Error, Debug)]
+pub enum MulticallError {
+    #[error("Invalid calldata: {0}")]
+    InvalidCalldata(String),
+}
+
+impl MulticallError {
+    pub fn to_readable_msg(&self) -> String {
+        match self {
+            MulticallError::InvalidCalldata(msg) => format!("Invalid calldata: {}", msg),
+        }
+    }
+}
+
+impl From<GuiError> for JsValue {
+    fn from(value: GuiError) -> Self {
+        JsError::new(&value.to_string()).into()
+    }
+}
+
+impl From<GuiError> for WasmEncodedError {
+    fn from(value: GuiError) -> Self {
+        WasmEncodedError {
+            msg: value.to_string(),
+            readable_msg: value.to_readable_msg(),
+        }
+    }
+}
+
+//
+// Tests
+//

--- a/crates/js_api/src/multicall.rs
+++ b/crates/js_api/src/multicall.rs
@@ -8,7 +8,8 @@ use wasm_bindgen_utils::{impl_wasm_traits, prelude::*, wasm_export};
 pub struct MulticallCalldataResult(#[tsify(type = "string")] Bytes);
 impl_wasm_traits!(MulticallCalldataResult);
 
-/// Generates multicall calldata from an array of individual calldatas.
+/// Generates multicall calldata to Orderbook smart contract
+/// from an array of individual calldatas.
 ///
 /// Takes an array of hex-encoded calldata strings and combines them into a single
 /// multicall transaction that executes all of them atomically.

--- a/packages/ui-components/src/__tests__/OrderDetail.test.ts
+++ b/packages/ui-components/src/__tests__/OrderDetail.test.ts
@@ -58,7 +58,8 @@ const defaultProps: ComponentProps<OrderDetail> = {
 	lightweightChartsTheme: readable(darkChartTheme),
 	onRemove: vi.fn(),
 	onDeposit: vi.fn(),
-	onWithdraw: vi.fn()
+	onWithdraw: vi.fn(),
+	onWithdrawAll: vi.fn()
 };
 
 const mockOrder: RaindexOrder = {
@@ -324,5 +325,30 @@ describe('OrderDetail', () => {
 		await user.click(withdrawButton[0]);
 
 		expect(mockOnWithdraw).toHaveBeenCalledWith(mockRaindexClient, mockOrder.vaults[1]);
+	});
+
+	it('calls onWithdrawAll callback when withdraw all button is clicked', async () => {
+		mockMatchesAccount.mockReturnValue(true);
+		const user = userEvent.setup();
+		const mockOnWithdraw = vi.fn();
+
+		render(OrderDetail, {
+			props: {
+				...defaultProps,
+				onWithdrawAll: mockOnWithdraw
+			},
+			context: new Map([['$$_queryClient', queryClient]])
+		});
+
+		await waitFor(() => {
+			expect(screen.getByText('Order')).toBeInTheDocument();
+			expect(screen.getByText('Orderbook')).toBeInTheDocument();
+			expect(screen.getByText('Owner')).toBeInTheDocument();
+			expect(screen.getByText('Created')).toBeInTheDocument();
+		});
+
+		const withdrawButton = screen.getAllByTestId('withdraw-all-button');
+		await user.click(withdrawButton[0]);
+		expect(mockOnWithdraw).toHaveBeenCalledWith(mockRaindexClient, mockOrder.vaults);
 	});
 });

--- a/packages/ui-components/src/__tests__/OrderDetail.test.ts
+++ b/packages/ui-components/src/__tests__/OrderDetail.test.ts
@@ -87,7 +87,7 @@ const mockOrder: RaindexOrder = {
 				symbol: 'MCK',
 				decimals: '18'
 			},
-			balance: BigInt(0),
+			balance: BigInt(10),
 			vaultId: BigInt(2),
 			owner: '0x1234567890123456789012345678901234567890',
 			ordersAsOutput: [],
@@ -105,7 +105,7 @@ const mockOrder: RaindexOrder = {
 				symbol: 'MCK2',
 				decimals: '18'
 			},
-			balance: BigInt(0),
+			balance: BigInt(20),
 			vaultId: BigInt(1),
 			owner: '0x1234567890123456789012345678901234567890',
 			ordersAsOutput: [],

--- a/packages/ui-components/src/__tests__/OrderDetail.test.ts
+++ b/packages/ui-components/src/__tests__/OrderDetail.test.ts
@@ -11,19 +11,19 @@ import OrderDetail from '../lib/components/detail/OrderDetail.svelte';
 import { readable, writable } from 'svelte/store';
 import { darkChartTheme } from '../lib/utils/lightweightChartsThemes';
 import userEvent from '@testing-library/user-event';
-import { useAccount } from '$lib/providers/wallet/useAccount';
 import type { ComponentProps } from 'svelte';
 import { invalidateTanstackQueries } from '$lib/queries/queryClient';
 import { useToasts } from '$lib/providers/toasts/useToasts';
 import { useRaindexClient } from '$lib/hooks/useRaindexClient';
+import { isAddressEq } from '$lib/utils/account';
 
 vi.mock('$lib/hooks/useRaindexClient', () => ({
 	useRaindexClient: vi.fn()
 }));
 
 // Mock the account hook
-vi.mock('$lib/providers/wallet/useAccount', () => ({
-	useAccount: vi.fn()
+vi.mock('$lib/utils/account', () => ({
+	isAddressEq: vi.fn()
 }));
 
 // Mock the js_api functions
@@ -122,7 +122,6 @@ const mockOrder: RaindexOrder = {
 	tradesCount: 0
 } as unknown as RaindexOrder;
 
-const mockMatchesAccount = vi.fn();
 describe('OrderDetail', () => {
 	let queryClient: QueryClient;
 	let mockRaindexClient: RaindexClient;
@@ -131,10 +130,6 @@ describe('OrderDetail', () => {
 		vi.clearAllMocks();
 		vi.resetAllMocks();
 		queryClient = new QueryClient();
-
-		(useAccount as Mock).mockReturnValue({
-			matchesAccount: mockMatchesAccount
-		});
 
 		mockRaindexClient = {
 			getOrderByHash: vi.fn().mockResolvedValue({
@@ -189,7 +184,7 @@ describe('OrderDetail', () => {
 	});
 
 	it('shows remove button if owner wallet matches and order is active', async () => {
-		mockMatchesAccount.mockReturnValue(true);
+		(isAddressEq as Mock).mockReturnValue(true);
 		render(OrderDetail, {
 			props: defaultProps,
 			context: new Map([['$$_queryClient', queryClient]])
@@ -209,7 +204,7 @@ describe('OrderDetail', () => {
 	});
 
 	it('does not show remove button if account does not match owner', async () => {
-		mockMatchesAccount.mockReturnValue(false);
+		(isAddressEq as Mock).mockReturnValue(false);
 
 		render(OrderDetail, {
 			props: defaultProps,
@@ -273,7 +268,7 @@ describe('OrderDetail', () => {
 	});
 
 	it('calls onDeposit callback when deposit button is clicked', async () => {
-		mockMatchesAccount.mockReturnValue(true);
+		(isAddressEq as Mock).mockReturnValue(true);
 		const user = userEvent.setup();
 		const mockOnDeposit = vi.fn();
 
@@ -302,7 +297,7 @@ describe('OrderDetail', () => {
 	});
 
 	it('calls onWithdraw callback when withdraw button is clicked', async () => {
-		mockMatchesAccount.mockReturnValue(true);
+		(isAddressEq as Mock).mockReturnValue(true);
 		const user = userEvent.setup();
 		const mockOnWithdraw = vi.fn();
 
@@ -328,7 +323,7 @@ describe('OrderDetail', () => {
 	});
 
 	it('calls onWithdrawAll callback when withdraw all button is clicked', async () => {
-		mockMatchesAccount.mockReturnValue(true);
+		(isAddressEq as Mock).mockReturnValue(true);
 		const user = userEvent.setup();
 		const mockOnWithdraw = vi.fn();
 

--- a/packages/ui-components/src/lib/components/detail/OrderDetail.svelte
+++ b/packages/ui-components/src/lib/components/detail/OrderDetail.svelte
@@ -231,8 +231,10 @@
 								<div>
 									{key}
 									{#if type === VaultType.InputOutput}
-										<InfoCircleOutline class="h-4 w-4" />
-										<Tooltip>{'These vaults can be an input or an output for this order'}</Tooltip>
+										<InfoCircleOutline class="inline h-4 w-4" />
+										<Tooltip class="z-10">
+											{'These vaults can be an input or an output for this order'}
+										</Tooltip>
 									{/if}
 								</div>
 								<div>

--- a/packages/ui-components/src/lib/components/detail/OrderDetail.svelte
+++ b/packages/ui-components/src/lib/components/detail/OrderDetail.svelte
@@ -209,7 +209,7 @@
 									{/if}
 								</div>
 								<div>
-									{#if filteredVaults.every((vault) => matchesAccount(vault.owner))}
+									{#if filteredVaults.every( (vault) => matchesAccount(vault.owner) ) && filteredVaults.length > 1 && filteredVaults.some((vault) => vault.balance > 0n)}
 										<Button
 											size="xs"
 											on:click={() => onWithdrawAll(raindexClient, filteredVaults)}
@@ -256,7 +256,7 @@
 				{/if}
 			{/each}
 			<!-- If there are different vault types — show additional withdraw all button below all vaults -->
-			{#if data.vaults.every( (vault) => matchesAccount(vault.owner) ) && vaultsGroupedByTypes[VaultType.InputOutput].length !== data.vaults.length}
+			{#if data.vaults.every( (vault) => matchesAccount(vault.owner) ) && vaultsGroupedByTypes[VaultType.InputOutput].length !== data.vaults.length && data.vaults.some((vault) => vault.balance > 0n)}
 				<Button
 					size="xs"
 					on:click={() => onWithdrawAll(raindexClient, data.vaults)}

--- a/packages/ui-components/src/lib/components/detail/OrderDetail.svelte
+++ b/packages/ui-components/src/lib/components/detail/OrderDetail.svelte
@@ -34,8 +34,8 @@
 	} from '@rainlanguage/orderbook';
 	import { useToasts } from '$lib/providers/toasts/useToasts';
 	import { useRaindexClient } from '$lib/hooks/useRaindexClient';
-	import { isAddress, isAddressEqual } from 'viem';
 	import type { VaultsGroupedByType } from '../../types/vaults';
+	import { isAddressEq } from '$lib/utils/account';
 
 	export let handleQuoteDebugModal: QuoteDebugModalHandler | undefined = undefined;
 	export let handleDebugTradeModal: DebugTradeModalHandler | undefined = undefined;
@@ -83,15 +83,6 @@
 			return result.value;
 		}
 	});
-
-	const matchesAddress = (a?: Address | null, b?: Address | null) => {
-		try {
-			if (!a || !b) return false;
-			return isAddress(a) && isAddress(b) && isAddressEqual(a, b);
-		} catch {
-			return false;
-		}
-	};
 
 	const interval = setInterval(async () => {
 		await invalidateTanstackQueries(queryClient, [orderHash]);
@@ -146,7 +137,7 @@
 	// Even if some vaults of that type has zero balance
 	$: getVaultsGroupFiltered = (type: RaindexVaultType) => {
 		return vaultsGroupedByTypes[type].filter(
-			(vault) => matchesAddress($account, vault.owner) && vault.balance > 0n
+			(vault) => isAddressEq($account, vault.owner) && vault.balance > 0n
 		);
 	};
 
@@ -160,7 +151,7 @@
 		if (!$orderDetailQuery.data?.vaults) return false;
 		const { vaults } = $orderDetailQuery.data;
 		const filteredVaults = vaults.filter(
-			(vault) => matchesAddress($account, vault.owner) && vault.balance > 0n
+			(vault) => isAddressEq($account, vault.owner) && vault.balance > 0n
 		);
 		return (
 			filteredVaults.length > 1 &&
@@ -183,7 +174,7 @@
 			</div>
 
 			<div class="flex items-center gap-2">
-				{#if matchesAddress($account, data.owner)}
+				{#if isAddressEq($account, data.owner)}
 					{#if data.active}
 						<Button
 							on:click={() => onRemove(raindexClient, data)}
@@ -258,7 +249,7 @@
 								{#each filteredVaults as vault}
 									<ButtonVaultLink tokenVault={vault} {chainId} {orderbookAddress}>
 										<svelte:fragment slot="buttons">
-											{#if matchesAddress($account, vault.owner)}
+											{#if isAddressEq($account, vault.owner)}
 												<div class="flex gap-1">
 													<Button
 														color="light"

--- a/packages/ui-components/src/lib/components/detail/OrderDetail.svelte
+++ b/packages/ui-components/src/lib/components/detail/OrderDetail.svelte
@@ -113,8 +113,7 @@
 
 	$: vaultsGroupedByTypes =
 		$orderDetailQuery?.data?.vaults?.reduce((acc, vault) => {
-			const type = vault.vaultType || 'inputOutput';
-			if (!acc[type]) acc[type] = [];
+			const type: RaindexVaultType = vault.vaultType ?? 'inputOutput';
 			acc[type].push(vault);
 			return acc;
 		}, getDefaultVaultsGroupedByType()) || getDefaultVaultsGroupedByType();

--- a/packages/ui-components/src/lib/components/tables/VaultsListTable.svelte
+++ b/packages/ui-components/src/lib/components/tables/VaultsListTable.svelte
@@ -9,7 +9,8 @@
 		TableBodyCell,
 		TableHeadCell,
 		Checkbox,
-		Tooltip
+		Tooltip,
+		Label
 	} from 'flowbite-svelte';
 	import { goto } from '$app/navigation';
 	import { DotsVerticalOutline } from 'flowbite-svelte-icons';
@@ -193,8 +194,10 @@
 		<svelte:fragment slot="bodyRow" let:item>
 			{#if onWithdrawMultiple && $account}
 				{#if matchesAccount(item.owner)}
-					<TableBodyCell tdClass="px-2 py-4">
-						<div class="relative">
+					<TableBodyCell tdClass="relative p-0" on:click={(e) => e.stopPropagation()}>
+						<Label
+							class="absolute bottom-px left-px right-px top-px flex cursor-pointer items-center justify-center"
+						>
 							<Checkbox
 								checked={isVaultSelected(item)}
 								disabled={isVaultDisabled(item)}
@@ -205,7 +208,7 @@
 							{#if isVaultEmpty(item)}
 								<Tooltip class="w-auto text-xs" placement="top">Vault is empty</Tooltip>
 							{/if}
-						</div>
+						</Label>
 					</TableBodyCell>
 				{:else}
 					<TableBodyCell tdClass="px-2 py-4">

--- a/packages/ui-components/src/lib/components/tables/VaultsListTable.svelte
+++ b/packages/ui-components/src/lib/components/tables/VaultsListTable.svelte
@@ -51,7 +51,8 @@
 		  ) => void)
 		| undefined = undefined;
 	export let onWithdrawMultiple:
-		| ((raindexClient: RaindexClient, vaults: RaindexVault[]) => void)
+		| ((raindexClient: RaindexClient, vaults: RaindexVault[]) => Promise<boolean>)
+		| undefined = undefined;
 
 	const { account, matchesAccount } = useAccount();
 	const raindexClient = useRaindexClient();
@@ -87,8 +88,10 @@
 
 	const handleWithdrawAll = async () => {
 		if (onWithdrawMultiple) {
-			await onWithdrawMultiple(raindexClient, selectedVaults);
-			selectedVaults = []; // Clear selection after withdrawal
+			const success = await onWithdrawMultiple(raindexClient, selectedVaults);
+			if (success) {
+				selectedVaults = []; // Clear selection after withdrawal
+			}
 		}
 	};
 

--- a/packages/ui-components/src/lib/components/tables/VaultsListTable.svelte
+++ b/packages/ui-components/src/lib/components/tables/VaultsListTable.svelte
@@ -1,4 +1,6 @@
 <script lang="ts" generics="T">
+	import { isAddressEq } from '../../utils/account';
+
 	import { toHex } from 'viem';
 	import { useRaindexClient } from '$lib/hooks/useRaindexClient';
 
@@ -54,7 +56,7 @@
 		| ((raindexClient: RaindexClient, vaults: RaindexVault[]) => Promise<boolean>)
 		| undefined = undefined;
 
-	const { account, matchesAccount } = useAccount();
+	const { account } = useAccount();
 	const raindexClient = useRaindexClient();
 
 	// State for selected vaults for multiple withdrawal
@@ -69,9 +71,9 @@
 		return vault.balance === 0n;
 	};
 
-	const isVaultDisabled = (vault: RaindexVault): boolean => {
+	$: isVaultDisabled = (vault: RaindexVault): boolean => {
 		if (isVaultEmpty(vault)) return true;
-		if (!matchesAccount(vault.owner)) return true; // Only allow selection of user's own vaults
+		if (!isAddressEq($account, vault.owner)) return true; // Only allow selection of user's own vaults
 		if (selectedVaults.length === 0) return false;
 		return vault.chainId !== selectedVaults[0].chainId;
 	};
@@ -196,7 +198,7 @@
 
 		<svelte:fragment slot="bodyRow" let:item>
 			{#if onWithdrawMultiple && $account}
-				{#if matchesAccount(item.owner)}
+				{#if isAddressEq($account, item.owner)}
 					<TableBodyCell tdClass="relative p-0" on:click={(e) => e.stopPropagation()}>
 						<Label
 							class="absolute bottom-px left-px right-px top-px flex cursor-pointer items-center justify-center"
@@ -274,7 +276,7 @@
 					</div>
 				{/if}
 			</TableBodyCell>
-			{#if handleDepositModal && handleWithdrawModal && matchesAccount(item.owner)}
+			{#if handleDepositModal && handleWithdrawModal && isAddressEq($account, item.owner)}
 				<TableBodyCell tdClass="px-0 text-right">
 					<Button
 						color="alternative"

--- a/packages/ui-components/src/lib/components/tables/VaultsListTable.svelte
+++ b/packages/ui-components/src/lib/components/tables/VaultsListTable.svelte
@@ -170,14 +170,27 @@
 				<div class="flex items-center gap-x-6">
 					<div class="text-3xl font-medium dark:text-white">Vaults</div>
 					{#if onWithdrawMultiple && $account}
-						<Button
-							color="alternative"
-							disabled={selectedVaults.length === 0}
-							class={selectedVaults.length === 0 ? 'text-gray-400' : ''}
-							on:click={handleWithdrawAll}
-						>
-							Withdraw all ({selectedVaults.length})
-						</Button>
+						<div class="flex items-center gap-x-2">
+							<Button
+								color="alternative"
+								disabled={selectedVaults.length === 0}
+								class={selectedVaults.length === 0 ? 'text-gray-400' : ''}
+								on:click={handleWithdrawAll}
+							>
+								Withdraw all ({selectedVaults.length})
+							</Button>
+							<Button
+								color="alternative"
+								disabled={selectedVaults.length === 0}
+								class={selectedVaults.length === 0 ? 'text-gray-400' : ''}
+								style="font-size: 1.5em; line-height: 20px;"
+								on:click={() => {
+									selectedVaults = [];
+								}}
+							>
+								&times;
+							</Button>
+						</div>
 					{/if}
 				</div>
 			</div>

--- a/packages/ui-components/src/lib/components/tables/VaultsListTable.svelte
+++ b/packages/ui-components/src/lib/components/tables/VaultsListTable.svelte
@@ -205,8 +205,14 @@
 								on:change={() => toggleVaultSelection(item)}
 								class="cursor-pointer"
 							/>
-							{#if isVaultEmpty(item)}
-								<Tooltip class="w-auto text-xs" placement="top">Vault is empty</Tooltip>
+							{#if isVaultDisabled(item)}
+								<Tooltip class="w-auto text-xs" placement="top">
+									{#if isVaultEmpty(item)}
+										Vault is empty
+									{:else if selectedVaults.length > 0 && item.chainId !== selectedVaults[0].chainId}
+										Vault is on a different chain
+									{/if}
+								</Tooltip>
 							{/if}
 						</Label>
 					</TableBodyCell>

--- a/packages/ui-components/src/lib/providers/transactions/TransactionManager.ts
+++ b/packages/ui-components/src/lib/providers/transactions/TransactionManager.ts
@@ -176,8 +176,8 @@ export class TransactionManager {
 	 * @param args - Configuration for the withdrawal transaction.
 	 * @param args.txHash - Hash of the transaction to track.
 	 * @param args.chainId - Chain ID where the transaction is being executed.
-	 * @param args.queryKey - The ID of the vault from which funds are withdrawn (used for query invalidation and UI links).
-	 * @param args.entity - The `SgVault` entity associated with this transaction.
+	 * @param args.queryKey - The query key to invalidate, but for multiple vaults withdrawal it's QKEY_VAULTS
+	 * @param args.vaults - The list of RaindexVault instances from which funds are withdrawn.
 	 * @returns A new Transaction instance configured for withdrawal.
 	 * @example
 	 * const tx = await manager.createWithdrawTransaction({

--- a/packages/ui-components/src/lib/providers/transactions/TransactionManager.ts
+++ b/packages/ui-components/src/lib/providers/transactions/TransactionManager.ts
@@ -195,7 +195,9 @@ export class TransactionManager {
 		const successMessage = 'Withdrawal successful.';
 		const { chainId, vaults, txHash, queryKey, raindexClient } = args;
 
-		const orderbook = vaults[0].orderbook; // Assuming all vaults share the same orderbook
+		// All vaults must share the same orderbook for multicall transactions
+		// It should be validated before calling this method
+		const orderbook = vaults[0].orderbook;
 		const explorerLink = await getExplorerLink(txHash, chainId, 'tx');
 		const toastLinks: ToastLink[] = [
 			{

--- a/packages/ui-components/src/lib/types/transaction.ts
+++ b/packages/ui-components/src/lib/types/transaction.ts
@@ -12,6 +12,7 @@ export type VaultActionArgs = {
 export enum TransactionName {
 	REMOVAL = 'Order Removal',
 	WITHDRAWAL = 'Vault Withdrawal',
+	WITHDRAWAL_MULTIPLE = 'Multiple Vault Withdrawals',
 	APPROVAL = 'Token Approval',
 	DEPOSIT = 'Vault Deposit'
 }

--- a/packages/ui-components/src/lib/types/vaults.ts
+++ b/packages/ui-components/src/lib/types/vaults.ts
@@ -1,0 +1,3 @@
+import type { RaindexVault, RaindexVaultType } from '@rainlanguage/orderbook';
+
+export type VaultsGroupedByType = Record<RaindexVaultType, RaindexVault[]>;

--- a/packages/ui-components/src/lib/utils/account.ts
+++ b/packages/ui-components/src/lib/utils/account.ts
@@ -5,10 +5,10 @@ import { isAddress, isAddressEqual, type Address } from 'viem';
 // If either address is undefined or null, it returns false.
 // If both addresses are valid, it checks for equality using isAddressEqual.
 export const isAddressEq = (a?: Address | null, b?: Address | null) => {
-  try {
-    if (!a || !b) return false;
-    return isAddress(a) && isAddress(b) && isAddressEqual(a, b);
-  } catch {
-    return false;
-  }
+	try {
+		if (!a || !b) return false;
+		return isAddress(a) && isAddress(b) && isAddressEqual(a, b);
+	} catch {
+		return false;
+	}
 };

--- a/packages/ui-components/src/lib/utils/account.ts
+++ b/packages/ui-components/src/lib/utils/account.ts
@@ -1,0 +1,14 @@
+import { isAddress, isAddressEqual, type Address } from 'viem';
+
+// This function checks if two addresses are equal, handling undefined and null cases.
+// It uses the viem library to ensure the addresses are valid before comparison.
+// If either address is undefined or null, it returns false.
+// If both addresses are valid, it checks for equality using isAddressEqual.
+export const isAddressEq = (a?: Address | null, b?: Address | null) => {
+  try {
+    if (!a || !b) return false;
+    return isAddress(a) && isAddress(b) && isAddressEqual(a, b);
+  } catch {
+    return false;
+  }
+};

--- a/packages/ui-components/src/lib/utils/account.ts
+++ b/packages/ui-components/src/lib/utils/account.ts
@@ -1,9 +1,18 @@
 import { isAddress, isAddressEqual, type Address } from 'viem';
 
-// This function checks if two addresses are equal, handling undefined and null cases.
-// It uses the viem library to ensure the addresses are valid before comparison.
-// If either address is undefined or null, it returns false.
-// If both addresses are valid, it checks for equality using isAddressEqual.
+/**
+ * Safely compares two Ethereum addresses for equality.
+ *
+ * @param a - First address to compare
+ * @param b - Second address to compare
+ * @returns true if both addresses are valid and equal, false otherwise
+ *
+ * Returns false if:
+ * - Either address is null/undefined
+ * - Either address is invalid
+ * - Addresses are valid but not equal
+ * - Any error occurs during comparison
+ */
 export const isAddressEq = (a?: Address | null, b?: Address | null) => {
 	try {
 		if (!a || !b) return false;

--- a/packages/ui-components/tsconfig.json
+++ b/packages/ui-components/tsconfig.json
@@ -13,6 +13,12 @@
 		"strict": true,
 		"module": "es2022",
 		"moduleResolution": "bundler",
-		"types": ["vitest/globals", "@testing-library/jest-dom", "vitest/importMeta", "codemirror-rainlang", "@rainlanguage/dotrain"]
-	},
+		"types": [
+			"vitest/globals",
+			"@testing-library/jest-dom",
+			"vitest/importMeta",
+			"codemirror-rainlang",
+			"@rainlanguage/dotrain"
+		]
+	}
 }

--- a/packages/webapp/src/__tests__/handleVaultDeposit.test.ts
+++ b/packages/webapp/src/__tests__/handleVaultDeposit.test.ts
@@ -133,7 +133,6 @@ describe('handleVaultDeposit', () => {
 				modalTitle: 'Approving TEST spend',
 				closeOnConfirm: true,
 				args: {
-					entity: mockVault,
 					toAddress: mockVault.token.address as Hex,
 					chainId: mockVault.chainId,
 					onConfirm: expect.any(Function),
@@ -161,7 +160,6 @@ describe('handleVaultDeposit', () => {
 					modalTitle: 'Depositing 100 TEST',
 					closeOnConfirm: false,
 					args: {
-						entity: mockVault,
 						toAddress: mockVault.orderbook,
 						chainId: mockVault.chainId,
 						onConfirm: expect.any(Function),

--- a/packages/webapp/src/__tests__/handleVaultWithdraw.test.ts
+++ b/packages/webapp/src/__tests__/handleVaultWithdraw.test.ts
@@ -97,7 +97,6 @@ describe('handleVaultWithdraw', () => {
 			open: true,
 			modalTitle: 'Withdrawing 0.1 TEST...',
 			args: {
-				entity: mockVault,
 				onConfirm: expect.any(Function),
 				calldata: mockCalldata
 			}

--- a/packages/webapp/src/lib/components/WithdrawMultipleModal.svelte
+++ b/packages/webapp/src/lib/components/WithdrawMultipleModal.svelte
@@ -3,7 +3,6 @@
 	import { Modal, Button } from 'flowbite-svelte';
 	import { appKitModal, connected } from '$lib/stores/wagmi';
 	import type { WithdrawMultipleModalProps } from '../services/handleMultipleVaultsWithdraw';
-	import { formatUnits } from 'viem';
 
 	/**
 	 * Modal component for withdrawing tokens from a vault.
@@ -37,10 +36,11 @@
 			<div class="max-h-48 space-y-2 overflow-y-auto">
 				{#each args.vaults as vault (vault.id)}
 					<div class="flex flex-row items-start justify-between rounded-lg bg-gray-50 p-3">
-						<span class="mr-2 truncate font-mono text-xs font-medium text-gray-900">{vault.id}</span
+						<span class="mr-2 truncate font-mono text-xs font-medium text-gray-900"
+							>{vault.vaultId}</span
 						>
 						<span class="whitespace-nowrap text-sm font-semibold text-gray-900">
-							{formatUnits(vault.balance, Number(vault.token.decimals ?? 18))}
+							{vault.formattedBalance}
 							&nbsp;
 							{vault.token.symbol}
 						</span>

--- a/packages/webapp/src/lib/components/WithdrawMultipleModal.svelte
+++ b/packages/webapp/src/lib/components/WithdrawMultipleModal.svelte
@@ -53,11 +53,9 @@
 			<div class="flex gap-2">
 				<Button color="alternative" on:click={handleClose}>Cancel</Button>
 				{#if account}
-					<div class="flex flex-col gap-2">
-						<Button color="blue" data-testid="withdraw-button" on:click={handleSubmit}>
-							Withdraw all
-						</Button>
-					</div>
+					<Button color="blue" data-testid="withdraw-button" on:click={handleSubmit}>
+						Withdraw all
+					</Button>
 				{:else}
 					<WalletConnect {appKitModal} {connected} />
 				{/if}

--- a/packages/webapp/src/lib/components/WithdrawMultipleModal.svelte
+++ b/packages/webapp/src/lib/components/WithdrawMultipleModal.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+	import { WalletConnect } from '@rainlanguage/ui-components';
+	import { Modal, Button } from 'flowbite-svelte';
+	import { appKitModal, connected } from '$lib/stores/wagmi';
+	import type { WithdrawMultipleModalProps } from '../services/handleMultipleVaultsWithdraw';
+	import { formatUnits } from 'viem';
+
+	/**
+	 * Modal component for withdrawing tokens from a vault.
+	 * This component should only be used for withdraw actions.
+	 */
+	export let open: WithdrawMultipleModalProps['open'];
+	export let args: WithdrawMultipleModalProps['args'];
+	export let onSubmit: WithdrawMultipleModalProps['onSubmit'];
+
+	const { account } = args;
+
+	function handleSubmit() {
+		onSubmit();
+		handleClose();
+	}
+
+	function handleClose() {
+		open = false;
+	}
+</script>
+
+<Modal bind:open autoclose={false} size="md">
+	<div class="space-y-4">
+		<h3 class="text-xl font-medium" data-testid="modal-title">Withdraw multiple vaults</h3>
+		{#if !account}
+			<div class="h-10">
+				<p>Connect your wallet to continue.</p>
+			</div>
+		{/if}
+		<div class="space-y-3">
+			<div class="max-h-48 space-y-2 overflow-y-auto">
+				{#each args.vaults as vault (vault.id)}
+					<div class="flex flex-row items-start justify-between rounded-lg bg-gray-50 p-3">
+						<span class="mr-2 truncate font-mono text-xs font-medium text-gray-900">{vault.id}</span
+						>
+						<span class="whitespace-nowrap text-sm font-semibold text-gray-900">
+							{formatUnits(vault.balance, Number(vault.token.decimals ?? 18))}
+							&nbsp;
+							{vault.token.symbol}
+						</span>
+					</div>
+				{/each}
+			</div>
+		</div>
+		<div class="flex flex-col justify-end gap-2">
+			<div class="flex gap-2">
+				<Button color="alternative" on:click={handleClose}>Cancel</Button>
+				{#if account}
+					<div class="flex flex-col gap-2">
+						<Button color="blue" data-testid="withdraw-button" on:click={handleSubmit}>
+							Withdraw all
+						</Button>
+					</div>
+				{:else}
+					<WalletConnect {appKitModal} {connected} />
+				{/if}
+			</div>
+		</div>
+	</div>
+</Modal>

--- a/packages/webapp/src/lib/components/WithdrawMultipleModal.svelte
+++ b/packages/webapp/src/lib/components/WithdrawMultipleModal.svelte
@@ -3,6 +3,7 @@
 	import { Modal, Button } from 'flowbite-svelte';
 	import { appKitModal, connected } from '$lib/stores/wagmi';
 	import type { WithdrawMultipleModalProps } from '../services/handleMultipleVaultsWithdraw';
+	import { toHex } from 'viem';
 
 	/**
 	 * Modal component for withdrawing tokens from a vault.
@@ -37,7 +38,7 @@
 				{#each args.vaults as vault (vault.id)}
 					<div class="flex flex-row items-start justify-between rounded-lg bg-gray-50 p-3">
 						<span class="mr-2 truncate font-mono text-xs font-medium text-gray-900"
-							>{vault.vaultId}</span
+							>{toHex(vault.vaultId)}</span
 						>
 						<span class="whitespace-nowrap text-sm font-semibold text-gray-900">
 							{vault.formattedBalance}

--- a/packages/webapp/src/lib/services/handleMultipleVaultsWithdraw.ts
+++ b/packages/webapp/src/lib/services/handleMultipleVaultsWithdraw.ts
@@ -1,0 +1,90 @@
+import type { RaindexClient, RaindexVault } from '@rainlanguage/orderbook';
+import { type Hex } from 'viem';
+import type { TransactionManager } from '@rainlanguage/ui-components';
+import type { TransactionConfirmationProps } from '@rainlanguage/ui-components';
+
+export type WithdrawMultipleModalProps = {
+  open: boolean;
+  args: {
+    vaults: RaindexVault[];
+    account: Hex;
+  };
+  onSubmit: () => void;
+};
+
+export interface MultipleVaultsWithdrawHandlerDependencies {
+  raindexClient: RaindexClient;
+  vaults: RaindexVault[];
+  handleWithdrawModal: (props: WithdrawMultipleModalProps) => void;
+  handleTransactionConfirmationModal: (props: TransactionConfirmationProps) => void;
+  errToast: (message: string) => void;
+  manager: TransactionManager;
+  account: Hex;
+}
+
+export async function handleMultipleVaultsWithdraw(deps: MultipleVaultsWithdrawHandlerDependencies): Promise<void> {
+  const {
+    raindexClient,
+    vaults,
+    handleWithdrawModal,
+    handleTransactionConfirmationModal,
+    errToast,
+    manager,
+    account
+  } = deps;
+  // Early return if no vaults are selected
+  if (vaults.length === 0) {
+    return errToast('No vaults selected for withdrawal.');
+  }
+  // Early return if vaults are not on the same chain
+  if (vaults.every(vault => vault.chainId !== vaults[0].chainId)) {
+    return errToast('All vaults must be on the same chain for withdrawal.');
+  }
+
+  handleWithdrawModal({
+    open: true,
+    args: {
+      vaults,
+      account
+    },
+    onSubmit: async () => {
+      try {
+        const calldatas = await Promise.all([
+          vaults.map(async (vault) => {
+            const calldata = await vault.getWithdrawCalldata(vault.balance.toString());
+            if (calldata.error) {
+              throw new Error(
+                `Failed to get withdrawal calldata for vault ${vault.id}: ${calldata.error?.msg || 'Unknown error'}`
+              );
+            }
+            return calldata.value;
+          }),
+        ]);
+
+        console.log('calldatas', calldatas);
+
+        // TODO
+        // handleTransactionConfirmationModal({
+        //   open: true,
+        //   modalTitle: `Withdrawing from multiple ${vaults.length} vaults...`,
+        //   args: {
+        //     toAddress: vaults[0].orderbook, // Assuming all vaults share the same orderbook
+        //     chainId: vaults[0].chainId,
+        //     onConfirm: (txHash: Hex) => {
+        //       manager.createWithdrawTransaction({
+        //         raindexClient,
+        //         entity: vaults,
+        //         txHash,
+        //         chainId: vaults[0].chainId,
+        //         vaults: vaults.map(vault => vault.id)
+        //       });
+        //     },
+        //     calldata: calldatas.join('') // Concatenate all calldata for the transaction
+        //   }
+        // });
+      } catch {
+        return errToast('Failed to get calldata for vault withdrawal.');
+      }
+    }
+  });
+}

--- a/packages/webapp/src/lib/services/handleMultipleVaultsWithdraw.ts
+++ b/packages/webapp/src/lib/services/handleMultipleVaultsWithdraw.ts
@@ -18,7 +18,9 @@ export interface MultipleVaultsWithdrawHandlerDependencies {
 	raindexClient: RaindexClient;
 	vaults: RaindexVault[];
 	handleWithdrawModal: (props: WithdrawMultipleModalProps) => void;
-	handleTransactionConfirmationModal: (props: TransactionConfirmationProps) => Promise<TransactionConfirmationModalResult>;
+	handleTransactionConfirmationModal: (
+		props: TransactionConfirmationProps
+	) => Promise<TransactionConfirmationModalResult>;
 	errToast: (message: string) => void;
 	manager: TransactionManager;
 	account: Hex;
@@ -94,7 +96,7 @@ export async function handleMultipleVaultsWithdraw(
 									vaults,
 									txHash,
 									queryKey: QKEY_VAULTS, // Invalidate all vaults
-									chainId: vaults[0].chainId,
+									chainId: vaults[0].chainId
 								});
 							}
 						}

--- a/packages/webapp/src/lib/services/handleMultipleVaultsWithdraw.ts
+++ b/packages/webapp/src/lib/services/handleMultipleVaultsWithdraw.ts
@@ -1,7 +1,7 @@
 import type { RaindexClient, RaindexVault } from '@rainlanguage/orderbook';
 import { generateMulticallCalldata } from '@rainlanguage/orderbook';
 import { type Hex } from 'viem';
-import type { TransactionManager } from '@rainlanguage/ui-components';
+import { QKEY_VAULTS, type TransactionManager } from '@rainlanguage/ui-components';
 import type { TransactionConfirmationProps } from '@rainlanguage/ui-components';
 
 export type WithdrawMultipleModalProps = {
@@ -89,7 +89,7 @@ export async function handleMultipleVaultsWithdraw(
 								raindexClient,
 								vaults,
 								txHash,
-								queryKey: txHash, // Use txHash as the query key
+								queryKey: QKEY_VAULTS, // Invalidate all vaults
 								chainId: vaults[0].chainId
 							});
 						}

--- a/packages/webapp/src/lib/services/handleMultipleVaultsWithdraw.ts
+++ b/packages/webapp/src/lib/services/handleMultipleVaultsWithdraw.ts
@@ -69,7 +69,7 @@ export async function handleMultipleVaultsWithdraw(
 							const result = await vault.getWithdrawCalldata(vault.balance.toString());
 							if (result.error) {
 								throw new Error(
-									`Failed to get withdrawal calldata for vault ${vault.id}: ${result.error.readableMsg || 'Unknown error'}`
+									`Failed to get withdrawal calldata for vault ${vault.id}: ${result.error.readableMsg}`
 								);
 							}
 							return result.value;
@@ -78,7 +78,7 @@ export async function handleMultipleVaultsWithdraw(
 					const calldataResult = await generateMulticallCalldata(calldatas);
 					if (calldataResult.error) {
 						throw new Error(
-							`Failed to generate multicall calldata: ${calldataResult.error.readableMsg || 'Unknown error'}`
+							`Failed to generate multicall calldata: ${calldataResult.error.readableMsg}`
 						);
 					}
 					const calldata = calldataResult.value;

--- a/packages/webapp/src/lib/services/handleMultipleVaultsWithdraw.ts
+++ b/packages/webapp/src/lib/services/handleMultipleVaultsWithdraw.ts
@@ -52,6 +52,11 @@ export async function handleMultipleVaultsWithdraw(
 		},
 		onSubmit: async () => {
 			try {
+				// Validate that all vaults share the same orderbook
+				const orderbook = vaults[0].orderbook;
+				if (vaults.some((vault) => vault.orderbook !== orderbook)) {
+					throw new Error('All vaults must share the same orderbook for batch withdrawal');
+				}
 				// Get individual withdrawal calldatas
 				const calldatas = await Promise.all(
 					vaults.map(async (vault) => {
@@ -76,7 +81,7 @@ export async function handleMultipleVaultsWithdraw(
 					open: true,
 					modalTitle: `Withdrawing from ${vaults.length} vaults...`,
 					args: {
-						toAddress: vaults[0].orderbook, // Assuming all vaults share the same orderbook
+						toAddress: orderbook,
 						chainId: vaults[0].chainId,
 						calldata,
 						onConfirm: (txHash: Hex) => {

--- a/packages/webapp/src/lib/services/handleMultipleVaultsWithdraw.ts
+++ b/packages/webapp/src/lib/services/handleMultipleVaultsWithdraw.ts
@@ -1,90 +1,100 @@
 import type { RaindexClient, RaindexVault } from '@rainlanguage/orderbook';
+import { generateMulticallCalldata } from '@rainlanguage/orderbook';
 import { type Hex } from 'viem';
 import type { TransactionManager } from '@rainlanguage/ui-components';
 import type { TransactionConfirmationProps } from '@rainlanguage/ui-components';
 
 export type WithdrawMultipleModalProps = {
-  open: boolean;
-  args: {
-    vaults: RaindexVault[];
-    account: Hex;
-  };
-  onSubmit: () => void;
+	open: boolean;
+	args: {
+		vaults: RaindexVault[];
+		account: Hex;
+	};
+	onSubmit: () => void;
 };
 
 export interface MultipleVaultsWithdrawHandlerDependencies {
-  raindexClient: RaindexClient;
-  vaults: RaindexVault[];
-  handleWithdrawModal: (props: WithdrawMultipleModalProps) => void;
-  handleTransactionConfirmationModal: (props: TransactionConfirmationProps) => void;
-  errToast: (message: string) => void;
-  manager: TransactionManager;
-  account: Hex;
+	raindexClient: RaindexClient;
+	vaults: RaindexVault[];
+	handleWithdrawModal: (props: WithdrawMultipleModalProps) => void;
+	handleTransactionConfirmationModal: (props: TransactionConfirmationProps) => void;
+	errToast: (message: string) => void;
+	manager: TransactionManager;
+	account: Hex;
 }
 
-export async function handleMultipleVaultsWithdraw(deps: MultipleVaultsWithdrawHandlerDependencies): Promise<void> {
-  const {
-    raindexClient,
-    vaults,
-    handleWithdrawModal,
-    handleTransactionConfirmationModal,
-    errToast,
-    manager,
-    account
-  } = deps;
-  // Early return if no vaults are selected
-  if (vaults.length === 0) {
-    return errToast('No vaults selected for withdrawal.');
-  }
-  // Early return if vaults are not on the same chain
-  if (vaults.every(vault => vault.chainId !== vaults[0].chainId)) {
-    return errToast('All vaults must be on the same chain for withdrawal.');
-  }
+export async function handleMultipleVaultsWithdraw(
+	deps: MultipleVaultsWithdrawHandlerDependencies
+): Promise<void> {
+	const {
+		raindexClient,
+		vaults,
+		handleWithdrawModal,
+		handleTransactionConfirmationModal,
+		errToast,
+		manager,
+		account
+	} = deps;
+	// Early return if no vaults are selected
+	if (vaults.length === 0) {
+		return errToast('No vaults selected for withdrawal.');
+	}
+	// Early return if vaults are not on the same chain
+	if (vaults.some((vault) => vault.chainId !== vaults[0].chainId)) {
+		return errToast('All vaults must be on the same chain for withdrawal.');
+	}
 
-  handleWithdrawModal({
-    open: true,
-    args: {
-      vaults,
-      account
-    },
-    onSubmit: async () => {
-      try {
-        const calldatas = await Promise.all([
-          vaults.map(async (vault) => {
-            const calldata = await vault.getWithdrawCalldata(vault.balance.toString());
-            if (calldata.error) {
-              throw new Error(
-                `Failed to get withdrawal calldata for vault ${vault.id}: ${calldata.error?.msg || 'Unknown error'}`
-              );
-            }
-            return calldata.value;
-          }),
-        ]);
+	handleWithdrawModal({
+		open: true,
+		args: {
+			vaults,
+			account
+		},
+		onSubmit: async () => {
+			try {
+				// Get individual withdrawal calldatas
+				const calldatas = await Promise.all(
+					vaults.map(async (vault) => {
+						const result = await vault.getWithdrawCalldata(vault.balance.toString());
+						if (result.error) {
+							throw new Error(
+								`Failed to get withdrawal calldata for vault ${vault.id}: ${result.error.readableMsg || 'Unknown error'}`
+							);
+						}
+						return result.value;
+					})
+				);
+				const calldataResult = await generateMulticallCalldata(calldatas);
+				if (calldataResult.error) {
+					throw new Error(
+						`Failed to generate multicall calldata: ${calldataResult.error.readableMsg || 'Unknown error'}`
+					);
+				}
+				const calldata = calldataResult.value;
 
-        console.log('calldatas', calldatas);
-
-        // TODO
-        // handleTransactionConfirmationModal({
-        //   open: true,
-        //   modalTitle: `Withdrawing from multiple ${vaults.length} vaults...`,
-        //   args: {
-        //     toAddress: vaults[0].orderbook, // Assuming all vaults share the same orderbook
-        //     chainId: vaults[0].chainId,
-        //     onConfirm: (txHash: Hex) => {
-        //       manager.createWithdrawTransaction({
-        //         raindexClient,
-        //         entity: vaults,
-        //         txHash,
-        //         chainId: vaults[0].chainId,
-        //         vaults: vaults.map(vault => vault.id)
-        //       });
-        //     },
-        //     calldata: calldatas.join('') // Concatenate all calldata for the transaction
-        //   }
-        // });
-      } catch {
-        return errToast('Failed to get calldata for vault withdrawal.');
-      }
-    }
-  });
+				handleTransactionConfirmationModal({
+					open: true,
+					modalTitle: `Withdrawing from ${vaults.length} vaults...`,
+					args: {
+						toAddress: vaults[0].orderbook, // Assuming all vaults share the same orderbook
+						chainId: vaults[0].chainId,
+						calldata,
+						onConfirm: (txHash: Hex) => {
+							manager.createMultipleVaultsWithdrawTransaction({
+								raindexClient,
+								vaults,
+								txHash,
+								queryKey: txHash, // Use txHash as the query key
+								chainId: vaults[0].chainId
+							});
+						}
+					}
+				});
+			} catch (error) {
+				return errToast(
+					`Failed to generate calldata for vault withdrawal: ${error instanceof Error ? error.message : 'Unknown error'}`
+				);
+			}
+		}
+	});
 }

--- a/packages/webapp/src/lib/services/handleVaultDeposit.ts
+++ b/packages/webapp/src/lib/services/handleVaultDeposit.ts
@@ -35,7 +35,6 @@ async function executeDeposit(args: DepositArgs) {
 				: `Depositing ${vault.token.symbol}`,
 			closeOnConfirm: false,
 			args: {
-				entity: vault,
 				toAddress: vault.orderbook,
 				chainId: vault.chainId,
 				onConfirm: (txHash: Hex) => {
@@ -75,7 +74,6 @@ export async function handleVaultDeposit(deps: VaultDepositHandlerDependencies):
 					modalTitle: `Approving ${vault.token.symbol || 'token'} spend`,
 					closeOnConfirm: true,
 					args: {
-						entity: vault,
 						toAddress: vault.token.address as Hex,
 						chainId: vault.chainId,
 						onConfirm: (txHash: Hex) => {

--- a/packages/webapp/src/lib/services/handleVaultWithdraw.ts
+++ b/packages/webapp/src/lib/services/handleVaultWithdraw.ts
@@ -44,7 +44,6 @@ export async function handleVaultWithdraw(deps: VaultWithdrawHandlerDependencies
 					open: true,
 					modalTitle: `Withdrawing ${formatUnits(amount, Number(vault.token.decimals))} ${vault.token.symbol}...`,
 					args: {
-						entity: vault,
 						toAddress: vault.orderbook,
 						chainId: vault.chainId,
 						onConfirm: (txHash: Hex) => {

--- a/packages/webapp/src/lib/services/modal.ts
+++ b/packages/webapp/src/lib/services/modal.ts
@@ -7,6 +7,8 @@ import {
 	type DisclaimerModalProps,
 	type VaultActionModalProps
 } from '@rainlanguage/ui-components';
+import WithdrawMultipleModal from '$lib/components/WithdrawMultipleModal.svelte';
+import type { WithdrawMultipleModalProps } from './handleMultipleVaultsWithdraw';
 
 export const handleDepositModal = (props: VaultActionModalProps) => {
 	new DepositModal({ target: document.body, props });
@@ -14,6 +16,10 @@ export const handleDepositModal = (props: VaultActionModalProps) => {
 
 export const handleWithdrawModal = (props: VaultActionModalProps) => {
 	new WithdrawModal({ target: document.body, props });
+};
+
+export const handleWithdrawMultipleModal = (props: WithdrawMultipleModalProps) => {
+	new WithdrawMultipleModal({ target: document.body, props });
 };
 
 export const handleTransactionConfirmationModal = (

--- a/packages/webapp/src/lib/services/modal.ts
+++ b/packages/webapp/src/lib/services/modal.ts
@@ -22,9 +22,14 @@ export const handleWithdrawMultipleModal = (props: WithdrawMultipleModalProps) =
 	new WithdrawMultipleModal({ target: document.body, props });
 };
 
+export type TransactionConfirmationModalResult = {
+	success: boolean;
+	hash?: string;
+};
+
 export const handleTransactionConfirmationModal = (
 	props: TransactionConfirmationProps
-): Promise<{ success: boolean; hash?: string }> => {
+): Promise<TransactionConfirmationModalResult> => {
 	return new Promise((resolve) => {
 		const originalOnConfirm = props.args.onConfirm;
 		let modalResolved = false;

--- a/packages/webapp/src/routes/orders/[chainId]-[orderbook]-[orderHash]/+page.svelte
+++ b/packages/webapp/src/routes/orders/[chainId]-[orderbook]-[orderHash]/+page.svelte
@@ -5,7 +5,8 @@
 	import {
 		handleDepositModal,
 		handleTransactionConfirmationModal,
-		handleWithdrawModal
+		handleWithdrawModal,
+		handleWithdrawMultipleModal
 	} from '$lib/services/modal';
 	import type { Address, RaindexClient, RaindexOrder, RaindexVault } from '@rainlanguage/orderbook';
 	import type { Hex } from 'viem';
@@ -13,6 +14,7 @@
 	import { handleRemoveOrder } from '$lib/services/handleRemoveOrder';
 	import { handleVaultWithdraw } from '$lib/services/handleVaultWithdraw';
 	import { handleVaultDeposit } from '$lib/services/handleVaultDeposit';
+	import { handleMultipleVaultsWithdraw } from '../../../lib/services/handleMultipleVaultsWithdraw';
 
 	const { orderHash, chainId, orderbook } = $page.params;
 	const parsedOrderHash = orderHash as Hex;
@@ -56,6 +58,18 @@
 			account: $account as Hex
 		});
 	}
+
+	async function onWithdrawAll(raindexClient: RaindexClient, vaults: RaindexVault[]) {
+		await handleMultipleVaultsWithdraw({
+			raindexClient,
+			vaults,
+			handleWithdrawModal: handleWithdrawMultipleModal,
+			handleTransactionConfirmationModal,
+			errToast,
+			manager,
+			account: $account as Hex
+		});
+	}
 </script>
 
 <PageHeader title="Order" pathname={$page.url.pathname} />
@@ -70,4 +84,5 @@
 	{onRemove}
 	{onDeposit}
 	{onWithdraw}
+	{onWithdrawAll}
 />

--- a/packages/webapp/src/routes/orders/[chainId]-[orderbook]-[orderHash]/+page.svelte
+++ b/packages/webapp/src/routes/orders/[chainId]-[orderbook]-[orderHash]/+page.svelte
@@ -60,7 +60,7 @@
 	}
 
 	async function onWithdrawAll(raindexClient: RaindexClient, vaults: RaindexVault[]) {
-		await handleMultipleVaultsWithdraw({
+		return handleMultipleVaultsWithdraw({
 			raindexClient,
 			vaults,
 			handleWithdrawModal: handleWithdrawMultipleModal,

--- a/packages/webapp/src/routes/orders/[chainId]-[orderbook]-[orderHash]/+page.svelte
+++ b/packages/webapp/src/routes/orders/[chainId]-[orderbook]-[orderHash]/+page.svelte
@@ -14,7 +14,7 @@
 	import { handleRemoveOrder } from '$lib/services/handleRemoveOrder';
 	import { handleVaultWithdraw } from '$lib/services/handleVaultWithdraw';
 	import { handleVaultDeposit } from '$lib/services/handleVaultDeposit';
-	import { handleMultipleVaultsWithdraw } from '../../../lib/services/handleMultipleVaultsWithdraw';
+	import { handleMultipleVaultsWithdraw } from '$lib/services/handleMultipleVaultsWithdraw';
 
 	const { orderHash, chainId, orderbook } = $page.params;
 	const parsedOrderHash = orderHash as Hex;

--- a/packages/webapp/src/routes/vaults/+page.svelte
+++ b/packages/webapp/src/routes/vaults/+page.svelte
@@ -19,7 +19,7 @@
 	import {
 		handleTransactionConfirmationModal,
 		handleWithdrawMultipleModal
-	} from '../../lib/services/modal';
+	} from '$lib/services/modal';
 	import type { Hex } from 'viem';
 
 	const { settings, accounts, activeAccountsItems, showInactiveOrders } = $page.data.stores;

--- a/packages/webapp/src/routes/vaults/+page.svelte
+++ b/packages/webapp/src/routes/vaults/+page.svelte
@@ -1,5 +1,11 @@
 <script lang="ts">
-	import { PageHeader, VaultsListTable } from '@rainlanguage/ui-components';
+	import {
+		PageHeader,
+		useAccount,
+		useToasts,
+		useTransactions,
+		VaultsListTable
+	} from '@rainlanguage/ui-components';
 	import { page } from '$app/stores';
 	import {
 		hideZeroBalanceVaults,
@@ -8,8 +14,31 @@
 		activeTokens
 	} from '$lib/stores/settings';
 	import { selectedChainIds } from '$lib/stores/settings';
+	import { handleMultipleVaultsWithdraw } from '$lib/services/handleMultipleVaultsWithdraw';
+	import type { RaindexClient, RaindexVault } from '@rainlanguage/orderbook';
+	import {
+		handleTransactionConfirmationModal,
+		handleWithdrawMultipleModal
+	} from '../../lib/services/modal';
+	import type { Hex } from 'viem';
 
-	const { activeAccountsItems, showInactiveOrders } = $page.data.stores;
+	const { settings, accounts, activeAccountsItems, showInactiveOrders } = $page.data.stores;
+
+	const { account } = useAccount();
+	const { manager } = useTransactions();
+	const { errToast } = useToasts();
+
+	function onWithdrawMultiple(raindexClient: RaindexClient, vaults: RaindexVault[]) {
+		return handleMultipleVaultsWithdraw({
+			raindexClient,
+			vaults,
+			handleWithdrawModal: handleWithdrawMultipleModal,
+			handleTransactionConfirmationModal,
+			errToast,
+			manager,
+			account: $account as Hex
+		});
+	}
 </script>
 
 <PageHeader title="Vaults" pathname={$page.url.pathname} />
@@ -22,4 +51,5 @@
 	{hideZeroBalanceVaults}
 	{activeTokens}
 	{selectedChainIds}
+	{onWithdrawMultiple}
 />

--- a/tauri-app/src/lib/components/ModalMultipleVaultsWithdraw.svelte
+++ b/tauri-app/src/lib/components/ModalMultipleVaultsWithdraw.svelte
@@ -63,7 +63,14 @@
       const calldataBytes = hexToBytes(
         (calldata.value.startsWith('0x') ? calldata.value : `0x${calldata.value}`) as Hex,
       );
-      const orderbook = vaults[0].orderbook; // Assuming all vaults belong to the same orderbook
+
+      const orderbook = vaults[0].orderbook;
+      // Validate all vaults belong to the same orderbook
+      const allSameOrderbook = vaults.every((vault) => vault.orderbook === orderbook);
+      if (!allSameOrderbook) {
+        throw new Error('All vaults must belong to the same orderbook for batch withdrawal');
+      }
+
       const tx = await ethersExecute(calldataBytes, orderbook);
       toasts.success('Transaction sent successfully!');
       await tx.wait(1);

--- a/tauri-app/src/lib/components/ModalMultipleVaultsWithdraw.svelte
+++ b/tauri-app/src/lib/components/ModalMultipleVaultsWithdraw.svelte
@@ -12,6 +12,7 @@
   export let open = false;
   export let vaults: RaindexVault[];
   export let onWithdraw: () => void;
+  export let onCancel: () => void = () => {};
 
   let isSubmitting = false;
   let selectWallet = false;
@@ -21,6 +22,11 @@
     if (!isSubmitting) {
       selectWallet = false;
     }
+  }
+
+  function close() {
+    onCancel();
+    reset();
   }
 
   async function executeLedger() {
@@ -77,7 +83,7 @@
     bind:open
     outsideclose={!isSubmitting}
     size="sm"
-    on:close={reset}
+    on:close={close}
   >
     <div class="space-y-3">
       <div class="max-h-48 space-y-2 overflow-y-auto">

--- a/tauri-app/src/lib/components/ModalMultipleVaultsWithdraw.svelte
+++ b/tauri-app/src/lib/components/ModalMultipleVaultsWithdraw.svelte
@@ -1,0 +1,121 @@
+<script lang="ts">
+  import { Button, Modal } from 'flowbite-svelte';
+  import { generateMulticallCalldata, type RaindexVault } from '@rainlanguage/orderbook';
+  import { multiVaultsWithdraw } from '$lib/services/vault';
+  import { ethersExecute } from '$lib/services/ethersTx';
+  import { toasts } from '$lib/stores/toasts';
+  import ModalExecute from './ModalExecute.svelte';
+  import { reportErrorToSentry } from '$lib/services/sentry';
+  import { formatEthersTransactionError } from '$lib/utils/transaction';
+  import { formatUnits, hexToBytes, type Hex } from 'viem';
+
+  export let open = false;
+  export let vaults: RaindexVault[];
+  export let onWithdraw: () => void;
+
+  let isSubmitting = false;
+  let selectWallet = false;
+
+  function reset() {
+    open = false;
+    if (!isSubmitting) {
+      selectWallet = false;
+    }
+  }
+
+  async function executeLedger() {
+    isSubmitting = true;
+    try {
+      await multiVaultsWithdraw(vaults);
+      onWithdraw();
+    } catch (e) {
+      reportErrorToSentry(e);
+    }
+    isSubmitting = false;
+    reset();
+  }
+
+  async function executeWalletconnect() {
+    isSubmitting = true;
+    try {
+      const calldatas = await Promise.all(
+        vaults.map(async (vault) => {
+          const calldata = await vault.getWithdrawCalldata(vault.balance.toString());
+          if (calldata.error) {
+            throw new Error(calldata.error.readableMsg);
+          }
+          return calldata.value;
+        }),
+      );
+      const calldata = await generateMulticallCalldata(calldatas);
+      if (calldata.error) {
+        throw new Error(calldata.error.readableMsg);
+      }
+      if (!calldata.value || calldata.value.length === 0) {
+        throw new Error('No calldata generated');
+      }
+      const calldataBytes = hexToBytes(
+        (calldata.value.startsWith('0x') ? calldata.value : `0x${calldata.value}`) as Hex,
+      );
+      const orderbook = vaults[0].orderbook; // Assuming all vaults belong to the same orderbook
+      const tx = await ethersExecute(calldataBytes, orderbook);
+      toasts.success('Transaction sent successfully!');
+      await tx.wait(1);
+      onWithdraw();
+    } catch (e) {
+      reportErrorToSentry(e);
+      toasts.error(formatEthersTransactionError(e));
+    }
+    isSubmitting = false;
+    reset();
+  }
+</script>
+
+{#if !selectWallet}
+  <Modal
+    title="Withdraw Multiple Vaults"
+    bind:open
+    outsideclose={!isSubmitting}
+    size="sm"
+    on:close={reset}
+  >
+    <div class="space-y-3">
+      <div class="max-h-48 space-y-2 overflow-y-auto">
+        {#each vaults as vault (vault.id)}
+          <div class="flex flex-row items-start justify-between rounded-lg bg-gray-50 p-3">
+            <span class="mr-2 truncate font-mono text-xs font-medium text-gray-900">{vault.id}</span
+            >
+            <span class="whitespace-nowrap text-sm font-semibold text-gray-900">
+              {formatUnits(vault.balance, Number(vault.token.decimals ?? 18))}
+              &nbsp;
+              {vault.token.symbol}
+            </span>
+          </div>
+        {/each}
+      </div>
+    </div>
+    <div class="flex w-full justify-end space-x-4">
+      <Button color="alternative" on:click={reset}>Cancel</Button>
+
+      <Button
+        on:click={() => {
+          selectWallet = true;
+          open = false;
+        }}
+      >
+        Proceed
+      </Button>
+    </div>
+  </Modal>
+{/if}
+
+<ModalExecute
+  chainId={vaults[0].chainId}
+  bind:open={selectWallet}
+  onBack={() => (open = true)}
+  title="Withdraw from Vault"
+  execButtonLabel="Withdraw"
+  {executeLedger}
+  {executeWalletconnect}
+  bind:isSubmitting
+/>

--- a/tauri-app/src/lib/components/ModalMultipleVaultsWithdraw.svelte
+++ b/tauri-app/src/lib/components/ModalMultipleVaultsWithdraw.svelte
@@ -7,7 +7,7 @@
   import ModalExecute from './ModalExecute.svelte';
   import { reportErrorToSentry } from '$lib/services/sentry';
   import { formatEthersTransactionError } from '$lib/utils/transaction';
-  import { formatUnits, hexToBytes, type Hex } from 'viem';
+  import { hexToBytes, toHex, type Hex } from 'viem';
 
   export let open = false;
   export let vaults: RaindexVault[];
@@ -89,10 +89,11 @@
       <div class="max-h-48 space-y-2 overflow-y-auto">
         {#each vaults as vault (vault.id)}
           <div class="flex flex-row items-start justify-between rounded-lg bg-gray-50 p-3">
-            <span class="mr-2 truncate font-mono text-xs font-medium text-gray-900">{vault.id}</span
+            <span class="mr-2 truncate font-mono text-xs font-medium text-gray-900"
+              >{toHex(vault.vaultId)}</span
             >
             <span class="whitespace-nowrap text-sm font-semibold text-gray-900">
-              {formatUnits(vault.balance, Number(vault.token.decimals ?? 18))}
+              {vault.formattedBalance}
               &nbsp;
               {vault.token.symbol}
             </span>

--- a/tauri-app/src/lib/services/modal.ts
+++ b/tauri-app/src/lib/services/modal.ts
@@ -48,13 +48,14 @@ export const handleDebugTradeModal = (txHash: string, rpcUrls: string[]) => {
   new ModalTradeDebug({ target: document.body, props: { open: true, txHash, rpcUrls } });
 };
 
-export const handleWithdrawMultipleModal = (vaults: RaindexVault[], onWithdraw: () => void) => {
+export const handleWithdrawMultipleModal = (vaults: RaindexVault[], onWithdraw: () => void, onCancel?: () => void) => {
   new ModalMultipleVaultsWithdraw({
     target: document.body,
     props: {
       open: true,
       vaults,
       onWithdraw,
+      onCancel,
     },
   });
 };

--- a/tauri-app/src/lib/services/modal.ts
+++ b/tauri-app/src/lib/services/modal.ts
@@ -6,6 +6,7 @@ import ModalTradeDebug from '$lib/components/modal/ModalTradeDebug.svelte';
 import ModalQuoteDebug from '$lib/components/modal/ModalQuoteDebug.svelte';
 import ModalScenarioDebug from '$lib/components/modal/ModalScenarioDebug.svelte';
 import type { getAllContexts } from 'svelte';
+import ModalMultipleVaultsWithdraw from '../components/ModalMultipleVaultsWithdraw.svelte';
 
 export const handleDepositModal = (
   vault: RaindexVault,
@@ -45,6 +46,17 @@ export const handleOrderRemoveModal = (
 
 export const handleDebugTradeModal = (txHash: string, rpcUrls: string[]) => {
   new ModalTradeDebug({ target: document.body, props: { open: true, txHash, rpcUrls } });
+};
+
+export const handleWithdrawMultipleModal = (vaults: RaindexVault[], onWithdraw: () => void) => {
+  new ModalMultipleVaultsWithdraw({
+    target: document.body,
+    props: {
+      open: true,
+      vaults,
+      onWithdraw,
+    },
+  });
 };
 
 export const handleQuoteDebugModal = (

--- a/tauri-app/src/lib/services/modal.ts
+++ b/tauri-app/src/lib/services/modal.ts
@@ -48,7 +48,11 @@ export const handleDebugTradeModal = (txHash: string, rpcUrls: string[]) => {
   new ModalTradeDebug({ target: document.body, props: { open: true, txHash, rpcUrls } });
 };
 
-export const handleWithdrawMultipleModal = (vaults: RaindexVault[], onWithdraw: () => void, onCancel?: () => void) => {
+export const handleWithdrawMultipleModal = (
+  vaults: RaindexVault[],
+  onWithdraw: () => void,
+  onCancel?: () => void,
+) => {
   new ModalMultipleVaultsWithdraw({
     target: document.body,
     props: {

--- a/tauri-app/src/lib/services/vault.ts
+++ b/tauri-app/src/lib/services/vault.ts
@@ -57,6 +57,25 @@ export async function vaultWithdraw(
   });
 }
 
+export async function multiVaultsWithdraw(vaults: RaindexVault[]) {
+  const chainId = get(walletConnectNetwork);
+  const orderbook = getOrderbookByChainId(chainId);
+
+  await invoke('vaults_withdraw', {
+    vaults: vaults.map((vault) => ({
+      vault_id: vault.id.toString(),
+      token: vault.token,
+      target_amount: vault.balance.toString(),
+    })),
+    transactionArgs: {
+      rpcs: orderbook.network.rpcs,
+      orderbook_address: orderbook.address,
+      derivation_index: get(ledgerWalletDerivationIndex),
+      chain_id: chainId,
+    },
+  });
+}
+
 export async function vaultDepositCalldata(vaultId: bigint, token: string, amount: bigint) {
   return await invoke('vault_deposit_calldata', {
     depositArgs: {

--- a/tauri-app/src/routes/orders/[chainId]-[orderbook]-[orderHash]/+page.svelte
+++ b/tauri-app/src/routes/orders/[chainId]-[orderbook]-[orderHash]/+page.svelte
@@ -13,6 +13,7 @@
     handleWithdrawModal,
     handleOrderRemoveModal,
     handleDebugTradeModal,
+    handleWithdrawMultipleModal,
   } from '$lib/services/modal';
   import type {
     Address,
@@ -71,6 +72,12 @@
       context,
     );
   }
+
+  function onWithdrawAll(_raindexClient: RaindexClient, vaults: RaindexVault[]) {
+    handleWithdrawMultipleModal(vaults, () => {
+      invalidateTanstackQueries(queryClient, [parsedOrderHash]);
+    });
+  }
 </script>
 
 <PageHeader title="Order" pathname={$page.url.pathname} />
@@ -89,5 +96,6 @@
     {onDeposit}
     {onWithdraw}
     {rpcs}
+    {onWithdrawAll}
   />
 </div>

--- a/tauri-app/src/routes/vaults/+page.svelte
+++ b/tauri-app/src/routes/vaults/+page.svelte
@@ -26,9 +26,19 @@
   import { queryClient } from '$lib/queries/queryClient';
 
   function onWithdrawMultiple(_raindexClient: RaindexClient, vaults: RaindexVault[]) {
-    handleWithdrawMultipleModal(vaults, () => {
-      // Invalidate all vault queries to refresh the data
-      invalidateTanstackQueries(queryClient, [QKEY_VAULTS]);
+    return new Promise((resolve) => {
+      handleWithdrawMultipleModal(
+        vaults,
+        () => {
+          // Invalidate all vault queries to refresh the data
+          invalidateTanstackQueries(queryClient, [QKEY_VAULTS]);
+          resolve(true);
+        },
+        () => {
+          // Handle cancel action if needed
+          resolve(false);
+        },
+      );
     });
   }
 </script>

--- a/tauri-app/src/routes/vaults/+page.svelte
+++ b/tauri-app/src/routes/vaults/+page.svelte
@@ -1,5 +1,10 @@
 <script lang="ts">
-  import { PageHeader, VaultsListTable } from '@rainlanguage/ui-components';
+  import {
+    invalidateTanstackQueries,
+    PageHeader,
+    QKEY_VAULTS,
+    VaultsListTable,
+  } from '@rainlanguage/ui-components';
   import { page } from '$app/stores';
 
   import {
@@ -18,9 +23,13 @@
   } from '$lib/services/modal';
   import { writable } from 'svelte/store';
   import type { RaindexClient, RaindexVault } from '@rainlanguage/orderbook';
+  import { queryClient } from '../../lib/queries/queryClient';
 
   function onWithdrawMultiple(_raindexClient: RaindexClient, vaults: RaindexVault[]) {
-    handleWithdrawMultipleModal(vaults, () => {});
+    handleWithdrawMultipleModal(vaults, () => {
+      // Invalidate all vault queries to refresh the data
+      invalidateTanstackQueries(queryClient, [QKEY_VAULTS]);
+    });
   }
 </script>
 

--- a/tauri-app/src/routes/vaults/+page.svelte
+++ b/tauri-app/src/routes/vaults/+page.svelte
@@ -23,7 +23,7 @@
   } from '$lib/services/modal';
   import { writable } from 'svelte/store';
   import type { RaindexClient, RaindexVault } from '@rainlanguage/orderbook';
-  import { queryClient } from '../../lib/queries/queryClient';
+  import { queryClient } from '$lib/queries/queryClient';
 
   function onWithdrawMultiple(_raindexClient: RaindexClient, vaults: RaindexVault[]) {
     handleWithdrawMultipleModal(vaults, () => {

--- a/tauri-app/src/routes/vaults/+page.svelte
+++ b/tauri-app/src/routes/vaults/+page.svelte
@@ -11,8 +11,17 @@
     activeTokens,
   } from '$lib/stores/settings';
 
-  import { handleDepositModal, handleWithdrawModal } from '$lib/services/modal';
+  import {
+    handleDepositModal,
+    handleWithdrawModal,
+    handleWithdrawMultipleModal,
+  } from '$lib/services/modal';
   import { writable } from 'svelte/store';
+  import type { RaindexClient, RaindexVault } from '@rainlanguage/orderbook';
+
+  function onWithdrawMultiple(_raindexClient: RaindexClient, vaults: RaindexVault[]) {
+    handleWithdrawMultipleModal(vaults, () => {});
+  }
 </script>
 
 <PageHeader title="Vaults" pathname={$page.url.pathname} />
@@ -26,5 +35,6 @@
   {handleDepositModal}
   {handleWithdrawModal}
   {activeTokens}
+  {onWithdrawMultiple}
   showMyItemsOnly={writable(false)}
 />

--- a/tauri-app/src/routes/vaults/+page.svelte
+++ b/tauri-app/src/routes/vaults/+page.svelte
@@ -26,7 +26,7 @@
   import { queryClient } from '$lib/queries/queryClient';
 
   function onWithdrawMultiple(_raindexClient: RaindexClient, vaults: RaindexVault[]) {
-    return new Promise((resolve) => {
+    return new Promise<boolean>((resolve) => {
       handleWithdrawMultipleModal(
         vaults,
         () => {


### PR DESCRIPTION
## Motivation
It closes #1963

## Solution
From User perspective this PR adds:
- [x] multi-select of vaults on Vaults page and withdrawal
   - which makes it possible to choose only vaults from the same chain
   - only with non-zero balance
   - and only the ones where the user is the owner
- [x] withdraw all vaults on Order Details page, including options:
   - withdraw all inputs (if >1)
   - withdraw all outputs (if >1)
   - withdraw all inputs&outputs (if >1)
   - withdraw all vaults (if >1 and it's not the same as inputs&outputs)
   - it also filters out zero balances
      e.g. you have 3 vaults there, and one of them is empty — then "Withdraw all" will withdraw only 2
      at the same time if you have 3 vaults, and only one have a positive balance — there will be no "Withdraw all" button (but mb we'd better have it anyway?)

The same functionality also implemented in Tauri-app.

Also this PR introduces `generateMulticallCalldata` function (js_api), which able to combine any calldata into multicallCall. So this PR also makes front-end able to decide which transactions it may want to put in a batch.

## Checks
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)

## Screenshots
<img width="1074" height="379" alt="image" src="https://github.com/user-attachments/assets/c739b2b7-23ee-45da-ad50-e1e33d8d9fdf" />
<img width="1079" height="379" alt="image" src="https://github.com/user-attachments/assets/e18036c0-0b4b-480c-a51f-8b3b9adef3fe" />
<img width="820" height="379" alt="image" src="https://github.com/user-attachments/assets/bc853dc4-d8c6-4028-a65c-bc2452d2592e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for withdrawing from multiple vaults simultaneously across web and desktop apps.
  * Introduced batch withdrawal modals and enhanced UI for grouped vault withdrawals and multi-vault selection.
  * Enabled "Withdraw all" buttons on order detail and vaults pages for convenient batch actions.
  * Added comprehensive error handling and user feedback for invalid calldata in batch withdrawals.
  * Implemented multicall calldata generation for efficient batch transaction execution.
  * Added new transaction type for multiple vault withdrawals and corresponding transaction manager support.
  * Introduced a utility for safe Ethereum address equality checks.
  * Added VaultsList abstraction for managing vault collections and multicall calldata generation.

* **Bug Fixes**
  * Improved address matching and vault grouping logic for more accurate withdrawal options.

* **Documentation**
  * Enhanced type definitions for grouped vaults and transaction confirmation results.

* **Chores**
  * Refactored transaction confirmation logic to use a shared constant for confirmations.
  * Updated test cases and mock data to reflect new multi-vault withdrawal features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->