### PR TITLE
Change trade timestamps from local datetime to UTC

### DIFF
--- a/packages/ui-components/src/lib/components/tables/OrderTradesListTable.svelte
+++ b/packages/ui-components/src/lib/components/tables/OrderTradesListTable.svelte
@@ -4,7 +4,7 @@
 	import { QKEY_ORDER_TRADES_LIST } from '../../queries/keys';
 	import { DEFAULT_PAGE_SIZE } from '../../queries/constants';
 	import { TableBodyCell, TableHeadCell } from 'flowbite-svelte';
-	import { formatTimestampSecondsAsLocal } from '../../services/time';
+	import { timestampSecondsToUTCTimestamp } from '../../services/time';
 	import Hash, { HashType } from '../Hash.svelte';
 	import { BugOutline } from 'flowbite-svelte-icons';
 	import type { RaindexOrder, RaindexTrade } from '@rainlanguage/orderbook';
@@ -84,7 +84,7 @@
 
 	<svelte:fragment slot="bodyRow" let:item>
 		<TableBodyCell tdClass="px-4 py-2">
-			{formatTimestampSecondsAsLocal(BigInt(item.timestamp))}
+			{timestampSecondsToUTCTimestamp(BigInt(item.timestamp))}
 		</TableBodyCell>
 		<TableBodyCell tdClass="break-all py-2 min-w-32">
 			<Hash type={HashType.Wallet} value={item.transaction.from} />


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
Trade timestamps were being displayed in local datetime format instead of UTC, which could cause confusion for users in different timezones when viewing trade data.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Updated the `OrderTradesListTable.svelte` component to display trade timestamps in UTC format for consistency across all users regardless of their local timezone.

**Changes Made**:
- Replaced the `formatTimestampSecondsAsLocal()` function with `timestampSecondsToUTCTimestamp()` in the trade timestamp display
- This ensures all users see trade timestamps in a standardized UTC format, eliminating timezone-related confusion
- The change affects the timestamp column in the order trades list table

**Impact**: 
- Provides consistent timestamp display across different user timezones
- Improves data clarity for trading activities
- Follows common practices for financial/trading applications where UTC timestamps are preferred for accuracy and consistency

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [ ] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)
