### PR TITLE
Refactor raindex sdk to take amounts in human-readable format

### DIFF
--- a/crates/common/src/raindex_client/add_orders.rs
+++ b/crates/common/src/raindex_client/add_orders.rs
@@ -82,6 +82,7 @@ impl RaindexClient {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(not(target_family = "wasm"))]
     use super::*;
 
     #[cfg(not(target_family = "wasm"))]

--- a/crates/common/src/raindex_client/mod.rs
+++ b/crates/common/src/raindex_client/mod.rs
@@ -399,9 +399,11 @@ impl From<RaindexError> for WasmEncodedError {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(target_family = "wasm")]
     use super::*;
     use rain_orderbook_app_settings::spec_version::SpecVersion;
 
+    #[cfg(not(target_family = "wasm"))]
     pub const CHAIN_ID_1_ORDERBOOK_ADDRESS: &str = "0x1234567890123456789012345678901234567890";
     pub fn get_test_yaml(subgraph1: &str, subgraph2: &str, rpc1: &str, rpc2: &str) -> String {
         format!(
@@ -464,10 +466,7 @@ deployers:
     #[cfg(target_family = "wasm")]
     mod wasm_tests {
         use super::*;
-        use alloy::primitives::Address;
         use rain_orderbook_app_settings::yaml::YamlError;
-        use std::str::FromStr;
-        use url::Url;
         use wasm_bindgen_test::wasm_bindgen_test;
 
         fn get_invalid_yaml() -> String {

--- a/crates/common/src/raindex_client/mod.rs
+++ b/crates/common/src/raindex_client/mod.rs
@@ -7,6 +7,7 @@ use alloy::{
     hex::FromHexError,
     primitives::{
         ruint::{FromUintError, ParseError},
+        utils::UnitsError,
         Address, ParseSignedError,
     },
 };
@@ -214,6 +215,8 @@ pub enum RaindexError {
     WriteLockError,
     #[error("Zero amount")]
     ZeroAmount,
+    #[error("Negative amount")]
+    NegativeAmount(String),
     #[error("Existing allowance")]
     ExistingAllowance,
     #[error(transparent)]
@@ -242,6 +245,8 @@ pub enum RaindexError {
     FromUint8Error(#[from] FromUintError<u8>),
     #[error("Missing decimals for token {0}")]
     MissingErc20Decimals(String),
+    #[error(transparent)]
+    UnitsError(#[from] UnitsError),
 }
 
 impl From<DotrainOrderError> for RaindexError {
@@ -316,6 +321,9 @@ impl RaindexError {
                 "Failed to modify the YAML configuration due to a lock error".to_string()
             }
             RaindexError::ZeroAmount => "Amount cannot be zero".to_string(),
+            RaindexError::NegativeAmount(amount) => {
+                format!("Amount cannot be negative: {}", amount)
+            }
             RaindexError::WritableTransactionExecuteError(err) => {
                 format!("Failed to execute transaction: {}", err)
             }
@@ -366,6 +374,9 @@ impl RaindexError {
                     "Missing decimal information for the token address: {}",
                     token
                 )
+            }
+            RaindexError::UnitsError(err) => {
+                format!("There was an error with parsing number: {}", err)
             }
         }
     }

--- a/crates/common/src/raindex_client/order_quotes.rs
+++ b/crates/common/src/raindex_client/order_quotes.rs
@@ -129,6 +129,7 @@ impl RaindexOrder {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(not(target_family = "wasm"))]
     use super::*;
 
     #[cfg(not(target_family = "wasm"))]

--- a/crates/common/src/raindex_client/orders.rs
+++ b/crates/common/src/raindex_client/orders.rs
@@ -682,6 +682,7 @@ impl RaindexOrder {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(not(target_family = "wasm"))]
     use super::*;
 
     #[cfg(not(target_family = "wasm"))]

--- a/crates/common/src/raindex_client/remove_orders.rs
+++ b/crates/common/src/raindex_client/remove_orders.rs
@@ -126,6 +126,7 @@ impl TryInto<OrderV3> for &RaindexOrder {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(not(target_family = "wasm"))]
     use super::*;
 
     #[cfg(not(target_family = "wasm"))]

--- a/crates/common/src/raindex_client/trades.rs
+++ b/crates/common/src/raindex_client/trades.rs
@@ -259,6 +259,7 @@ impl RaindexTrade {
 
 #[cfg(test)]
 mod test_helpers {
+    #[cfg(not(target_family = "wasm"))]
     use super::*;
 
     #[cfg(not(target_family = "wasm"))]

--- a/crates/common/src/raindex_client/transactions.rs
+++ b/crates/common/src/raindex_client/transactions.rs
@@ -127,6 +127,7 @@ impl TryFrom<SgTransaction> for RaindexTransaction {
 
 #[cfg(test)]
 mod test_helpers {
+    #[cfg(not(target_family = "wasm"))]
     use super::*;
 
     #[cfg(not(target_family = "wasm"))]

--- a/crates/common/src/raindex_client/vaults.rs
+++ b/crates/common/src/raindex_client/vaults.rs
@@ -1263,6 +1263,7 @@ impl TryFrom<RaindexVaultToken> for SgErc20 {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(not(target_family = "wasm"))]
     use super::*;
 
     #[cfg(not(target_family = "wasm"))]

--- a/crates/js_api/src/gui/deposits.rs
+++ b/crates/js_api/src/gui/deposits.rs
@@ -132,10 +132,7 @@ impl DotrainOrderGui {
         &mut self,
         #[wasm_export(param_description = "Token key from the deposits configuration")]
         token: String,
-        #[wasm_export(
-            param_description = "Human-readable amount (e.g., '100.5') or empty string to remove"
-        )]
-        amount: String,
+        #[wasm_export(param_description = "Human-readable amount (e.g., '100.5')")] amount: String,
     ) -> Result<(), GuiError> {
         let gui_deposit = self.get_gui_deposit(&token)?;
 

--- a/packages/orderbook/README.md
+++ b/packages/orderbook/README.md
@@ -254,7 +254,10 @@ const vault = result.value; // RaindexVault instance
 const token = vault.token; // RaindexVaultToken
 
 // Get the current balance for this vault (in token's smallest unit)
-const balance = vault.balance; // string (e.g., "1000000" for 1 USDC with 6 decimals)
+const balance = vault.balance; // bigint (e.g., BigInt(1000000) for 1 USDC with 6 decimals)
+
+// Get the current balance for this vault (in token's smallest unit)
+const balance = vault.formattedBalance; // string (e.g., "1")
 
 // Get the orders that use this vault as input (selling from this vault)
 const inputOrders = vault.ordersAsInput; // RaindexOrderAsIO[]
@@ -271,10 +274,6 @@ const balanceChanges = await vault.getBalanceChanges(); // RaindexVaultBalanceCh
 ### Get calldatas for vault deposit and withdraw
 
 ```javascript
-// Helper function to convert token amounts to smallest unit
-// Any other library can be used to parse amounts, such as ethers.js or can be done manually
-import { parseUnits } from 'viem';
-
 // Get the vault using the raindex client
 const result = await raindexClient.getVault(14, "0x59401C93239a3D8956C7881f0dB45B5727241872", "0x01");
 if (result.error) {
@@ -284,20 +283,17 @@ if (result.error) {
 const vault = result.value; // RaindexVault instance
 
 // Get calldata to deposit tokens into this vault
-const depositAmount = parseUnits("10.5", 6); // 10.5 USDC with 6 decimals = "10500000"
-const depositCalldata = await vault.getDepositCalldata(depositAmount);
+const depositCalldata = await vault.getDepositCalldata("10.5"); // 10.5 tokens (e.g., USDC)
 // Returns hex-encoded calldata to be sent to the orderbook contract
 
 // Get calldata to withdraw tokens from this vault
-const withdrawAmount = parseUnits("5.25", 6); // 5.25 USDC = "5250000"
-const withdrawCalldata = await vault.getWithdrawCalldata(withdrawAmount);
+const withdrawCalldata = await vault.getWithdrawCalldata("5.25"); // 5.25 tokens (e.g., USDC)
 // Returns hex-encoded calldata to be sent to the orderbook contract
 ```
 
 ### Get DotrainOrderGui instance to construct UI to deploy an order
 
 ```javascript
-import { parseUnits } from 'viem';
 import { DotrainOrderGui } from '@rainlanguage/orderbook';
 
 // Prepare the dotrain that will be used for this order
@@ -413,8 +409,7 @@ gui.setFieldValue("frequency", "24"); // Trade every 24 hours
 
 // Set the deposit amount for a token
 // Token names come from the deposits configuration
-const depositAmountUsdt = parseUnits("1000", 6); // 1000 USDT initial deposit
-gui.setDeposit("input-token", depositAmountUsdt);
+gui.setDeposit("input-token", "1000"); // Deposit 1000 tokens into the input vault
 
 // Set a custom vaultId for an input vault (optional)
 // Parameters:

--- a/packages/orderbook/README.md
+++ b/packages/orderbook/README.md
@@ -256,8 +256,8 @@ const token = vault.token; // RaindexVaultToken
 // Get the current balance for this vault (in token's smallest unit)
 const balance = vault.balance; // bigint (e.g., BigInt(1000000) for 1 USDC with 6 decimals)
 
-// Get the current balance for this vault (in token's smallest unit)
-const balance = vault.formattedBalance; // string (e.g., "1")
+// Get the current balance in human-readable format
+const formattedBalance = vault.formattedBalance; // string (e.g., "1")
 
 // Get the orders that use this vault as input (selling from this vault)
 const inputOrders = vault.ordersAsInput; // RaindexOrderAsIO[]

--- a/packages/orderbook/test/js_api/raindexClient.test.ts
+++ b/packages/orderbook/test/js_api/raindexClient.test.ts
@@ -1682,7 +1682,7 @@ describe('Rain Orderbook JS API Package Bindgen Tests - Raindex Client', async f
 
 			const res = await vault.getDepositCalldata('-100');
 			if (!res.error) assert.fail('expected to reject, but resolved');
-			assert.equal(res.error.msg, 'invalid digit: -');
+			assert.equal(res.error.msg, 'Negative amount');
 		});
 
 		it('should get withdraw calldata for a vault', async () => {
@@ -1764,7 +1764,7 @@ describe('Rain Orderbook JS API Package Bindgen Tests - Raindex Client', async f
 				JSON.stringify({
 					jsonrpc: '2.0',
 					id: 1,
-					result: '0x0000000000000000000000000000000000000000000000000000000000000064'
+					result: '0x0000000000000000000000000000000000000000000000056BC75E2D63100000'
 				})
 			);
 
@@ -1789,7 +1789,7 @@ describe('Rain Orderbook JS API Package Bindgen Tests - Raindex Client', async f
 				JSON.stringify({
 					jsonrpc: '2.0',
 					id: 1,
-					result: '0x0000000000000000000000000000000000000000000000000000000000000064'
+					result: '0x0000000000000000000000000000000000000000000000056BC75E2D63100000'
 				})
 			);
 

--- a/packages/ui-components/src/__tests__/InputTokenAmount.test.ts
+++ b/packages/ui-components/src/__tests__/InputTokenAmount.test.ts
@@ -5,7 +5,7 @@ import InputTokenAmount from '$lib/components/input/InputTokenAmount.svelte';
 describe('InputTokenAmount', () => {
 	it('should handle input with 18 decimals', async () => {
 		const { getByRole, component } = render(InputTokenAmount, {
-			props: { decimals: 18, value: 0n }
+			props: { decimals: 18, value: '0' }
 		});
 		const input = getByRole('textbox');
 
@@ -21,7 +21,7 @@ describe('InputTokenAmount', () => {
 
 	it('should handle input with 6 decimals', async () => {
 		const { getByRole, component } = render(InputTokenAmount, {
-			props: { decimals: 6, value: 0n }
+			props: { decimals: 6, value: '0' }
 		});
 		const input = getByRole('textbox');
 
@@ -37,7 +37,7 @@ describe('InputTokenAmount', () => {
 
 	it('should handle input with 0 decimals', async () => {
 		const { getByRole, component } = render(InputTokenAmount, {
-			props: { decimals: 0, value: 0n }
+			props: { decimals: 0, value: '0' }
 		});
 		const input = getByRole('textbox');
 
@@ -50,7 +50,7 @@ describe('InputTokenAmount', () => {
 
 	it('should handle empty input', async () => {
 		const { getByRole, component } = render(InputTokenAmount, {
-			props: { decimals: 18, value: 0n }
+			props: { decimals: 18, value: '0' }
 		});
 		const input = getByRole('textbox');
 
@@ -60,7 +60,7 @@ describe('InputTokenAmount', () => {
 
 	it('should handle invalid input', async () => {
 		const { getByRole, component } = render(InputTokenAmount, {
-			props: { decimals: 18, value: 0n }
+			props: { decimals: 18, value: '0' }
 		});
 		const input = getByRole('textbox');
 
@@ -70,11 +70,11 @@ describe('InputTokenAmount', () => {
 
 	it('should handle maxValue prop', async () => {
 		const { getByText, component } = render(InputTokenAmount, {
-			props: { decimals: 18, maxValue: 1000000000000000000n, value: 0n }
+			props: { decimals: 18, maxValue: '1000', value: '0' }
 		});
 		const maxButton = getByText('MAX');
 
 		await fireEvent.click(maxButton);
-		expect(component.$$.ctx[component.$$.props.value]).toBe(1000000000000000000n);
+		expect(component.$$.ctx[component.$$.props.value]).toBe('1000');
 	});
 });

--- a/packages/ui-components/src/__tests__/InputTokenAmount.test.ts
+++ b/packages/ui-components/src/__tests__/InputTokenAmount.test.ts
@@ -3,74 +3,39 @@ import { describe, it, expect } from 'vitest';
 import InputTokenAmount from '$lib/components/input/InputTokenAmount.svelte';
 
 describe('InputTokenAmount', () => {
-	it('should handle input with 18 decimals', async () => {
+	it('should handle numeric input', async () => {
 		const { getByRole, component } = render(InputTokenAmount, {
-			props: { decimals: 18, value: '0' }
+			props: { value: '0' }
 		});
 		const input = getByRole('textbox');
 
-		await fireEvent.input(input, { target: { value: '1.5' } });
-		expect(component.$$.ctx[component.$$.props.value]).toBe(1500000000000000000n);
-
-		await fireEvent.input(input, { target: { value: '0.000000000000000001' } });
-		expect(component.$$.ctx[component.$$.props.value]).toBe(1n);
-
-		await fireEvent.input(input, { target: { value: '1000000' } });
-		expect(component.$$.ctx[component.$$.props.value]).toBe(1000000000000000000000000n);
-	});
-
-	it('should handle input with 6 decimals', async () => {
-		const { getByRole, component } = render(InputTokenAmount, {
-			props: { decimals: 6, value: '0' }
-		});
-		const input = getByRole('textbox');
-
-		await fireEvent.input(input, { target: { value: '1.5' } });
-		expect(component.$$.ctx[component.$$.props.value]).toBe(1500000n);
-
-		await fireEvent.input(input, { target: { value: '0.000001' } });
-		expect(component.$$.ctx[component.$$.props.value]).toBe(1n);
-
-		await fireEvent.input(input, { target: { value: '1000000' } });
-		expect(component.$$.ctx[component.$$.props.value]).toBe(1000000000000n);
-	});
-
-	it('should handle input with 0 decimals', async () => {
-		const { getByRole, component } = render(InputTokenAmount, {
-			props: { decimals: 0, value: '0' }
-		});
-		const input = getByRole('textbox');
-
-		await fireEvent.input(input, { target: { value: '1' } });
-		expect(component.$$.ctx[component.$$.props.value]).toBe(1n);
-
-		await fireEvent.input(input, { target: { value: '1000000' } });
-		expect(component.$$.ctx[component.$$.props.value]).toBe(1000000n);
+		await fireEvent.input(input, { target: { value: '9999' } });
+		expect(component.$$.ctx[component.$$.props.value]).toBe('9999');
 	});
 
 	it('should handle empty input', async () => {
 		const { getByRole, component } = render(InputTokenAmount, {
-			props: { decimals: 18, value: '0' }
+			props: { value: '0' }
 		});
 		const input = getByRole('textbox');
 
 		await fireEvent.input(input, { target: { value: '' } });
-		expect(component.$$.ctx[component.$$.props.value]).toBe(0n);
+		expect(component.$$.ctx[component.$$.props.value]).toBe('0');
 	});
 
 	it('should handle invalid input', async () => {
 		const { getByRole, component } = render(InputTokenAmount, {
-			props: { decimals: 18, value: '0' }
+			props: { value: '0' }
 		});
 		const input = getByRole('textbox');
 
 		await fireEvent.input(input, { target: { value: 'abc' } });
-		expect(component.$$.ctx[component.$$.props.value]).toBe(0n);
+		expect(component.$$.ctx[component.$$.props.value]).toBe('0');
 	});
 
 	it('should handle maxValue prop', async () => {
 		const { getByText, component } = render(InputTokenAmount, {
-			props: { decimals: 18, maxValue: '1000', value: '0' }
+			props: { maxValue: '1000', value: '0' }
 		});
 		const maxButton = getByText('MAX');
 

--- a/packages/ui-components/src/__tests__/TransactionManager.test.ts
+++ b/packages/ui-components/src/__tests__/TransactionManager.test.ts
@@ -13,7 +13,6 @@ import {
 	RaindexVault,
 	type Address
 } from '@rainlanguage/orderbook';
-import { formatUnits } from 'viem';
 import type { AwaitSubgraphConfig } from '$lib/services/awaitTransactionIndexing';
 
 vi.mock('../lib/models/Transaction', () => ({
@@ -529,7 +528,7 @@ describe('TransactionManager', () => {
 			}
 		} as unknown as RaindexVault;
 		const mockArgs: InternalTransactionArgs & {
-			amount: bigint;
+			amount: string;
 			entity: RaindexVault;
 			raindexClient: RaindexClient;
 		} = {
@@ -537,7 +536,7 @@ describe('TransactionManager', () => {
 			chainId: 1,
 			queryKey: '0xvaultid',
 			entity: mockEntity,
-			amount: 1000000000000000000n,
+			amount: '1000',
 			raindexClient: mockRaindexClient
 		};
 
@@ -551,17 +550,12 @@ describe('TransactionManager', () => {
 				() => mockTransaction as unknown as TransactionStore
 			);
 
-			const expectedReadableAmount = formatUnits(
-				mockArgs.amount,
-				Number(mockEntity.token.decimals)
-			);
-
 			await manager.createDepositTransaction(mockArgs);
 
 			expect(TransactionStore).toHaveBeenCalledWith(
 				expect.objectContaining({
 					...mockArgs,
-					name: `Depositing ${expectedReadableAmount} ${mockEntity.token.symbol}`,
+					name: `Depositing ${mockArgs.amount} ${mockEntity.token.symbol}`,
 					errorMessage: 'Deposit failed.',
 					successMessage: 'Deposit successful.',
 					queryKey: mockArgs.queryKey,

--- a/packages/ui-components/src/lib/components/input/InputTokenAmount.svelte
+++ b/packages/ui-components/src/lib/components/input/InputTokenAmount.svelte
@@ -14,6 +14,8 @@
 
 		if (inputValue === '') {
 			value = '0';
+		} else if (isNaN(Number(inputValue))) {
+			value = '0';
 		} else {
 			value = inputValue;
 		}

--- a/packages/ui-components/src/lib/components/input/InputTokenAmount.svelte
+++ b/packages/ui-components/src/lib/components/input/InputTokenAmount.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { InputAddon, Button, Alert } from 'flowbite-svelte';
+	import { InputAddon, Button } from 'flowbite-svelte';
 
 	export let symbol: string | undefined = undefined;
 	export let maxValue: string | undefined = undefined;

--- a/packages/ui-components/src/lib/components/input/InputTokenAmount.svelte
+++ b/packages/ui-components/src/lib/components/input/InputTokenAmount.svelte
@@ -1,9 +1,7 @@
 <script lang="ts">
 	import { InputAddon, Button, Alert } from 'flowbite-svelte';
-	import { InfoCircleSolid } from 'flowbite-svelte-icons';
 
 	export let symbol: string | undefined = undefined;
-	export let decimals: number = 0;
 	export let maxValue: string | undefined = undefined;
 	let inputValue: string = '';
 	export let value: string = '0';
@@ -26,6 +24,15 @@
 		value = maxValue;
 		inputValue = maxValue;
 	}
+
+	function handleKeyDown(event: KeyboardEvent) {
+		if (
+			!/[0-9.]/.test(event.key) &&
+			!['Backspace', 'Delete', 'Tab', 'ArrowLeft', 'ArrowRight'].includes(event.key)
+		) {
+			event.preventDefault();
+		}
+	}
 </script>
 
 <div class="w-full">
@@ -36,6 +43,7 @@
 				class={`focus:border-primary-500 focus:ring-primary-500 dark:focus:border-primary-500 dark:focus:ring-primary-500 block w-full rounded-lg border-gray-300 bg-gray-50 p-2.5 text-sm text-gray-900 disabled:cursor-not-allowed disabled:opacity-50 rtl:text-right dark:border-gray-500 dark:bg-gray-600 dark:text-white dark:placeholder-gray-400 ${symbol && '!rounded-none !rounded-l-lg'}`}
 				bind:value={inputValue}
 				on:input={handleInput}
+				on:keydown={handleKeyDown}
 			/>
 
 			{#if maxValue}
@@ -53,11 +61,4 @@
 			</InputAddon>
 		{/if}
 	</div>
-	{#if decimals === 0}
-		<Alert color="yellow" border class="mt-2">
-			<InfoCircleSolid slot="icon" class="h-6 w-6" />
-			This token does not specify a number of decimals. <br />You are inputting the raw integer
-			amount with 0 decimal places.
-		</Alert>
-	{/if}
 </div>

--- a/packages/ui-components/src/lib/components/input/InputTokenAmount.svelte
+++ b/packages/ui-components/src/lib/components/input/InputTokenAmount.svelte
@@ -1,37 +1,28 @@
 <script lang="ts">
 	import { InputAddon, Button, Alert } from 'flowbite-svelte';
 	import { InfoCircleSolid } from 'flowbite-svelte-icons';
-	import { parseUnits } from 'viem';
 
 	export let symbol: string | undefined = undefined;
 	export let decimals: number = 0;
-	export let maxValue: bigint | undefined = undefined;
+	export let maxValue: string | undefined = undefined;
 	let inputValue: string = '';
-	export let value: bigint = 0n;
+	export let value: string = '0';
 
 	function handleInput(event: Event) {
 		const input = event.target as HTMLInputElement;
 		inputValue = input.value;
 
 		if (inputValue === '') {
-			value = 0n;
+			value = '0';
 		} else {
-			try {
-				value = parseUnits(inputValue, decimals);
-				// eslint-disable-next-line @typescript-eslint/no-unused-vars
-			} catch (_e) {
-				value = 0n;
-			}
+			value = inputValue;
 		}
 	}
 
 	function fillMaxValue() {
 		if (!maxValue) return;
-
 		value = maxValue;
-		inputValue = maxValue.toString().padStart(decimals + 1, '0');
-		inputValue = inputValue.slice(0, -decimals) + '.' + inputValue.slice(-decimals);
-		inputValue = inputValue.replace(/\.?0+$/, '');
+		inputValue = maxValue;
 	}
 </script>
 

--- a/packages/ui-components/src/lib/providers/transactions/TransactionManager.ts
+++ b/packages/ui-components/src/lib/providers/transactions/TransactionManager.ts
@@ -14,7 +14,6 @@ import {
 	type Address,
 	type Hex
 } from '@rainlanguage/orderbook';
-import { formatUnits } from 'viem';
 
 /**
  * Function type for adding toast notifications to the UI.
@@ -231,7 +230,7 @@ export class TransactionManager {
 	 * @param args.txHash - Hash of the transaction to track.
 	 * @param args.chainId - Chain ID where the transaction is being executed.
 	 * @param args.queryKey - The ID of the vault into which funds are deposited (used for query invalidation and UI links).
-	 * @param args.entity - The `SgVault` entity associated with this transaction.
+	 * @param args.entity - The `RaindexVault` entity associated with this transaction.
 	 * @param args.amount - The amount of tokens being deposited.
 	 * @returns A new Transaction instance configured for deposit.
 	 * @example
@@ -239,20 +238,19 @@ export class TransactionManager {
 	 *   txHash: '0xdef...',
 	 *   chainId: 1,
 	 *   queryKey: '0x789...', // Vault ID
-	 *   entity: sgVaultInstance,
-	 *   amount: 1000n
+	 *   entity: RaindexVault,
+	 *   amount: "1000"
 	 * });
 	 */
 	public async createDepositTransaction(
 		args: InternalTransactionArgs & {
-			amount: bigint;
+			amount: string;
 			entity: RaindexVault;
 			raindexClient: RaindexClient;
 		}
 	): Promise<Transaction> {
 		const tokenSymbol = args.entity.token.symbol;
-		const readableAmount = formatUnits(args.amount, Number(args.entity.token.decimals));
-		const name = `Depositing ${readableAmount} ${tokenSymbol}`;
+		const name = `Depositing ${args.amount} ${tokenSymbol}`;
 		const errorMessage = 'Deposit failed.';
 		const successMessage = 'Deposit successful.';
 		const {

--- a/packages/ui-components/src/lib/providers/transactions/TransactionManager.ts
+++ b/packages/ui-components/src/lib/providers/transactions/TransactionManager.ts
@@ -116,14 +116,14 @@ export class TransactionManager {
 	 * @param args.txHash - Hash of the transaction to track.
 	 * @param args.chainId - Chain ID where the transaction is being executed.
 	 * @param args.queryKey - The ID of the vault from which funds are withdrawn (used for query invalidation and UI links).
-	 * @param args.entity - The `SgVault` entity associated with this transaction.
+	 * @param args.entity - The `RaindexVault` entity associated with this transaction.
 	 * @returns A new Transaction instance configured for withdrawal.
 	 * @example
 	 * const tx = await manager.createWithdrawTransaction({
 	 *   txHash: '0x123...',
 	 *   chainId: 1,
 	 *   queryKey: '0x789...', // Vault ID
-	 *   entity: sgVaultInstance
+	 *   entity: RaindexVault,
 	 * });
 	 */
 	public async createWithdrawTransaction(

--- a/packages/ui-components/src/lib/types/modal.ts
+++ b/packages/ui-components/src/lib/types/modal.ts
@@ -5,7 +5,7 @@ import type { Hex } from 'viem';
 export type VaultActionModalProps = {
 	open: boolean;
 	args: VaultActionArgs;
-	onSubmit: (amount: bigint) => void;
+	onSubmit: (amount: string) => void;
 };
 
 export type DisclaimerModalProps = {

--- a/packages/webapp/src/__tests__/DepositModal.test.ts
+++ b/packages/webapp/src/__tests__/DepositModal.test.ts
@@ -70,7 +70,7 @@ describe('DepositModal', () => {
 		const depositButton = screen.getByTestId('deposit-button');
 		await fireEvent.click(depositButton);
 
-		expect(mockOnSubmit).toHaveBeenCalledWith(BigInt(1000000000000000000));
+		expect(mockOnSubmit).toHaveBeenCalledWith('1');
 	});
 
 	it('shows error when amount exceeds balance', async () => {

--- a/packages/webapp/src/__tests__/WithdrawModal.test.ts
+++ b/packages/webapp/src/__tests__/WithdrawModal.test.ts
@@ -66,18 +66,13 @@ describe('WithdrawModal', () => {
 			expect(screen.getByText('Balance of connected wallet')).toBeInTheDocument();
 		});
 
-		const inputAmount = '1';
-		const expectedAmountBigInt = BigInt(
-			parseFloat(inputAmount) * 10 ** Number(mockVault.token.decimals)
-		);
-
 		const amountInput = screen.getByRole('textbox');
-		await fireEvent.input(amountInput, { target: { value: inputAmount } });
+		await fireEvent.input(amountInput, { target: { value: '1' } });
 
 		const withdrawButton = screen.getByTestId('withdraw-button');
 		await fireEvent.click(withdrawButton);
 
-		expect(defaultProps.onSubmit).toHaveBeenCalledWith(expectedAmountBigInt);
+		expect(defaultProps.onSubmit).toHaveBeenCalledWith('1');
 	});
 
 	it('shows error when amount exceeds balance', async () => {

--- a/packages/webapp/src/__tests__/handleVaultDeposit.test.ts
+++ b/packages/webapp/src/__tests__/handleVaultDeposit.test.ts
@@ -60,7 +60,7 @@ describe('handleVaultDeposit', () => {
 	});
 
 	describe('onSubmit callback from handleDepositModal', () => {
-		const mockAmount = 100n;
+		const mockAmount = '100';
 		const mockApprovalCalldata = '0xapprovalcalldata' as Hex;
 		const mockDepositCalldata = '0xdepositcalldata' as Hex;
 		const mockTxHashApproval = '0xtxhashapproval' as Hex;
@@ -83,9 +83,9 @@ describe('handleVaultDeposit', () => {
 			const onSubmitCall = mockHandleDepositModal.mock.calls[0][0].onSubmit;
 			await onSubmitCall(mockAmount);
 
-			expect(mockVault.getApprovalCalldata).toHaveBeenCalledWith(mockAmount.toString());
+			expect(mockVault.getApprovalCalldata).toHaveBeenCalledWith(mockAmount);
 			expect(mockErrToast).not.toHaveBeenCalledWith('Approval error');
-			expect(mockVault.getDepositCalldata).toHaveBeenCalledWith(mockAmount.toString());
+			expect(mockVault.getDepositCalldata).toHaveBeenCalledWith(mockAmount);
 			expect(mockHandleTransactionConfirmationModal).toHaveBeenCalledTimes(1);
 			expect(mockHandleTransactionConfirmationModal).toHaveBeenCalledWith({
 				open: true,
@@ -153,7 +153,7 @@ describe('handleVaultDeposit', () => {
 				entity: mockVault
 			});
 
-			expect(mockVault.getDepositCalldata).toHaveBeenCalledWith(mockAmount.toString());
+			expect(mockVault.getDepositCalldata).toHaveBeenCalledWith(mockAmount);
 			await waitFor(() => {
 				expect(mockHandleTransactionConfirmationModal).toHaveBeenCalledTimes(2);
 				expect(mockHandleTransactionConfirmationModal).toHaveBeenNthCalledWith(2, {

--- a/packages/webapp/src/__tests__/handleVaultWithdraw.test.ts
+++ b/packages/webapp/src/__tests__/handleVaultWithdraw.test.ts
@@ -91,11 +91,11 @@ describe('handleVaultWithdraw', () => {
 		await handleVaultWithdraw(mockDeps);
 
 		const onSubmitCall = mockHandleWithdrawModal.mock.calls[0][0].onSubmit;
-		await onSubmitCall(100n);
+		await onSubmitCall('100');
 
 		expect(mockHandleTransactionConfirmationModal).toHaveBeenCalledWith({
 			open: true,
-			modalTitle: 'Withdrawing 0.1 TEST...',
+			modalTitle: 'Withdrawing 100 TEST...',
 			args: {
 				entity: mockVault,
 				onConfirm: expect.any(Function),
@@ -116,7 +116,7 @@ describe('handleVaultWithdraw', () => {
 		await handleVaultWithdraw(mockDeps);
 
 		const onSubmitCall = mockHandleWithdrawModal.mock.calls[0][0].onSubmit;
-		await onSubmitCall(100n);
+		await onSubmitCall('100');
 
 		const onConfirmCall = mockHandleTransactionConfirmationModal.mock.calls[0][0].args.onConfirm;
 		onConfirmCall(mockTxHash);

--- a/packages/webapp/src/lib/components/DepositModal.svelte
+++ b/packages/webapp/src/lib/components/DepositModal.svelte
@@ -10,6 +10,7 @@
 	import { fade } from 'svelte/transition';
 	import truncateEthAddress from 'truncate-eth-address';
 	import type { AccountBalance } from '@rainlanguage/orderbook';
+	import { parseUnits } from 'viem';
 
 	/**
 	 * Modal component for depositing tokens into a vault.
@@ -17,11 +18,11 @@
 	 */
 	export let open: boolean;
 	export let args: VaultActionArgs;
-	export let onSubmit: (amount: bigint) => void;
+	export let onSubmit: (amount: string) => void;
 
 	const { vault, account } = args;
 
-	let amount: bigint = 0n;
+	let amount: string = '0';
 	let userBalance: AccountBalance = {
 		balance: BigInt(0),
 		formattedBalance: '0'
@@ -46,10 +47,13 @@
 
 	function handleClose() {
 		open = false;
-		amount = 0n;
+		amount = '0';
 	}
 
-	$: validation = validateAmount(amount, userBalance.balance);
+	$: validation = validateAmount(
+		BigInt(parseUnits(amount, Number(vault.token.decimals))),
+		userBalance.balance
+	);
 </script>
 
 <Modal bind:open autoclose={false} size="md">
@@ -89,7 +93,7 @@
 			bind:value={amount}
 			symbol={vault.token.symbol}
 			decimals={Number(vault.token.decimals)}
-			maxValue={userBalance.balance}
+			maxValue={userBalance.formattedBalance}
 		/>
 		<div class="flex flex-col justify-end gap-2">
 			<div class="flex gap-2">

--- a/packages/webapp/src/lib/components/DepositModal.svelte
+++ b/packages/webapp/src/lib/components/DepositModal.svelte
@@ -92,7 +92,6 @@
 		<InputTokenAmount
 			bind:value={amount}
 			symbol={vault.token.symbol}
-			decimals={Number(vault.token.decimals)}
 			maxValue={userBalance.formattedBalance}
 		/>
 		<div class="flex flex-col justify-end gap-2">

--- a/packages/webapp/src/lib/components/WithdrawModal.svelte
+++ b/packages/webapp/src/lib/components/WithdrawModal.svelte
@@ -92,7 +92,6 @@
 		<InputTokenAmount
 			bind:value={amount}
 			symbol={vault.token.symbol}
-			decimals={Number(vault.token.decimals)}
 			maxValue={vault.formattedBalance}
 		/>
 		<div class="flex flex-col justify-end gap-2">

--- a/packages/webapp/src/lib/components/WithdrawModal.svelte
+++ b/packages/webapp/src/lib/components/WithdrawModal.svelte
@@ -10,6 +10,7 @@
 	import { fade } from 'svelte/transition';
 	import truncateEthAddress from 'truncate-eth-address';
 	import type { AccountBalance } from '@rainlanguage/orderbook';
+	import { parseUnits } from 'viem';
 
 	/**
 	 * Modal component for withdrawing tokens from a vault.
@@ -17,11 +18,11 @@
 	 */
 	export let open: boolean;
 	export let args: VaultActionArgs;
-	export let onSubmit: (amount: bigint) => void;
+	export let onSubmit: (amount: string) => void;
 
 	const { vault, account } = args;
 
-	let amount: bigint = 0n;
+	let amount: string = '0';
 	let userBalance: AccountBalance = {
 		balance: 0n,
 		formattedBalance: '0'
@@ -46,10 +47,13 @@
 
 	function handleClose() {
 		open = false;
-		amount = 0n;
+		amount = '0';
 	}
 
-	$: validation = validateAmount(amount, BigInt(vault.balance));
+	$: validation = validateAmount(
+		parseUnits(amount, Number(vault.token.decimals)),
+		BigInt(vault.balance)
+	);
 </script>
 
 <Modal bind:open autoclose={false} size="md">
@@ -89,7 +93,7 @@
 			bind:value={amount}
 			symbol={vault.token.symbol}
 			decimals={Number(vault.token.decimals)}
-			maxValue={vault.balance}
+			maxValue={vault.formattedBalance}
 		/>
 		<div class="flex flex-col justify-end gap-2">
 			<div class="flex gap-2">

--- a/packages/webapp/src/lib/services/handleVaultDeposit.ts
+++ b/packages/webapp/src/lib/services/handleVaultDeposit.ts
@@ -1,5 +1,5 @@
 import type { RaindexClient, RaindexVault } from '@rainlanguage/orderbook';
-import { formatUnits, type Hex } from 'viem';
+import { type Hex } from 'viem';
 import type {
 	TransactionManager,
 	VaultActionModalProps,
@@ -16,22 +16,19 @@ export interface VaultDepositHandlerDependencies {
 	account: Hex;
 }
 
-export type DepositArgs = VaultDepositHandlerDependencies & { amount: bigint };
+export type DepositArgs = VaultDepositHandlerDependencies & { amount: string };
 
 async function executeDeposit(args: DepositArgs) {
 	const { raindexClient, amount, vault, handleTransactionConfirmationModal, errToast, manager } =
 		args;
-	const calldataResult = await vault.getDepositCalldata(amount.toString());
-	const displayAmount = vault.token.decimals
-		? formatUnits(amount, Number(vault.token.decimals))
-		: amount.toString();
+	const calldataResult = await vault.getDepositCalldata(amount);
 	if (calldataResult.error) {
 		return errToast(calldataResult.error.msg);
 	} else if (calldataResult.value) {
 		handleTransactionConfirmationModal({
 			open: true,
-			modalTitle: displayAmount
-				? `Depositing ${displayAmount} ${vault.token.symbol}`
+			modalTitle: amount
+				? `Depositing ${amount} ${vault.token.symbol}`
 				: `Depositing ${vault.token.symbol}`,
 			closeOnConfirm: false,
 			args: {
@@ -63,9 +60,9 @@ export async function handleVaultDeposit(deps: VaultDepositHandlerDependencies):
 			vault,
 			account
 		},
-		onSubmit: async (amount: bigint) => {
+		onSubmit: async (amount: string) => {
 			const depositArgs = { ...deps, amount };
-			const approvalResult = await vault.getApprovalCalldata(amount.toString());
+			const approvalResult = await vault.getApprovalCalldata(amount);
 			if (approvalResult.error) {
 				// If getting approval calldata fails, immediately invoke deposit
 				await executeDeposit(depositArgs);

--- a/packages/webapp/src/lib/services/handleVaultWithdraw.ts
+++ b/packages/webapp/src/lib/services/handleVaultWithdraw.ts
@@ -1,5 +1,5 @@
 import type { RaindexClient, RaindexVault } from '@rainlanguage/orderbook';
-import { formatUnits, type Hex } from 'viem';
+import { type Hex } from 'viem';
 import type { TransactionManager } from '@rainlanguage/ui-components';
 import type {
 	VaultActionModalProps,
@@ -32,17 +32,17 @@ export async function handleVaultWithdraw(deps: VaultWithdrawHandlerDependencies
 			vault,
 			account
 		},
-		onSubmit: async (amount: bigint) => {
+		onSubmit: async (amount: string) => {
 			let calldata: string;
 			try {
-				const calldataResult = await vault.getWithdrawCalldata(amount.toString());
+				const calldataResult = await vault.getWithdrawCalldata(amount);
 				if (calldataResult.error) {
 					return errToast(calldataResult.error.msg);
 				}
 				calldata = calldataResult.value;
 				handleTransactionConfirmationModal({
 					open: true,
-					modalTitle: `Withdrawing ${formatUnits(amount, Number(vault.token.decimals))} ${vault.token.symbol}...`,
+					modalTitle: `Withdrawing ${amount} ${vault.token.symbol}...`,
 					args: {
 						entity: vault,
 						toAddress: vault.orderbook,

--- a/tauri-app/src/lib/components/ModalVaultDeposit.svelte
+++ b/tauri-app/src/lib/components/ModalVaultDeposit.svelte
@@ -54,7 +54,7 @@
         throw new Error(allowance.error.readableMsg);
       }
       if (BigInt(allowance.value) < parseUnits(amount, Number(vault.token.decimals))) {
-        const calldata = await vault.getApprovalCalldata(amount.toString());
+        const calldata = await vault.getApprovalCalldata(amount);
         if (calldata.error) {
           throw new Error(calldata.error.readableMsg);
         }
@@ -63,7 +63,7 @@
         await approveTx.wait(1);
       }
 
-      const calldata = await vault.getDepositCalldata(amount.toString());
+      const calldata = await vault.getDepositCalldata(amount);
       if (calldata.error) {
         throw new Error(calldata.error.readableMsg);
       }
@@ -151,7 +151,6 @@
         <InputTokenAmount
           bind:value={amount}
           symbol={vault.token.symbol}
-          decimals={Number(vault.token.decimals) ?? 0}
           maxValue={userBalance.formattedBalance}
         />
       </ButtonGroup>

--- a/tauri-app/src/lib/components/ModalVaultWithdraw.svelte
+++ b/tauri-app/src/lib/components/ModalVaultWithdraw.svelte
@@ -119,7 +119,6 @@
       <InputTokenAmount
         bind:value={amount}
         symbol={vault.token.symbol}
-        decimals={Number(vault.token.decimals ?? 0)}
         maxValue={vault.formattedBalance}
       />
 


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

See issue: https://github.com/rainlanguage/rain.orderbook/issues/2007

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

- Use parse units function from alloy in functions that we take amount input from the user
- Update the UI with this change
- Update tests

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved error handling with new specific errors for negative amounts and integration of unit-related errors.
  
* **Refactor**
  * Vault deposit and withdrawal inputs now accept human-readable decimal strings (e.g., "10.5") instead of raw smallest-unit integers.
  * UI components, modals, transaction flows, and SDK examples updated to handle amounts as strings for consistency.
  * Input components simplified by removing bigint parsing and enforcing valid numeric input via key restrictions.

* **Bug Fixes**
  * Enhanced input validation to disallow negative and zero amounts with clear user-facing error messages.

* **Tests**
  * Tests updated to accommodate string-based amount inputs and new error messages reflecting negative amount handling.

* **Documentation**
  * Parameter descriptions and annotations revised to emphasize human-readable decimal string formats for amount inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->