### PR TITLE
Refactor raindex sdk to take amounts in human-readable format

### DIFF
--- a/crates/common/src/raindex_client/mod.rs
+++ b/crates/common/src/raindex_client/mod.rs
@@ -7,6 +7,7 @@ use alloy::{
     hex::FromHexError,
     primitives::{
         ruint::{FromUintError, ParseError},
+        utils::UnitsError,
         Address, ParseSignedError,
     },
 };
@@ -222,6 +223,8 @@ pub enum RaindexError {
     WriteLockError,
     #[error("Zero amount")]
     ZeroAmount,
+    #[error("Negative amount")]
+    NegativeAmount(String),
     #[error("Existing allowance")]
     ExistingAllowance,
     #[error(transparent)]
@@ -250,6 +253,8 @@ pub enum RaindexError {
     TryFromUint(#[from] FromUintError<u8>),
     #[error("Missing decimals for token {0}")]
     MissingErc20Decimals(String),
+    #[error(transparent)]
+    UnitsError(#[from] UnitsError),
     #[error(transparent)]
     AmountFormatterError(#[from] AmountFormatterError),
 }
@@ -320,6 +325,9 @@ impl RaindexError {
                 "Failed to modify the YAML configuration due to a lock error".to_string()
             }
             RaindexError::ZeroAmount => "Amount cannot be zero".to_string(),
+            RaindexError::NegativeAmount(amount) => {
+                format!("Amount cannot be negative: {}", amount)
+            }
             RaindexError::WritableTransactionExecuteError(err) => {
                 format!("Failed to execute transaction: {}", err)
             }
@@ -359,6 +367,9 @@ impl RaindexError {
             RaindexError::TryFromUint(err) => format!("Failed to convert to u8: {err}"),
             RaindexError::MissingErc20Decimals(token) => {
                 format!("Missing decimal information for the token address: {token}")
+            }
+            RaindexError::UnitsError(err) => {
+                format!("There was an error with parsing number: {}", err)
             }
             RaindexError::AmountFormatterError(err) => format!("Amount formatter error: {err}"),
         }

--- a/crates/js_api/src/gui/deposits.rs
+++ b/crates/js_api/src/gui/deposits.rs
@@ -132,10 +132,7 @@ impl DotrainOrderGui {
         &mut self,
         #[wasm_export(param_description = "Token key from the deposits configuration")]
         token: String,
-        #[wasm_export(
-            param_description = "Human-readable amount (e.g., '100.5') or empty string to remove"
-        )]
-        amount: String,
+        #[wasm_export(param_description = "Human-readable amount (e.g., '100.5')")] amount: String,
     ) -> Result<(), GuiError> {
         let gui_deposit = self.get_gui_deposit(&token)?;
 

--- a/packages/orderbook/README.md
+++ b/packages/orderbook/README.md
@@ -253,8 +253,11 @@ const vault = result.value; // RaindexVault instance
 // Get the token information for this vault
 const token = vault.token; // RaindexVaultToken
 
-// Get the current balance for this vault (in token's smallest unit)
-const balance = vault.balance; // string (e.g., "1000000" for 1 USDC with 6 decimals)
+// Get the current balance for this vault in Float format
+const balance = vault.balance; // Float 
+
+// Get the current balance in human-readable format
+const formattedBalance = vault.formattedBalance; // string (e.g., "1")
 
 // Get the orders that use this vault as input (selling from this vault)
 const inputOrders = vault.ordersAsInput; // RaindexOrderAsIO[]
@@ -271,10 +274,6 @@ const balanceChanges = await vault.getBalanceChanges(); // RaindexVaultBalanceCh
 ### Get calldatas for vault deposit and withdraw
 
 ```javascript
-// Helper function to convert token amounts to smallest unit
-// Any other library can be used to parse amounts, such as ethers.js or can be done manually
-import { parseUnits } from 'viem';
-
 // Get the vault using the raindex client
 const result = await raindexClient.getVault(14, "0x59401C93239a3D8956C7881f0dB45B5727241872", "0x01");
 if (result.error) {
@@ -284,20 +283,17 @@ if (result.error) {
 const vault = result.value; // RaindexVault instance
 
 // Get calldata to deposit tokens into this vault
-const depositAmount = parseUnits("10.5", 6); // 10.5 USDC with 6 decimals = "10500000"
-const depositCalldata = await vault.getDepositCalldata(depositAmount);
+const depositCalldata = await vault.getDepositCalldata("10.5"); // 10.5 tokens (e.g., USDC)
 // Returns hex-encoded calldata to be sent to the orderbook contract
 
 // Get calldata to withdraw tokens from this vault
-const withdrawAmount = parseUnits("5.25", 6); // 5.25 USDC = "5250000"
-const withdrawCalldata = await vault.getWithdrawCalldata(withdrawAmount);
+const withdrawCalldata = await vault.getWithdrawCalldata("5.25"); // 5.25 tokens (e.g., USDC)
 // Returns hex-encoded calldata to be sent to the orderbook contract
 ```
 
 ### Get DotrainOrderGui instance to construct UI to deploy an order
 
 ```javascript
-import { parseUnits } from 'viem';
 import { DotrainOrderGui } from '@rainlanguage/orderbook';
 
 // Prepare the dotrain that will be used for this order
@@ -413,8 +409,7 @@ gui.setFieldValue("frequency", "24"); // Trade every 24 hours
 
 // Set the deposit amount for a token
 // Token names come from the deposits configuration
-const depositAmountUsdt = parseUnits("1000", 6); // 1000 USDT initial deposit
-gui.setDeposit("input-token", depositAmountUsdt);
+gui.setDeposit("input-token", "1000"); // Deposit 1000 tokens into the input vault
 
 // Set a custom vaultId for an input vault (optional)
 // Parameters:

--- a/packages/orderbook/test/js_api/raindexClient.test.ts
+++ b/packages/orderbook/test/js_api/raindexClient.test.ts
@@ -1723,7 +1723,7 @@ describe('Rain Orderbook JS API Package Bindgen Tests - Raindex Client', async f
 
 			const res = await vault.getDepositCalldata('-100');
 			if (!res.error) assert.fail('expected to reject, but resolved');
-			assert.equal(res.error.msg, 'invalid digit: -');
+			assert.equal(res.error.msg, 'Negative amount');
 		});
 
 		it('should get withdraw calldata for a vault', async () => {
@@ -1805,7 +1805,7 @@ describe('Rain Orderbook JS API Package Bindgen Tests - Raindex Client', async f
 				JSON.stringify({
 					jsonrpc: '2.0',
 					id: 1,
-					result: '0x0000000000000000000000000000000000000000000000000000000000000064'
+					result: '0x0000000000000000000000000000000000000000000000056BC75E2D63100000'
 				})
 			);
 
@@ -1830,7 +1830,7 @@ describe('Rain Orderbook JS API Package Bindgen Tests - Raindex Client', async f
 				JSON.stringify({
 					jsonrpc: '2.0',
 					id: 1,
-					result: '0x0000000000000000000000000000000000000000000000000000000000000064'
+					result: '0x0000000000000000000000000000000000000000000000056BC75E2D63100000'
 				})
 			);
 

--- a/packages/ui-components/src/__tests__/InputTokenAmount.test.ts
+++ b/packages/ui-components/src/__tests__/InputTokenAmount.test.ts
@@ -3,78 +3,43 @@ import { describe, it, expect } from 'vitest';
 import InputTokenAmount from '$lib/components/input/InputTokenAmount.svelte';
 
 describe('InputTokenAmount', () => {
-	it('should handle input with 18 decimals', async () => {
+	it('should handle numeric input', async () => {
 		const { getByRole, component } = render(InputTokenAmount, {
-			props: { decimals: 18, value: 0n }
+			props: { value: '0' }
 		});
 		const input = getByRole('textbox');
 
-		await fireEvent.input(input, { target: { value: '1.5' } });
-		expect(component.$$.ctx[component.$$.props.value]).toBe(1500000000000000000n);
-
-		await fireEvent.input(input, { target: { value: '0.000000000000000001' } });
-		expect(component.$$.ctx[component.$$.props.value]).toBe(1n);
-
-		await fireEvent.input(input, { target: { value: '1000000' } });
-		expect(component.$$.ctx[component.$$.props.value]).toBe(1000000000000000000000000n);
-	});
-
-	it('should handle input with 6 decimals', async () => {
-		const { getByRole, component } = render(InputTokenAmount, {
-			props: { decimals: 6, value: 0n }
-		});
-		const input = getByRole('textbox');
-
-		await fireEvent.input(input, { target: { value: '1.5' } });
-		expect(component.$$.ctx[component.$$.props.value]).toBe(1500000n);
-
-		await fireEvent.input(input, { target: { value: '0.000001' } });
-		expect(component.$$.ctx[component.$$.props.value]).toBe(1n);
-
-		await fireEvent.input(input, { target: { value: '1000000' } });
-		expect(component.$$.ctx[component.$$.props.value]).toBe(1000000000000n);
-	});
-
-	it('should handle input with 0 decimals', async () => {
-		const { getByRole, component } = render(InputTokenAmount, {
-			props: { decimals: 0, value: 0n }
-		});
-		const input = getByRole('textbox');
-
-		await fireEvent.input(input, { target: { value: '1' } });
-		expect(component.$$.ctx[component.$$.props.value]).toBe(1n);
-
-		await fireEvent.input(input, { target: { value: '1000000' } });
-		expect(component.$$.ctx[component.$$.props.value]).toBe(1000000n);
+		await fireEvent.input(input, { target: { value: '9999' } });
+		expect(component.$$.ctx[component.$$.props.value]).toBe('9999');
 	});
 
 	it('should handle empty input', async () => {
 		const { getByRole, component } = render(InputTokenAmount, {
-			props: { decimals: 18, value: 0n }
+			props: { value: '0' }
 		});
 		const input = getByRole('textbox');
 
 		await fireEvent.input(input, { target: { value: '' } });
-		expect(component.$$.ctx[component.$$.props.value]).toBe(0n);
+		expect(component.$$.ctx[component.$$.props.value]).toBe('0');
 	});
 
 	it('should handle invalid input', async () => {
 		const { getByRole, component } = render(InputTokenAmount, {
-			props: { decimals: 18, value: 0n }
+			props: { value: '0' }
 		});
 		const input = getByRole('textbox');
 
 		await fireEvent.input(input, { target: { value: 'abc' } });
-		expect(component.$$.ctx[component.$$.props.value]).toBe(0n);
+		expect(component.$$.ctx[component.$$.props.value]).toBe('0');
 	});
 
 	it('should handle maxValue prop', async () => {
 		const { getByText, component } = render(InputTokenAmount, {
-			props: { decimals: 18, maxValue: 1000000000000000000n, value: 0n }
+			props: { maxValue: '1000', value: '0' }
 		});
 		const maxButton = getByText('MAX');
 
 		await fireEvent.click(maxButton);
-		expect(component.$$.ctx[component.$$.props.value]).toBe(1000000000000000000n);
+		expect(component.$$.ctx[component.$$.props.value]).toBe('1000');
 	});
 });

--- a/packages/ui-components/src/__tests__/TransactionManager.test.ts
+++ b/packages/ui-components/src/__tests__/TransactionManager.test.ts
@@ -13,7 +13,6 @@ import {
 	RaindexVault,
 	type Address
 } from '@rainlanguage/orderbook';
-import { formatUnits } from 'viem';
 import type { AwaitSubgraphConfig } from '$lib/services/awaitTransactionIndexing';
 
 vi.mock('../lib/models/Transaction', () => ({
@@ -529,7 +528,7 @@ describe('TransactionManager', () => {
 			}
 		} as unknown as RaindexVault;
 		const mockArgs: InternalTransactionArgs & {
-			amount: bigint;
+			amount: string;
 			entity: RaindexVault;
 			raindexClient: RaindexClient;
 		} = {
@@ -537,7 +536,7 @@ describe('TransactionManager', () => {
 			chainId: 1,
 			queryKey: '0xvaultid',
 			entity: mockEntity,
-			amount: 1000000000000000000n,
+			amount: '1000',
 			raindexClient: mockRaindexClient
 		};
 
@@ -551,17 +550,12 @@ describe('TransactionManager', () => {
 				() => mockTransaction as unknown as TransactionStore
 			);
 
-			const expectedReadableAmount = formatUnits(
-				mockArgs.amount,
-				Number(mockEntity.token.decimals)
-			);
-
 			await manager.createDepositTransaction(mockArgs);
 
 			expect(TransactionStore).toHaveBeenCalledWith(
 				expect.objectContaining({
 					...mockArgs,
-					name: `Depositing ${expectedReadableAmount} ${mockEntity.token.symbol}`,
+					name: `Depositing ${mockArgs.amount} ${mockEntity.token.symbol}`,
 					errorMessage: 'Deposit failed.',
 					successMessage: 'Deposit successful.',
 					queryKey: mockArgs.queryKey,

--- a/packages/ui-components/src/lib/providers/transactions/TransactionManager.ts
+++ b/packages/ui-components/src/lib/providers/transactions/TransactionManager.ts
@@ -14,7 +14,6 @@ import {
 	type Address,
 	type Hex
 } from '@rainlanguage/orderbook';
-import { formatUnits } from 'viem';
 
 /**
  * Function type for adding toast notifications to the UI.
@@ -117,14 +116,14 @@ export class TransactionManager {
 	 * @param args.txHash - Hash of the transaction to track.
 	 * @param args.chainId - Chain ID where the transaction is being executed.
 	 * @param args.queryKey - The ID of the vault from which funds are withdrawn (used for query invalidation and UI links).
-	 * @param args.entity - The `SgVault` entity associated with this transaction.
+	 * @param args.entity - The `RaindexVault` entity associated with this transaction.
 	 * @returns A new Transaction instance configured for withdrawal.
 	 * @example
 	 * const tx = await manager.createWithdrawTransaction({
 	 *   txHash: '0x123...',
 	 *   chainId: 1,
 	 *   queryKey: '0x789...', // Vault ID
-	 *   entity: sgVaultInstance
+	 *   entity: raindexVault
 	 * });
 	 */
 	public async createWithdrawTransaction(
@@ -231,7 +230,7 @@ export class TransactionManager {
 	 * @param args.txHash - Hash of the transaction to track.
 	 * @param args.chainId - Chain ID where the transaction is being executed.
 	 * @param args.queryKey - The ID of the vault into which funds are deposited (used for query invalidation and UI links).
-	 * @param args.entity - The `SgVault` entity associated with this transaction.
+	 * @param args.entity - The `RaindexVault` entity associated with this transaction.
 	 * @param args.amount - The amount of tokens being deposited.
 	 * @returns A new Transaction instance configured for deposit.
 	 * @example
@@ -239,20 +238,19 @@ export class TransactionManager {
 	 *   txHash: '0xdef...',
 	 *   chainId: 1,
 	 *   queryKey: '0x789...', // Vault ID
-	 *   entity: sgVaultInstance,
-	 *   amount: 1000n
+	 *   entity: raindexVault,
+	 *   amount: '1000'
 	 * });
 	 */
 	public async createDepositTransaction(
 		args: InternalTransactionArgs & {
-			amount: bigint;
+			amount: string;
 			entity: RaindexVault;
 			raindexClient: RaindexClient;
 		}
 	): Promise<Transaction> {
 		const tokenSymbol = args.entity.token.symbol;
-		const readableAmount = formatUnits(args.amount, Number(args.entity.token.decimals));
-		const name = `Depositing ${readableAmount} ${tokenSymbol}`;
+		const name = `Depositing ${args.amount} ${tokenSymbol}`;
 		const errorMessage = 'Deposit failed.';
 		const successMessage = 'Deposit successful.';
 		const {

--- a/packages/ui-components/src/lib/types/modal.ts
+++ b/packages/ui-components/src/lib/types/modal.ts
@@ -5,7 +5,7 @@ import type { Hex } from 'viem';
 export type VaultActionModalProps = {
 	open: boolean;
 	args: VaultActionArgs;
-	onSubmit: (amount: bigint) => void;
+	onSubmit: (amount: string) => void;
 };
 
 export type DisclaimerModalProps = {

--- a/packages/webapp/src/__tests__/DepositModal.test.ts
+++ b/packages/webapp/src/__tests__/DepositModal.test.ts
@@ -70,7 +70,7 @@ describe('DepositModal', () => {
 		const depositButton = screen.getByTestId('deposit-button');
 		await fireEvent.click(depositButton);
 
-		expect(mockOnSubmit).toHaveBeenCalledWith(BigInt(1000000000000000000));
+		expect(mockOnSubmit).toHaveBeenCalledWith('1');
 	});
 
 	it('shows error when amount exceeds balance', async () => {

--- a/packages/webapp/src/__tests__/WithdrawModal.test.ts
+++ b/packages/webapp/src/__tests__/WithdrawModal.test.ts
@@ -66,18 +66,13 @@ describe('WithdrawModal', () => {
 			expect(screen.getByText('Balance of connected wallet')).toBeInTheDocument();
 		});
 
-		const inputAmount = '1';
-		const expectedAmountBigInt = BigInt(
-			parseFloat(inputAmount) * 10 ** Number(mockVault.token.decimals)
-		);
-
 		const amountInput = screen.getByRole('textbox');
-		await fireEvent.input(amountInput, { target: { value: inputAmount } });
+		await fireEvent.input(amountInput, { target: { value: '1' } });
 
 		const withdrawButton = screen.getByTestId('withdraw-button');
 		await fireEvent.click(withdrawButton);
 
-		expect(defaultProps.onSubmit).toHaveBeenCalledWith(expectedAmountBigInt);
+		expect(defaultProps.onSubmit).toHaveBeenCalledWith('1');
 	});
 
 	it('shows error when amount exceeds balance', async () => {

--- a/packages/webapp/src/__tests__/handleVaultDeposit.test.ts
+++ b/packages/webapp/src/__tests__/handleVaultDeposit.test.ts
@@ -60,7 +60,7 @@ describe('handleVaultDeposit', () => {
 	});
 
 	describe('onSubmit callback from handleDepositModal', () => {
-		const mockAmount = 100n;
+		const mockAmount = '100';
 		const mockApprovalCalldata = '0xapprovalcalldata' as Hex;
 		const mockDepositCalldata = '0xdepositcalldata' as Hex;
 		const mockTxHashApproval = '0xtxhashapproval' as Hex;
@@ -83,9 +83,9 @@ describe('handleVaultDeposit', () => {
 			const onSubmitCall = mockHandleDepositModal.mock.calls[0][0].onSubmit;
 			await onSubmitCall(mockAmount);
 
-			expect(mockVault.getApprovalCalldata).toHaveBeenCalledWith(mockAmount.toString());
+			expect(mockVault.getApprovalCalldata).toHaveBeenCalledWith(mockAmount);
 			expect(mockErrToast).not.toHaveBeenCalledWith('Approval error');
-			expect(mockVault.getDepositCalldata).toHaveBeenCalledWith(mockAmount.toString());
+			expect(mockVault.getDepositCalldata).toHaveBeenCalledWith(mockAmount);
 			expect(mockHandleTransactionConfirmationModal).toHaveBeenCalledTimes(1);
 			expect(mockHandleTransactionConfirmationModal).toHaveBeenCalledWith({
 				open: true,
@@ -153,7 +153,7 @@ describe('handleVaultDeposit', () => {
 				entity: mockVault
 			});
 
-			expect(mockVault.getDepositCalldata).toHaveBeenCalledWith(mockAmount.toString());
+			expect(mockVault.getDepositCalldata).toHaveBeenCalledWith(mockAmount);
 			await waitFor(() => {
 				expect(mockHandleTransactionConfirmationModal).toHaveBeenCalledTimes(2);
 				expect(mockHandleTransactionConfirmationModal).toHaveBeenNthCalledWith(2, {

--- a/packages/webapp/src/__tests__/handleVaultWithdraw.test.ts
+++ b/packages/webapp/src/__tests__/handleVaultWithdraw.test.ts
@@ -91,11 +91,11 @@ describe('handleVaultWithdraw', () => {
 		await handleVaultWithdraw(mockDeps);
 
 		const onSubmitCall = mockHandleWithdrawModal.mock.calls[0][0].onSubmit;
-		await onSubmitCall(100n);
+		await onSubmitCall('100');
 
 		expect(mockHandleTransactionConfirmationModal).toHaveBeenCalledWith({
 			open: true,
-			modalTitle: 'Withdrawing 0.1 TEST...',
+			modalTitle: 'Withdrawing 100 TEST...',
 			args: {
 				entity: mockVault,
 				onConfirm: expect.any(Function),
@@ -116,7 +116,7 @@ describe('handleVaultWithdraw', () => {
 		await handleVaultWithdraw(mockDeps);
 
 		const onSubmitCall = mockHandleWithdrawModal.mock.calls[0][0].onSubmit;
-		await onSubmitCall(100n);
+		await onSubmitCall('100');
 
 		const onConfirmCall = mockHandleTransactionConfirmationModal.mock.calls[0][0].args.onConfirm;
 		onConfirmCall(mockTxHash);

--- a/packages/webapp/src/lib/components/DepositModal.svelte
+++ b/packages/webapp/src/lib/components/DepositModal.svelte
@@ -10,6 +10,7 @@
 	import { fade } from 'svelte/transition';
 	import truncateEthAddress from 'truncate-eth-address';
 	import type { AccountBalance } from '@rainlanguage/orderbook';
+	import { parseUnits } from 'viem';
 
 	/**
 	 * Modal component for depositing tokens into a vault.
@@ -17,11 +18,11 @@
 	 */
 	export let open: boolean;
 	export let args: VaultActionArgs;
-	export let onSubmit: (amount: bigint) => void;
+	export let onSubmit: (amount: string) => void;
 
 	const { vault, account } = args;
 
-	let amount: bigint = 0n;
+	let amount: string = '0';
 	let userBalance: AccountBalance = {
 		balance: BigInt(0),
 		formattedBalance: '0'
@@ -46,10 +47,13 @@
 
 	function handleClose() {
 		open = false;
-		amount = 0n;
+		amount = '0';
 	}
 
-	$: validation = validateAmount(amount, userBalance.balance);
+	$: validation = validateAmount(
+		BigInt(parseUnits(amount, Number(vault.token.decimals))),
+		userBalance.balance
+	);
 </script>
 
 <Modal bind:open autoclose={false} size="md">
@@ -88,8 +92,7 @@
 		<InputTokenAmount
 			bind:value={amount}
 			symbol={vault.token.symbol}
-			decimals={Number(vault.token.decimals)}
-			maxValue={userBalance.balance}
+			maxValue={userBalance.formattedBalance}
 		/>
 		<div class="flex flex-col justify-end gap-2">
 			<div class="flex gap-2">

--- a/packages/webapp/src/lib/components/WithdrawModal.svelte
+++ b/packages/webapp/src/lib/components/WithdrawModal.svelte
@@ -10,6 +10,7 @@
 	import { fade } from 'svelte/transition';
 	import truncateEthAddress from 'truncate-eth-address';
 	import type { AccountBalance } from '@rainlanguage/orderbook';
+	import { parseUnits } from 'viem';
 
 	/**
 	 * Modal component for withdrawing tokens from a vault.
@@ -17,11 +18,11 @@
 	 */
 	export let open: boolean;
 	export let args: VaultActionArgs;
-	export let onSubmit: (amount: bigint) => void;
+	export let onSubmit: (amount: string) => void;
 
 	const { vault, account } = args;
 
-	let amount: bigint = 0n;
+	let amount: string = '0';
 	let userBalance: AccountBalance = {
 		balance: 0n,
 		formattedBalance: '0'
@@ -46,10 +47,13 @@
 
 	function handleClose() {
 		open = false;
-		amount = 0n;
+		amount = '0';
 	}
 
-	$: validation = validateAmount(amount, BigInt(vault.balance));
+	$: validation = validateAmount(
+		parseUnits(amount, Number(vault.token.decimals)),
+		BigInt(vault.balance)
+	);
 </script>
 
 <Modal bind:open autoclose={false} size="md">
@@ -88,8 +92,7 @@
 		<InputTokenAmount
 			bind:value={amount}
 			symbol={vault.token.symbol}
-			decimals={Number(vault.token.decimals)}
-			maxValue={vault.balance}
+			maxValue={vault.formattedBalance}
 		/>
 		<div class="flex flex-col justify-end gap-2">
 			<div class="flex gap-2">

--- a/packages/webapp/src/lib/services/handleVaultDeposit.ts
+++ b/packages/webapp/src/lib/services/handleVaultDeposit.ts
@@ -1,5 +1,5 @@
 import type { RaindexClient, RaindexVault } from '@rainlanguage/orderbook';
-import { formatUnits, type Hex } from 'viem';
+import { type Hex } from 'viem';
 import type {
 	TransactionManager,
 	VaultActionModalProps,
@@ -16,22 +16,19 @@ export interface VaultDepositHandlerDependencies {
 	account: Hex;
 }
 
-export type DepositArgs = VaultDepositHandlerDependencies & { amount: bigint };
+export type DepositArgs = VaultDepositHandlerDependencies & { amount: string };
 
 async function executeDeposit(args: DepositArgs) {
 	const { raindexClient, amount, vault, handleTransactionConfirmationModal, errToast, manager } =
 		args;
-	const calldataResult = await vault.getDepositCalldata(amount.toString());
-	const displayAmount = vault.token.decimals
-		? formatUnits(amount, Number(vault.token.decimals))
-		: amount.toString();
+	const calldataResult = await vault.getDepositCalldata(amount);
 	if (calldataResult.error) {
 		return errToast(calldataResult.error.msg);
 	} else if (calldataResult.value) {
 		handleTransactionConfirmationModal({
 			open: true,
-			modalTitle: displayAmount
-				? `Depositing ${displayAmount} ${vault.token.symbol}`
+			modalTitle: amount
+				? `Depositing ${amount} ${vault.token.symbol}`
 				: `Depositing ${vault.token.symbol}`,
 			closeOnConfirm: false,
 			args: {
@@ -63,9 +60,9 @@ export async function handleVaultDeposit(deps: VaultDepositHandlerDependencies):
 			vault,
 			account
 		},
-		onSubmit: async (amount: bigint) => {
+		onSubmit: async (amount: string) => {
 			const depositArgs = { ...deps, amount };
-			const approvalResult = await vault.getApprovalCalldata(amount.toString());
+			const approvalResult = await vault.getApprovalCalldata(amount);
 			if (approvalResult.error) {
 				// If getting approval calldata fails, immediately invoke deposit
 				await executeDeposit(depositArgs);

--- a/packages/webapp/src/lib/services/handleVaultWithdraw.ts
+++ b/packages/webapp/src/lib/services/handleVaultWithdraw.ts
@@ -1,5 +1,5 @@
 import type { RaindexClient, RaindexVault } from '@rainlanguage/orderbook';
-import { formatUnits, type Hex } from 'viem';
+import { type Hex } from 'viem';
 import type { TransactionManager } from '@rainlanguage/ui-components';
 import type {
 	VaultActionModalProps,
@@ -32,17 +32,17 @@ export async function handleVaultWithdraw(deps: VaultWithdrawHandlerDependencies
 			vault,
 			account
 		},
-		onSubmit: async (amount: bigint) => {
+		onSubmit: async (amount: string) => {
 			let calldata: string;
 			try {
-				const calldataResult = await vault.getWithdrawCalldata(amount.toString());
+				const calldataResult = await vault.getWithdrawCalldata(amount);
 				if (calldataResult.error) {
 					return errToast(calldataResult.error.msg);
 				}
 				calldata = calldataResult.value;
 				handleTransactionConfirmationModal({
 					open: true,
-					modalTitle: `Withdrawing ${formatUnits(amount, Number(vault.token.decimals))} ${vault.token.symbol}...`,
+					modalTitle: `Withdrawing ${amount} ${vault.token.symbol}...`,
 					args: {
 						entity: vault,
 						toAddress: vault.orderbook,


### PR DESCRIPTION
> [!NOTE]
> This is the duplicate of https://github.com/rainlanguage/rain.orderbook/pull/2008. This works well after the upgrade

<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)

fix https://github.com/rainlanguage/rain.orderbook/issues/2007

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved error messages for negative and invalid token amounts during vault operations.

* **Bug Fixes**
  * Clarified input validation and error handling for deposit and withdrawal amounts, ensuring negative or empty values are properly rejected.

* **Refactor**
  * Unified token amount handling across the app: all user-facing amount inputs and related logic now use human-readable decimal strings instead of raw smallest-unit values or bigints.
  * Updated all relevant UI components, modals, and transaction handlers to accept and display string amounts, simplifying input and validation.

* **Documentation**
  * Updated documentation and code examples to reflect the new string-based, human-readable amount format.

* **Tests**
  * Adjusted and simplified tests to use string amounts and verify correct error messages and UI behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->