### PR TITLE
Unify working with QueryFilters and introduce FilterStores

### DIFF
--- a/crates/common/src/raindex_client/filters/errors.rs
+++ b/crates/common/src/raindex_client/filters/errors.rs
@@ -1,0 +1,31 @@
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PersistentFilterStoreError {
+    LoadError(String),
+    SaveError(String),
+}
+
+impl std::fmt::Display for PersistentFilterStoreError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PersistentFilterStoreError::LoadError(msg) => write!(f, "Load error: {}", msg),
+            PersistentFilterStoreError::SaveError(msg) => write!(f, "Save error: {}", msg),
+        }
+    }
+}
+
+impl std::error::Error for PersistentFilterStoreError {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FilterError {
+    InvalidUrlParams(String),
+}
+
+impl std::fmt::Display for FilterError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FilterError::InvalidUrlParams(msg) => write!(f, "Invalid URL parameters: {}", msg),
+        }
+    }
+}
+
+impl std::error::Error for FilterError {}

--- a/crates/common/src/raindex_client/filters/mod.rs
+++ b/crates/common/src/raindex_client/filters/mod.rs
@@ -1,0 +1,6 @@
+pub mod errors;
+pub mod store_basic;
+pub mod store_localstorage;
+pub mod traits;
+pub mod vaults_builder;
+pub mod vaults_filter;

--- a/crates/common/src/raindex_client/filters/store_basic.rs
+++ b/crates/common/src/raindex_client/filters/store_basic.rs
@@ -1,0 +1,309 @@
+use super::{vaults_builder::VaultsFilterBuilder, vaults_filter::GetVaultsFilters};
+use crate::raindex_client::filters::traits::{FilterBuilder, FilterStore};
+use crate::raindex_client::*;
+use serde::{Deserialize, Serialize};
+
+//
+// Basic store for filters
+//
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default, Tsify)]
+#[serde(rename_all = "camelCase")]
+pub struct BasicFilterStore {
+    pub vaults: GetVaultsFilters,
+}
+
+impl BasicFilterStore {
+    pub fn new() -> Self {
+        Self {
+            vaults: GetVaultsFilters::default(),
+        }
+    }
+}
+
+impl FilterStore for BasicFilterStore {
+    fn set_vaults_filters(&mut self, filters: GetVaultsFilters) {
+        self.vaults = filters;
+    }
+    fn update_vaults_filters<F>(&mut self, update_fn: F)
+    where
+        F: FnOnce(VaultsFilterBuilder) -> VaultsFilterBuilder,
+    {
+        let builder = VaultsFilterBuilder::from(self.vaults.clone());
+        let updated_filter = update_fn(builder).build();
+        self.vaults = updated_filter;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::raindex_client::filters::traits::{Filter, FilterStore};
+    use alloy::primitives::Address;
+    use std::str::FromStr;
+
+    #[test]
+    fn test_basic_filter_store_new() {
+        let store = BasicFilterStore::new();
+        assert!(store.vaults.owners.is_empty());
+        assert!(!store.vaults.hide_zero_balance);
+        assert!(store.vaults.tokens.is_none());
+    }
+
+    #[test]
+    fn test_basic_filter_store_default() {
+        let store = BasicFilterStore::default();
+        assert!(store.vaults.owners.is_empty());
+        assert!(!store.vaults.hide_zero_balance);
+        assert!(store.vaults.tokens.is_none());
+    }
+
+    #[test]
+    fn test_set_vaults_filters() {
+        let owner1 = Address::from_str("0x1234567890abcdef1234567890abcdef12345678").unwrap();
+        let token1 = Address::from_str("0x1111111111111111111111111111111111111111").unwrap();
+
+        let mut store = BasicFilterStore::new();
+        let filters = GetVaultsFilters {
+            owners: vec![owner1],
+            hide_zero_balance: true,
+            tokens: Some(vec![token1]),
+        };
+
+        store.set_vaults_filters(filters.clone());
+
+        assert_eq!(store.vaults.owners, filters.owners);
+        assert_eq!(store.vaults.hide_zero_balance, filters.hide_zero_balance);
+        assert_eq!(store.vaults.tokens, filters.tokens);
+    }
+
+    #[test]
+    fn test_update_vaults_filters_basic() {
+        let owner1 = Address::from_str("0x1234567890abcdef1234567890abcdef12345678").unwrap();
+
+        let mut store = BasicFilterStore::new();
+
+        // Update Stored value using closure
+        store.update_vaults_filters(|builder| {
+            builder.set_owners(vec![owner1]).set_hide_zero_balance(true)
+        });
+
+        assert_eq!(store.vaults.owners.len(), 1);
+        assert_eq!(store.vaults.owners[0], owner1);
+        assert!(store.vaults.hide_zero_balance);
+        assert!(store.vaults.tokens.is_none());
+    }
+
+    #[test]
+    fn test_update_vaults_filters_with_existing_state() {
+        let owner1 = Address::from_str("0x1234567890abcdef1234567890abcdef12345678").unwrap();
+        let owner2 = Address::from_str("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd").unwrap();
+        let token1 = Address::from_str("0x1111111111111111111111111111111111111111").unwrap();
+
+        let mut store = BasicFilterStore::new();
+
+        // Set initial filters (loaded from URL params / localStorage / etc)
+        store.set_vaults_filters(GetVaultsFilters {
+            owners: vec![owner1],
+            hide_zero_balance: false,
+            tokens: Some(vec![token1]),
+        });
+
+        // Then changing only part of the state
+        store.update_vaults_filters(|builder| {
+            builder.set_owners(vec![owner2]).set_hide_zero_balance(true)
+        });
+
+        assert_eq!(store.vaults.owners.len(), 1);
+        assert_eq!(store.vaults.owners[0], owner2);
+        assert!(store.vaults.hide_zero_balance);
+        assert!(store.vaults.tokens.is_some());
+        assert_eq!(store.vaults.tokens.as_ref().unwrap().len(), 1);
+        assert_eq!(store.vaults.tokens.as_ref().unwrap()[0], token1);
+    }
+
+    #[test]
+    fn test_immutability_original_filters_not_modified() {
+        let owner1 = Address::from_str("0x1234567890abcdef1234567890abcdef12345678").unwrap();
+        let owner2 = Address::from_str("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd").unwrap();
+
+        let mut store = BasicFilterStore::new();
+
+        // Set initial filters
+        let original_filters = GetVaultsFilters {
+            owners: vec![owner1],
+            hide_zero_balance: false,
+            tokens: None,
+        };
+        store.set_vaults_filters(original_filters.clone());
+        let filters_before_update = store.vaults.clone();
+        store.update_vaults_filters(|builder| {
+            builder.set_owners(vec![owner2]).set_hide_zero_balance(true)
+        });
+
+        // Check that original filters are not modified
+        assert_eq!(original_filters.owners.len(), 1);
+        assert_eq!(original_filters.owners[0], owner1);
+        assert!(!original_filters.hide_zero_balance);
+        assert!(original_filters.tokens.is_none());
+
+        // Check that filters stored before update are not modified
+        assert_eq!(filters_before_update.owners.len(), 1);
+        assert_eq!(filters_before_update.owners[0], owner1);
+        assert!(!filters_before_update.hide_zero_balance);
+        assert!(filters_before_update.tokens.is_none());
+
+        // Check that store was updated correctly
+        assert_eq!(store.vaults.owners.len(), 1);
+        assert_eq!(store.vaults.owners[0], owner2);
+        assert!(store.vaults.hide_zero_balance);
+    }
+
+    #[test]
+    fn test_multiple_updates_dont_affect_each_other() {
+        let owner1 = Address::from_str("0x1234567890abcdef1234567890abcdef12345678").unwrap();
+        let owner2 = Address::from_str("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd").unwrap();
+        let owner3 = Address::from_str("0x1111111111111111111111111111111111111111").unwrap();
+
+        let mut store = BasicFilterStore::new();
+
+        store.update_vaults_filters(|builder| builder.set_owners(vec![owner1]));
+        let state_after_first_update = store.vaults.clone();
+
+        store.update_vaults_filters(|builder| {
+            builder.set_owners(vec![owner2]).set_hide_zero_balance(true)
+        });
+        let state_after_second_update = store.vaults.clone();
+
+        store.update_vaults_filters(|builder| {
+            builder
+                .set_owners(vec![owner3])
+                .set_hide_zero_balance(false)
+        });
+
+        // Check that each update did not affect the previously "extracted" state
+        assert_eq!(state_after_first_update.owners.len(), 1);
+        assert_eq!(state_after_first_update.owners[0], owner1);
+        assert!(!state_after_first_update.hide_zero_balance);
+
+        assert_eq!(state_after_second_update.owners.len(), 1);
+        assert_eq!(state_after_second_update.owners[0], owner2);
+        assert!(state_after_second_update.hide_zero_balance);
+
+        // Check that final store state is correct
+        assert_eq!(store.vaults.owners.len(), 1);
+        assert_eq!(store.vaults.owners[0], owner3);
+        assert!(!store.vaults.hide_zero_balance);
+    }
+
+    #[test]
+    fn test_url_params_integration() {
+        let owner1 = Address::from_str("0x1234567890abcdef1234567890abcdef12345678").unwrap();
+        let token1 = Address::from_str("0x1111111111111111111111111111111111111111").unwrap();
+
+        let mut store = BasicFilterStore::new();
+
+        store.update_vaults_filters(|builder| {
+            builder
+                .set_owners(vec![owner1])
+                .set_hide_zero_balance(true)
+                .set_tokens(Some(vec![token1]))
+        });
+
+        let url_params = store.vaults.to_url_params();
+        assert!(url_params.contains(&format!("owner={}", owner1)));
+        assert!(url_params.contains("hideZeroBalance=true"));
+        assert!(url_params.contains(&format!("token[]={}", token1)));
+
+        let restored_filters = GetVaultsFilters::from_url_params(url_params).unwrap();
+        assert_eq!(store.vaults.owners, restored_filters.owners);
+        assert_eq!(
+            store.vaults.hide_zero_balance,
+            restored_filters.hide_zero_balance
+        );
+        assert_eq!(store.vaults.tokens, restored_filters.tokens);
+    }
+
+    #[test]
+    fn test_serialization_integration() {
+        let owner1 = Address::from_str("0x1234567890abcdef1234567890abcdef12345678").unwrap();
+        let token1 = Address::from_str("0x1111111111111111111111111111111111111111").unwrap();
+
+        let mut store = BasicFilterStore::new();
+
+        store.update_vaults_filters(|builder| {
+            builder
+                .set_owners(vec![owner1])
+                .set_hide_zero_balance(true)
+                .set_tokens(Some(vec![token1]))
+        });
+
+        // Test JSON serialization
+        let json = serde_json::to_string(&store).unwrap();
+        let deserialized: BasicFilterStore = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(store.vaults.owners, deserialized.vaults.owners);
+        assert_eq!(
+            store.vaults.hide_zero_balance,
+            deserialized.vaults.hide_zero_balance
+        );
+        assert_eq!(store.vaults.tokens, deserialized.vaults.tokens);
+    }
+    #[test]
+    fn test_filter_store_trait_implementation() {
+        let owner1 = Address::from_str("0x1234567890abcdef1234567890abcdef12345678").unwrap();
+
+        // Test FilterStore trait
+        let mut store = BasicFilterStore::new();
+
+        let filters = GetVaultsFilters {
+            owners: vec![owner1],
+            hide_zero_balance: true,
+            tokens: None,
+        };
+
+        // Test set_vaults_filters
+        FilterStore::set_vaults_filters(&mut store, filters.clone());
+        assert_eq!(store.vaults.owners, filters.owners);
+        assert_eq!(store.vaults.hide_zero_balance, filters.hide_zero_balance);
+        assert_eq!(store.vaults.tokens, filters.tokens);
+
+        // Test update_vaults_filters
+        let owner2 = Address::from_str("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd").unwrap();
+        FilterStore::update_vaults_filters(&mut store, |builder| builder.set_owners(vec![owner2]));
+        assert_eq!(store.vaults.owners.len(), 1);
+        assert_eq!(store.vaults.owners[0], owner2);
+        assert!(store.vaults.hide_zero_balance); // should be preserved
+    }
+
+    #[test]
+    fn test_clone_behavior() {
+        let owner1 = Address::from_str("0x1234567890abcdef1234567890abcdef12345678").unwrap();
+
+        let mut store1 = BasicFilterStore::new();
+        store1.update_vaults_filters(|builder| {
+            builder.set_owners(vec![owner1]).set_hide_zero_balance(true)
+        });
+
+        // Clone store
+        let mut store2 = store1.clone();
+
+        // Modify clone
+        let owner2 = Address::from_str("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd").unwrap();
+        store2.update_vaults_filters(|builder| {
+            builder
+                .set_owners(vec![owner2])
+                .set_hide_zero_balance(false)
+        });
+
+        // Check that original wasn't modified
+        assert_eq!(store1.vaults.owners.len(), 1);
+        assert_eq!(store1.vaults.owners[0], owner1);
+        assert!(store1.vaults.hide_zero_balance);
+
+        // Check that clone was modified
+        assert_eq!(store2.vaults.owners.len(), 1);
+        assert_eq!(store2.vaults.owners[0], owner2);
+        assert!(!store2.vaults.hide_zero_balance);
+    }
+}

--- a/crates/common/src/raindex_client/filters/store_localstorage.rs
+++ b/crates/common/src/raindex_client/filters/store_localstorage.rs
@@ -1,0 +1,46 @@
+use crate::raindex_client::filters::{
+    errors::PersistentFilterStoreError,
+    store_basic::BasicFilterStore,
+    traits::{FilterStore, PersistentFilterStore},
+    vaults_builder::VaultsFilterBuilder,
+    vaults_filter::GetVaultsFilters,
+};
+
+pub struct LocalStorageFilterStore {
+    key: String,
+    store: BasicFilterStore,
+}
+
+impl LocalStorageFilterStore {
+    pub fn new(key: &str) -> Self {
+        Self {
+            key: key.to_string(),
+            store: BasicFilterStore::new(),
+        }
+    }
+}
+
+impl FilterStore for LocalStorageFilterStore {
+    fn set_vaults_filters(&mut self, filters: GetVaultsFilters) {
+        self.store.set_vaults_filters(filters);
+    }
+
+    fn update_vaults_filters<F>(&mut self, update_fn: F)
+    where
+        F: FnOnce(VaultsFilterBuilder) -> VaultsFilterBuilder,
+    {
+        self.store.update_vaults_filters(update_fn);
+    }
+}
+
+impl PersistentFilterStore for LocalStorageFilterStore {
+    fn load(&mut self) -> Result<(), PersistentFilterStoreError> {
+        // Load filters from local storage (not implemented here)
+        todo!("Implement loading from local storage");
+    }
+
+    fn save(&self) -> Result<(), PersistentFilterStoreError> {
+        // Save filters to local storage (not implemented here)
+        todo!("Implement saving to local storage");
+    }
+}

--- a/crates/common/src/raindex_client/filters/traits.rs
+++ b/crates/common/src/raindex_client/filters/traits.rs
@@ -1,0 +1,36 @@
+use serde::{Deserialize, Serialize};
+
+use crate::raindex_client::filters::{
+    errors::{FilterError, PersistentFilterStoreError},
+    vaults_builder::VaultsFilterBuilder,
+    vaults_filter::GetVaultsFilters,
+};
+
+/// Builder trait for constructing filter builder.
+/// Must implement `build` method to return the final filter type
+pub trait FilterBuilder {
+    type Output;
+    fn build(self) -> Self::Output;
+}
+
+/// Filter trait for converting filters to URL parameters and vice versa.
+/// Must implement `to_url_params` to convert the filter to URL parameters
+/// and `from_url_params` to create a filter from URL parameters.
+pub trait Filter: Serialize + for<'de> Deserialize<'de> {
+    fn to_url_params(&self) -> String;
+    fn from_url_params(params: String) -> Result<Self, FilterError>;
+}
+
+/// FilterStore trait for managing filters
+pub trait FilterStore {
+    fn set_vaults_filters(&mut self, filters: GetVaultsFilters);
+    fn update_vaults_filters<F>(&mut self, update_fn: F)
+    where
+        F: FnOnce(VaultsFilterBuilder) -> VaultsFilterBuilder;
+}
+
+/// PersistentFilterStore trait for managing filters with persistence
+pub trait PersistentFilterStore: FilterStore {
+    fn load(&mut self) -> Result<(), PersistentFilterStoreError>;
+    fn save(&self) -> Result<(), PersistentFilterStoreError>;
+}

--- a/crates/common/src/raindex_client/filters/vaults_builder.rs
+++ b/crates/common/src/raindex_client/filters/vaults_builder.rs
@@ -1,0 +1,218 @@
+use super::traits::FilterBuilder;
+use super::vaults_filter::GetVaultsFilters;
+use crate::raindex_client::*;
+use alloy::primitives::Address;
+
+//
+// Vaults Filter Builder
+//
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default, Tsify)]
+#[serde(rename_all = "camelCase")]
+pub struct VaultsFilterBuilder {
+    pub owners: Vec<Address>,
+    pub hide_zero_balance: bool,
+    pub tokens: Option<Vec<Address>>,
+}
+impl_wasm_traits!(VaultsFilterBuilder);
+
+impl VaultsFilterBuilder {
+    pub fn new() -> Self {
+        Self {
+            owners: Vec::new(),
+            hide_zero_balance: false,
+            tokens: None,
+        }
+    }
+
+    pub fn from(filters: GetVaultsFilters) -> Self {
+        Self {
+            owners: filters.owners.clone(),
+            hide_zero_balance: filters.hide_zero_balance.clone(),
+            tokens: filters.tokens.clone(),
+        }
+    }
+
+    pub fn set_owners(mut self, owners: Vec<Address>) -> Self {
+        self.owners = owners;
+        self
+    }
+
+    pub fn set_hide_zero_balance(mut self, hide_zero_balance: bool) -> Self {
+        self.hide_zero_balance = hide_zero_balance;
+        self
+    }
+
+    pub fn set_tokens(mut self, tokens: Option<Vec<Address>>) -> Self {
+        self.tokens = tokens;
+        self
+    }
+}
+
+impl FilterBuilder for VaultsFilterBuilder {
+    type Output = GetVaultsFilters;
+
+    fn build(self) -> Self::Output {
+        GetVaultsFilters {
+            owners: self.owners,
+            hide_zero_balance: self.hide_zero_balance,
+            tokens: self.tokens,
+        }
+    }
+}
+
+impl From<VaultsFilterBuilder> for GetVaultsFilters {
+    fn from(builder: VaultsFilterBuilder) -> Self {
+        builder.build()
+    }
+}
+impl From<GetVaultsFilters> for VaultsFilterBuilder {
+    fn from(filters: GetVaultsFilters) -> Self {
+        VaultsFilterBuilder::from(filters)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::raindex_client::filters::traits::FilterBuilder;
+    use alloy::primitives::Address;
+    use std::str::FromStr;
+
+    #[test]
+    fn test_vaults_filter_builder_from_filters() {
+        let owner1 = Address::from_str("0x1234567890abcdef1234567890abcdef12345678").unwrap();
+        let token1 = Address::from_str("0x1111111111111111111111111111111111111111").unwrap();
+
+        let filters = GetVaultsFilters {
+            owners: vec![owner1],
+            hide_zero_balance: true,
+            tokens: Some(vec![token1]),
+        };
+
+        let builder = VaultsFilterBuilder::from(filters.clone());
+        assert_eq!(builder.owners, filters.owners);
+        assert_eq!(builder.hide_zero_balance, filters.hide_zero_balance);
+        assert_eq!(builder.tokens, filters.tokens);
+    }
+
+    #[test]
+    fn test_vaults_filter_builder_set_owners() {
+        let owner1 = Address::from_str("0x1234567890abcdef1234567890abcdef12345678").unwrap();
+        let owner2 = Address::from_str("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd").unwrap();
+
+        let builder = VaultsFilterBuilder::new().set_owners(vec![owner1, owner2]);
+
+        assert_eq!(builder.owners.len(), 2);
+        assert!(builder.owners.contains(&owner1));
+        assert!(builder.owners.contains(&owner2));
+    }
+
+    #[test]
+    fn test_vaults_filter_builder_chaining() {
+        let owner1 = Address::from_str("0x1234567890abcdef1234567890abcdef12345678").unwrap();
+        let token1 = Address::from_str("0x1111111111111111111111111111111111111111").unwrap();
+
+        let builder = VaultsFilterBuilder::new()
+            .set_owners(vec![owner1])
+            .set_hide_zero_balance(true)
+            .set_tokens(Some(vec![token1]));
+
+        assert_eq!(builder.owners.len(), 1);
+        assert_eq!(builder.owners[0], owner1);
+        assert!(builder.hide_zero_balance);
+        assert!(builder.tokens.is_some());
+        assert_eq!(builder.tokens.as_ref().unwrap().len(), 1);
+        assert_eq!(builder.tokens.as_ref().unwrap()[0], token1);
+    }
+
+    #[test]
+    fn test_vaults_filter_builder_build() {
+        let owner1 = Address::from_str("0x1234567890abcdef1234567890abcdef12345678").unwrap();
+        let token1 = Address::from_str("0x1111111111111111111111111111111111111111").unwrap();
+
+        let filters = VaultsFilterBuilder::new()
+            .set_owners(vec![owner1])
+            .set_hide_zero_balance(true)
+            .set_tokens(Some(vec![token1]))
+            .build();
+
+        assert_eq!(filters.owners.len(), 1);
+        assert_eq!(filters.owners[0], owner1);
+        assert!(filters.hide_zero_balance);
+        assert!(filters.tokens.is_some());
+        assert_eq!(filters.tokens.as_ref().unwrap().len(), 1);
+        assert_eq!(filters.tokens.as_ref().unwrap()[0], token1);
+    }
+
+    #[test]
+    fn test_from_trait_vaults_filter_builder_to_filters() {
+        let owner1 = Address::from_str("0x1234567890abcdef1234567890abcdef12345678").unwrap();
+
+        let builder = VaultsFilterBuilder::new()
+            .set_owners(vec![owner1])
+            .set_hide_zero_balance(true);
+
+        let filters: GetVaultsFilters = builder.into();
+        assert_eq!(filters.owners.len(), 1);
+        assert_eq!(filters.owners[0], owner1);
+        assert!(filters.hide_zero_balance);
+    }
+
+    #[test]
+    fn test_from_trait_filters_to_vaults_filter_builder() {
+        let owner1 = Address::from_str("0x1234567890abcdef1234567890abcdef12345678").unwrap();
+
+        let filters = GetVaultsFilters {
+            owners: vec![owner1],
+            hide_zero_balance: true,
+            tokens: None,
+        };
+
+        let builder: VaultsFilterBuilder = filters.into();
+        assert_eq!(builder.owners.len(), 1);
+        assert_eq!(builder.owners[0], owner1);
+        assert!(builder.hide_zero_balance);
+        assert!(builder.tokens.is_none());
+    }
+
+    #[test]
+    fn test_builder_immutability() {
+        let owner1 = Address::from_str("0x1234567890abcdef1234567890abcdef12345678").unwrap();
+        let owner2 = Address::from_str("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd").unwrap();
+
+        let original_builder = VaultsFilterBuilder::new().set_owners(vec![owner1]);
+        let new_builder = original_builder.clone().set_owners(vec![owner2]);
+
+        // Check that original builder did not change
+        assert_eq!(original_builder.owners.len(), 1);
+        assert_eq!(original_builder.owners[0], owner1);
+
+        // Check that new builder has new values
+        assert_eq!(new_builder.owners.len(), 1);
+        assert_eq!(new_builder.owners[0], owner2);
+    }
+
+    #[test]
+    fn test_roundtrip_filters_to_builder_and_back() {
+        let owner1 = Address::from_str("0x1234567890abcdef1234567890abcdef12345678").unwrap();
+        let token1 = Address::from_str("0x1111111111111111111111111111111111111111").unwrap();
+
+        let original_filters = GetVaultsFilters {
+            owners: vec![owner1],
+            hide_zero_balance: true,
+            tokens: Some(vec![token1]),
+        };
+
+        // Filters -> Builder -> Filters
+        let builder = VaultsFilterBuilder::from(original_filters.clone());
+        let restored_filters = builder.build();
+
+        assert_eq!(original_filters.owners, restored_filters.owners);
+        assert_eq!(
+            original_filters.hide_zero_balance,
+            restored_filters.hide_zero_balance
+        );
+        assert_eq!(original_filters.tokens, restored_filters.tokens);
+    }
+}

--- a/crates/common/src/raindex_client/filters/vaults_filter.rs
+++ b/crates/common/src/raindex_client/filters/vaults_filter.rs
@@ -1,0 +1,383 @@
+use super::traits::Filter;
+use crate::raindex_client::{filters::errors::FilterError, *};
+use alloy::primitives::Address;
+use rain_orderbook_subgraph_client::types::common::{SgBytes, SgVaultsListFilterArgs};
+
+//
+// Vaults Filters
+//
+
+#[derive(Serialize, Deserialize, Debug, Clone, Tsify, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct GetVaultsFilters {
+    #[tsify(type = "Address[]")]
+    pub owners: Vec<Address>,
+    pub hide_zero_balance: bool,
+    #[tsify(optional, type = "Address[]")]
+    pub tokens: Option<Vec<Address>>,
+}
+impl_wasm_traits!(GetVaultsFilters);
+
+impl TryFrom<GetVaultsFilters> for SgVaultsListFilterArgs {
+    type Error = RaindexError;
+    fn try_from(filters: GetVaultsFilters) -> Result<Self, Self::Error> {
+        Ok(Self {
+            owners: filters
+                .owners
+                .into_iter()
+                .map(|owner| SgBytes(owner.to_string()))
+                .collect(),
+            hide_zero_balance: filters.hide_zero_balance,
+            tokens: filters
+                .tokens
+                .map(|tokens| {
+                    tokens
+                        .into_iter()
+                        .map(|token| token.to_string().to_lowercase())
+                        .collect()
+                })
+                .unwrap_or_default(),
+        })
+    }
+}
+
+impl Filter for GetVaultsFilters {
+    fn to_url_params(&self) -> String {
+        let mut params = Vec::new();
+
+        for owner in &self.owners {
+            params.push(format!("owner={}", owner));
+        }
+
+        if self.hide_zero_balance {
+            params.push("hideZeroBalance=true".to_string());
+        }
+
+        if let Some(tokens) = &self.tokens {
+            for token in tokens {
+                params.push(format!("token[]={}", token));
+            }
+        }
+
+        params.join("&")
+    }
+
+    fn from_url_params(params: String) -> Result<Self, FilterError> {
+        let mut owners = Vec::new();
+        let mut hide_zero_balance = false;
+        let mut tokens = None;
+
+        if params.is_empty() {
+            return Ok(GetVaultsFilters::default());
+        }
+
+        for param in params.split('&') {
+            if param.is_empty() {
+                continue;
+            }
+
+            let parts: Vec<&str> = param.splitn(2, '=').collect();
+            if parts.len() == 1 {
+                // Handle shorthand for hideZeroBalance
+                if parts[0] == "hideZeroBalance" {
+                    hide_zero_balance = true;
+                    continue;
+                }
+            }
+            if parts.len() != 2 {
+                // Skip other cases
+                continue;
+            }
+
+            let key = parts[0];
+            let value = parts[1];
+
+            match key {
+                "owner" => {
+                    let address = value.parse::<Address>().map_err(|err| {
+                        FilterError::InvalidUrlParams(format!(
+                            "Invalid owner address '{}': {}",
+                            value, err
+                        ))
+                    })?;
+                    owners.push(address);
+                }
+                "hideZeroBalance" => {
+                    hide_zero_balance = value == "true";
+                }
+                "token[]" => {
+                    if tokens.is_none() {
+                        tokens = Some(Vec::new());
+                    }
+                    if let Some(ref mut t) = tokens {
+                        let token = value.parse::<Address>().map_err(|err| {
+                            FilterError::InvalidUrlParams(format!(
+                                "Invalid token address '{}': {}",
+                                value, err
+                            ))
+                        })?;
+                        t.push(token);
+                    }
+                }
+                _ => {
+                    // Ignore unknown parameters
+                }
+            }
+        }
+
+        Ok(GetVaultsFilters {
+            owners,
+            hide_zero_balance,
+            tokens,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::raindex_client::filters::traits::Filter;
+    use alloy::primitives::Address;
+    use std::str::FromStr;
+
+    #[test]
+    fn test_get_vaults_filters_default() {
+        let filters = GetVaultsFilters::default();
+        assert!(filters.owners.is_empty());
+        assert!(!filters.hide_zero_balance);
+        assert!(filters.tokens.is_none());
+    }
+
+    //
+    // URL Params serialization
+    //
+    #[test]
+    fn test_to_url_params_empty() {
+        let filters = GetVaultsFilters::default();
+        let params = filters.to_url_params();
+        assert_eq!(params, "");
+    }
+
+    #[test]
+    fn test_to_url_params_with_owners_only() {
+        let owner1 = Address::from_str("0x1234567890abcdef1234567890abcdef12345678").unwrap();
+        let owner2 = Address::from_str("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd").unwrap();
+
+        let filters = GetVaultsFilters {
+            owners: vec![owner1, owner2],
+            hide_zero_balance: false,
+            tokens: None,
+        };
+
+        let params = filters.to_url_params();
+        assert!(params.contains(&format!("owner={}", owner1)));
+        assert!(params.contains(&format!("owner={}", owner2)));
+        assert!(params.contains("&"));
+    }
+
+    #[test]
+    fn test_to_url_params_with_hide_zero_balance() {
+        let filters = GetVaultsFilters {
+            owners: vec![],
+            hide_zero_balance: true,
+            tokens: None,
+        };
+
+        let params = filters.to_url_params();
+        assert_eq!(params, "hideZeroBalance=true");
+    }
+
+    #[test]
+    fn test_to_url_params_with_tokens() {
+        let token1 = Address::from_str("0x1111111111111111111111111111111111111111").unwrap();
+        let token2 = Address::from_str("0x2222222222222222222222222222222222222222").unwrap();
+
+        let filters = GetVaultsFilters {
+            owners: vec![],
+            hide_zero_balance: false,
+            tokens: Some(vec![token1, token2]),
+        };
+
+        let params = filters.to_url_params();
+        assert!(params.contains(&format!("token[]={}", token1)));
+        assert!(params.contains(&format!("token[]={}", token2)));
+        assert!(params.contains("&"));
+    }
+
+    #[test]
+    fn test_to_url_params_all() {
+        let owner1 = Address::from_str("0x1234567890abcdef1234567890abcdef12345678").unwrap();
+        let token1 = Address::from_str("0x1111111111111111111111111111111111111111").unwrap();
+
+        let filters = GetVaultsFilters {
+            owners: vec![owner1],
+            hide_zero_balance: true,
+            tokens: Some(vec![token1]),
+        };
+
+        let params = filters.to_url_params();
+        assert!(params.contains(&format!("owner={}", owner1)));
+        assert!(params.contains("hideZeroBalance=true"));
+        assert!(params.contains(&format!("token[]={}", token1)));
+        // Should have 2 ampersands connecting 3 parameters
+        assert_eq!(params.matches('&').count(), 2);
+    }
+
+    //
+    // URL Params deserialization
+    //
+    #[test]
+    fn test_from_url_params_empty() {
+        let params = "".to_string();
+        let filters = GetVaultsFilters::from_url_params(params).unwrap();
+
+        assert!(filters.owners.is_empty());
+        assert!(!filters.hide_zero_balance);
+        assert!(filters.tokens.is_none());
+    }
+
+    #[test]
+    fn test_from_url_params_with_owners() {
+        let owner1 = Address::from_str("0x1234567890abcdef1234567890abcdef12345678").unwrap();
+        let owner2 = Address::from_str("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd").unwrap();
+
+        let params = format!("owner={}&owner={}", owner1, owner2);
+
+        let filters = GetVaultsFilters::from_url_params(params).unwrap();
+        assert_eq!(filters.owners.len(), 2);
+        assert!(filters.owners.contains(&owner1));
+        assert!(filters.owners.contains(&owner2));
+    }
+
+    #[test]
+    fn test_from_url_params_with_hide_zero_balance() {
+        let params = "hideZeroBalance=true".to_string();
+
+        let filters = GetVaultsFilters::from_url_params(params).unwrap();
+        assert!(filters.hide_zero_balance);
+    }
+    #[test]
+    fn test_from_url_params_with_hide_zero_balance_shorthand() {
+        let params = "hideZeroBalance".to_string();
+
+        let filters = GetVaultsFilters::from_url_params(params).unwrap();
+        assert!(filters.hide_zero_balance);
+    }
+
+    #[test]
+    fn test_from_url_params_with_tokens() {
+        let token1 = Address::from_str("0x1111111111111111111111111111111111111111").unwrap();
+        let token2 = Address::from_str("0x2222222222222222222222222222222222222222").unwrap();
+
+        let params = format!("token[]={}&token[]={}", token1, token2);
+
+        let filters = GetVaultsFilters::from_url_params(params).unwrap();
+        assert!(filters.tokens.is_some());
+        let tokens = filters.tokens.unwrap();
+        assert_eq!(tokens.len(), 2);
+        assert!(tokens.contains(&token1));
+        assert!(tokens.contains(&token2));
+    }
+
+    #[test]
+    fn test_from_url_params_with_invalid_owner() {
+        let params = "owner=invalid_address".to_string();
+
+        let result = GetVaultsFilters::from_url_params(params);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Invalid owner address"));
+    }
+
+    #[test]
+    fn test_from_url_params_all() {
+        let owner1 = Address::from_str("0x1234567890abcdef1234567890abcdef12345678").unwrap();
+        let token1 = Address::from_str("0x1111111111111111111111111111111111111111").unwrap();
+
+        let params = format!(
+            "owner={}&hideZeroBalance=true&token[]={}&unknown_param=value",
+            owner1, token1
+        );
+
+        let filters = GetVaultsFilters::from_url_params(params).unwrap();
+        assert_eq!(filters.owners.len(), 1);
+        assert_eq!(filters.owners[0], owner1);
+        assert!(filters.hide_zero_balance);
+        assert!(filters.tokens.is_some());
+        let tokens = filters.tokens.unwrap();
+        assert_eq!(tokens.len(), 1);
+        assert_eq!(tokens[0], token1);
+    }
+
+    #[test]
+    fn test_from_url_params_malformed() {
+        // Test various malformed parameter strings
+        let test_cases = vec![
+            "owner",                      // Missing value
+            "=value",                     // Missing key
+            "owner=",                     // Empty value (should fail for address parsing)
+            "owner&hideZeroBalance=true", // Missing = for first param
+        ];
+
+        for malformed_params in test_cases {
+            let result = GetVaultsFilters::from_url_params(malformed_params.to_string());
+            // Some cases should succeed (like missing values), others should fail
+            // The important thing is that they don't panic
+            if malformed_params == "owner=" {
+                assert!(
+                    result.is_err(),
+                    "Expected error for empty address: {}",
+                    malformed_params
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_roundtrip_url_params() {
+        let owner1 = Address::from_str("0x1234567890abcdef1234567890abcdef12345678").unwrap();
+        let token1 = Address::from_str("0x1111111111111111111111111111111111111111").unwrap();
+
+        let original_filters = GetVaultsFilters {
+            owners: vec![owner1],
+            hide_zero_balance: true,
+            tokens: Some(vec![token1]),
+        };
+
+        // Convert to URL params and back
+        let params = original_filters.to_url_params();
+        let restored_filters = GetVaultsFilters::from_url_params(params).unwrap();
+
+        assert_eq!(original_filters.owners, restored_filters.owners);
+        assert_eq!(
+            original_filters.hide_zero_balance,
+            restored_filters.hide_zero_balance
+        );
+        assert_eq!(original_filters.tokens, restored_filters.tokens);
+    }
+
+    //
+    // TryFrom conversion to SgVaultsListFilterArgs
+    //
+    #[test]
+    fn test_try_from_sg_vaults_list_filter_args() {
+        let owner1 = Address::from_str("0x1234567890abcdef1234567890abcdef12345678").unwrap();
+        let token1 = Address::from_str("0x1111111111111111111111111111111111111111").unwrap();
+
+        let filters = GetVaultsFilters {
+            owners: vec![owner1],
+            hide_zero_balance: true,
+            tokens: Some(vec![token1]),
+        };
+
+        let sg_filter_args: SgVaultsListFilterArgs = filters.try_into().unwrap();
+
+        assert_eq!(sg_filter_args.owners.len(), 1);
+        assert_eq!(sg_filter_args.owners[0].0, owner1.to_string());
+        assert!(sg_filter_args.hide_zero_balance);
+        assert_eq!(sg_filter_args.tokens.len(), 1);
+        assert_eq!(sg_filter_args.tokens[0], token1.to_string().to_lowercase());
+    }
+}

--- a/crates/common/src/raindex_client/mod.rs
+++ b/crates/common/src/raindex_client/mod.rs
@@ -26,6 +26,7 @@ use url::Url;
 use wasm_bindgen_utils::{impl_wasm_traits, prelude::*, wasm_export};
 
 pub mod add_orders;
+pub mod filters;
 pub mod order_quotes;
 pub mod orders;
 pub mod remove_orders;


### PR DESCRIPTION
## Motivation
It closes #1954 

## Solution
This code introduces some structs on top of already existing filter structs that is used in RaindexClient requests.

Let's look at this using the example of structure `GetVaultsFilters`, which is used as argument of `RaindexClient::get_vaults` 
- To make it easier to build/change the filter and ensure it's immutable nature, there is introduced `VaultsFilterBuilder`
- It implements functions that mutates inner state of Builder and `build()`
- `BasicFilterStore` is another struct that keeps all possible filters, such as `GetVaultsFilters` and `GetOrdersFilters` (at the moment this is the only filters we have, but there might be more). `BasicFilterStore` implements:
    - setters — that overrides one of filters without side-effects,
    - updaters — method that accepts closure, which works with the internally created Builder to create a new state and store it inside the store,
- on top of it there might be any kind of `PersistentFilterStore`, which will have `save` and `load` methods and facade methods to BasicFilterStore's setters and updaters, while updaters should also call `save` method under the hood. In this way, `setters` might be used to override state without triggering `save` method (see whe we need it below), and `update` methods to update the state

You can take a look on some tests, but `PersistentFilterStore` is not implemented yet.

So here is the example of idea (rust-like pseudocode):
```
let store = LocalStorageFiltersStore::new("key_in_localstorage_to_store_data");
await store.load();

// If we're on the Vaults page we may load state from URL Params
store.set_vaults_filters(
  GetVaultsFilters::from_url_params(url_params)?
);

// Then if we need to handle click on some of filters
store.update_vaults_filters(
  | builder | {
    builder.set_owners(...).set_tokens(...)
 }
); // At this point it would be saved automatically

// And then to fetch a data we need to get the readonly immutable struct
client.get_vaults(chainIds, store.vaults);
```


## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [ ] made this PR as small as possible
- [ ] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)
