### PR TITLE
Change owner balance function to return account balance instance

### DIFF
--- a/crates/common/src/raindex_client/vaults.rs
+++ b/crates/common/src/raindex_client/vaults.rs
@@ -66,7 +66,6 @@ pub struct RaindexVault {
 #[cfg(target_family = "wasm")]
 #[wasm_bindgen]
 impl RaindexVault {
-    #[cfg(target_family = "wasm")]
     fn u256_to_bigint(value: U256) -> Result<BigInt, RaindexError> {
         BigInt::from_str(&value.to_string())
             .map_err(|e| RaindexError::JsError(e.to_string().into()))
@@ -154,15 +153,35 @@ impl RaindexVault {
     }
 }
 
-/// Represents the balance of an account.
-#[derive(Serialize, Deserialize, Debug, Clone, Tsify)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+#[wasm_bindgen]
 pub struct AccountBalance {
-    #[tsify(type = "bigint")]
-    pub balance: U256,
-    pub formatted_balance: String,
+    balance: U256,
+    formatted_balance: String,
 }
-impl_wasm_traits!(AccountBalance);
+#[cfg(target_family = "wasm")]
+#[wasm_bindgen]
+impl AccountBalance {
+    #[wasm_bindgen(getter)]
+    pub fn balance(&self) -> Result<BigInt, RaindexError> {
+        BigInt::from_str(&self.balance.to_string())
+            .map_err(|e| RaindexError::JsError(e.to_string().into()))
+    }
+    #[wasm_bindgen(getter = formattedBalance)]
+    pub fn formatted_balance(&self) -> String {
+        self.formatted_balance.clone()
+    }
+}
+#[cfg(not(target_family = "wasm"))]
+impl AccountBalance {
+    pub fn balance(&self) -> U256 {
+        self.balance
+    }
+    pub fn formatted_balance(&self) -> String {
+        self.formatted_balance.clone()
+    }
+}
 
 /// Token metadata associated with a vault in the Raindex system.
 ///
@@ -500,7 +519,8 @@ impl RaindexVault {
     #[wasm_export(
         js_name = "getOwnerBalance",
         return_description = "Owner balance in both raw and human-readable format",
-        unchecked_return_type = "AccountBalance"
+        unchecked_return_type = "AccountBalance",
+        preserve_js_class
     )]
     pub async fn get_owner_balance_wasm_binding(&self) -> Result<AccountBalance, RaindexError> {
         let balance = self.clone().get_owner_balance(self.owner).await?;

--- a/packages/orderbook/test/js_api/raindexClient.test.ts
+++ b/packages/orderbook/test/js_api/raindexClient.test.ts
@@ -1902,6 +1902,7 @@ describe('Rain Orderbook JS API Package Bindgen Tests - Raindex Client', async f
 			);
 
 			const res = extractWasmEncodedData(await vault.getOwnerBalance());
+			assert.equal(typeof res.balance, 'bigint');
 			assert.equal(res.balance, BigInt(1000));
 			assert.equal(res.formattedBalance, '0.000000000000001');
 		});

--- a/packages/webapp/src/lib/components/DepositModal.svelte
+++ b/packages/webapp/src/lib/components/DepositModal.svelte
@@ -22,7 +22,10 @@
 	const { vault, account } = args;
 
 	let amount: bigint = 0n;
-	let userBalance: AccountBalance = { balance: BigInt(0), formattedBalance: '0' };
+	let userBalance: AccountBalance = {
+		balance: BigInt(0),
+		formattedBalance: '0'
+	} as unknown as AccountBalance;
 	let errorMessage = '';
 	let isCheckingCalldata = false;
 

--- a/packages/webapp/src/lib/components/WithdrawModal.svelte
+++ b/packages/webapp/src/lib/components/WithdrawModal.svelte
@@ -22,7 +22,10 @@
 	const { vault, account } = args;
 
 	let amount: bigint = 0n;
-	let userBalance: AccountBalance = { balance: 0n, formattedBalance: '0' };
+	let userBalance: AccountBalance = {
+		balance: 0n,
+		formattedBalance: '0'
+	} as unknown as AccountBalance;
 	let errorMessage = '';
 	let isCheckingCalldata = false;
 

--- a/tauri-app/src/lib/components/ModalVaultDeposit.svelte
+++ b/tauri-app/src/lib/components/ModalVaultDeposit.svelte
@@ -17,7 +17,10 @@
   let amount: bigint;
   let isSubmitting = false;
   let selectWallet = false;
-  let userBalance: AccountBalance = { balance: BigInt(0), formattedBalance: '0' };
+  let userBalance: AccountBalance = {
+    balance: BigInt(0),
+    formattedBalance: '0',
+  } as unknown as AccountBalance;
 
   function reset() {
     open = false;


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Because of the serialization, bigint types were ending up as strings on the js side. Instead of returning an object, we needed to return an instance, keeping the true types for the object fields.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [ ] made this PR as small as possible
- [ ] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility of account balance data when interacting with JavaScript by refining how balances are exposed and formatted.
  * Ensured that balance values returned from the vault are consistently recognized as JavaScript BigInt types.

* **Tests**
  * Added a test to verify that account balances are returned as BigInt in JavaScript.

* **Style**
  * Updated type assertions for user balance initialization in several modal components for improved type safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->