### PR TITLE
Add multiple withdrawal on vaults page

### DIFF
--- a/crates/common/src/raindex_client/vaults_list.rs
+++ b/crates/common/src/raindex_client/vaults_list.rs
@@ -159,6 +159,10 @@ impl RaindexVaultsList {
     /// the provided list of IDs. The original list order is preserved;
     /// the input `ids` order does not affect the result ordering.
     ///
+    /// Notes:
+    /// - Duplicate IDs in `ids` are ignored (deduplicated).
+    /// - Unknown IDs are ignored (they do not cause errors).
+    ///
     /// ## Examples
     ///
     /// ```javascript
@@ -383,6 +387,12 @@ mod tests {
             let ids = vec![];
             let filtered = vaults_list.pick_by_ids(ids);
             assert_eq!(filtered.items().len(), 0);
+
+            // Test duplicate IDs are deduped
+            let ids_duped = vec!["0x0123".to_string(), "0x0123".to_string()];
+            let filtered_duped = vaults_list.pick_by_ids(ids_duped);
+            assert_eq!(filtered_duped.items().len(), 1);
+            assert_eq!(filtered_duped.items()[0].id().to_string(), "0x0123");
         }
 
         #[tokio::test]

--- a/crates/common/src/raindex_client/vaults_list.rs
+++ b/crates/common/src/raindex_client/vaults_list.rs
@@ -39,8 +39,9 @@ impl RaindexVaultsList {
     }
 
     pub fn concat(&self, other: &RaindexVaultsList) -> RaindexVaultsList {
-        let mut combined_vaults = self.0.clone();
-        combined_vaults.extend(other.0.clone());
+        let mut combined_vaults = Vec::with_capacity(self.0.len() + other.0.len());
+        combined_vaults.extend_from_slice(&self.0);
+        combined_vaults.extend_from_slice(&other.0);
         RaindexVaultsList::new(combined_vaults)
     }
 
@@ -156,7 +157,8 @@ impl RaindexVaultsList {
     /// Filters vaults by a list of IDs and returns a new RaindexVaultsList
     ///
     /// Creates a new vault list containing only vaults whose IDs match
-    /// the provided list of IDs.
+    /// the provided list of IDs. The original list order is preserved;
+    /// the input `ids` order does not affect the result ordering.
     ///
     /// ## Examples
     ///

--- a/crates/common/src/raindex_client/vaults_list.rs
+++ b/crates/common/src/raindex_client/vaults_list.rs
@@ -259,7 +259,7 @@ mod tests {
             )
             .unwrap();
             let vaults = raindex_client.get_vaults(None, None, None).await.unwrap();
-            vaults
+            vaults.items()
         }
 
         #[tokio::test]

--- a/crates/common/src/raindex_client/vaults_list.rs
+++ b/crates/common/src/raindex_client/vaults_list.rs
@@ -191,7 +191,10 @@ impl RaindexVaultsList {
         unchecked_return_type = "RaindexVaultsList",
         preserve_js_class
     )]
-    pub fn concat_wasm(&self, other: &RaindexVaultsList) -> Result<RaindexVaultsList, VaultsListError> {
+    pub fn concat_wasm(
+        &self,
+        other: &RaindexVaultsList,
+    ) -> Result<RaindexVaultsList, VaultsListError> {
         Ok(self.concat(other))
     }
 }
@@ -379,7 +382,7 @@ mod tests {
             let vaults = get_vaults().await;
             let first_vault = vec![vaults[0].clone()];
             let second_vault = vec![vaults[1].clone()];
-            
+
             let vaults_list1 = RaindexVaultsList::new(first_vault);
             let vaults_list2 = RaindexVaultsList::new(second_vault);
 

--- a/crates/common/src/raindex_client/vaults_list.rs
+++ b/crates/common/src/raindex_client/vaults_list.rs
@@ -361,6 +361,13 @@ mod tests {
             let filtered = vaults_list.pick_by_ids(ids);
             assert_eq!(filtered.items().len(), 2);
 
+            // Verify order preservation: original vault sequence must prevail
+            let ids_reversed = vec!["0x0234".to_string(), "0x0123".to_string()];
+            let filtered_rev = vaults_list.pick_by_ids(ids_reversed);
+            assert_eq!(filtered_rev.items().len(), 2);
+            assert_eq!(filtered_rev.items()[0].id().to_string(), "0x0123");
+            assert_eq!(filtered_rev.items()[1].id().to_string(), "0x0234");
+
             // Test filtering by single ID
             let ids = vec!["0x0234".to_string()];
             let filtered = vaults_list.pick_by_ids(ids);

--- a/crates/common/src/raindex_client/vaults_list.rs
+++ b/crates/common/src/raindex_client/vaults_list.rs
@@ -26,13 +26,12 @@ impl RaindexVaultsList {
     }
 
     pub fn pick_by_ids(&self, ids: Vec<String>) -> RaindexVaultsList {
+        use std::collections::HashSet;
+        let ids_set: HashSet<String> = ids.into_iter().collect();
         let filtered_vaults = self
             .0
             .iter()
-            .filter(|vault| {
-                let vault_id = vault.id().to_string();
-                ids.contains(&vault_id)
-            })
+            .filter(|vault| ids_set.contains(&vault.id().to_string()))
             .cloned()
             .collect();
         RaindexVaultsList::new(filtered_vaults)

--- a/packages/orderbook/test/js_api/raindexClient.test.ts
+++ b/packages/orderbook/test/js_api/raindexClient.test.ts
@@ -1509,7 +1509,7 @@ describe('Rain Orderbook JS API Package Bindgen Tests - Raindex Client', async f
 					},
 					1
 				)
-			);
+			).items;
 
 			assert.equal(result.length, 2);
 			assert.equal(result[0].vaultId, BigInt(vault1.vaultId));

--- a/packages/ui-components/eslint.config.js
+++ b/packages/ui-components/eslint.config.js
@@ -20,16 +20,26 @@ export default ts.config(
 		rules: {
 			'no-console': process.env.NODE_ENV === 'production' || process.env.CI ? 'error' : 'off',
 			'no-trailing-spaces': 'error',
-			'@typescript-eslint/ban-ts-comment': 'off'
+			'@typescript-eslint/ban-ts-comment': 'off',
+			// Allow undefined variables for TypeScript (handled by TypeScript compiler)
+			'@typescript-eslint/no-undef': 'off'
 		}
 	},
 	{
 		files: ['**/*.svelte'],
-
 		languageOptions: {
 			parserOptions: {
-				parser: ts.parser
+				parser: ts.parser,
+				extraFileExtensions: ['.svelte'],
+				svelteFeatures: {
+					// Enable support for generics in Svelte components
+					experimentalGenerics: true
+				}
 			}
+		},
+		rules: {
+			// Allow undefined variables in Svelte generics
+			'no-undef': 'off'
 		}
 	},
 	{

--- a/packages/ui-components/eslint.config.js
+++ b/packages/ui-components/eslint.config.js
@@ -20,8 +20,6 @@ export default ts.config(
 		rules: {
 			'no-console': process.env.NODE_ENV === 'production' || process.env.CI ? 'error' : 'off',
 			'no-trailing-spaces': 'error',
-			'@typescript-eslint/ban-ts-comment': 'off',
-			// Allow undefined variables for TypeScript (handled by TypeScript compiler)
 			'@typescript-eslint/no-undef': 'off'
 		}
 	},

--- a/packages/ui-components/src/__tests__/ListViewOrderbookFilters.test.ts
+++ b/packages/ui-components/src/__tests__/ListViewOrderbookFilters.test.ts
@@ -30,8 +30,7 @@ vi.mock('$lib/hooks/useRaindexClient', () => ({
 	useRaindexClient: vi.fn()
 }));
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type ListViewOrderbookFiltersProps = ComponentProps<ListViewOrderbookFilters<any>>;
+type ListViewOrderbookFiltersProps = ComponentProps<ListViewOrderbookFilters>;
 
 describe('ListViewOrderbookFilters', () => {
 	const mockGetAllAccounts = vi.fn();

--- a/packages/ui-components/src/__tests__/OrdersListTable.test.ts
+++ b/packages/ui-components/src/__tests__/OrdersListTable.test.ts
@@ -76,8 +76,7 @@ const {
 	mockSelectedChainIdsStore
 } = await vi.hoisted(() => import('../lib/__mocks__/stores'));
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type OrdersListTableProps = ComponentProps<OrdersListTable<any>>;
+type OrdersListTableProps = ComponentProps<OrdersListTable>;
 
 const defaultProps: OrdersListTableProps = {
 	activeAccountsItems: mockActiveAccountsItemsStore,

--- a/packages/ui-components/src/__tests__/VaultsListTable.test.ts
+++ b/packages/ui-components/src/__tests__/VaultsListTable.test.ts
@@ -255,12 +255,18 @@ describe('VaultsListTable', () => {
 		expect(networkElements).toHaveLength(2);
 		expect(networkElements[0]).toHaveTextContent('Ethereum'); // chainId 1
 
-		const vaultCheckboxes = screen.getAllByRole('vault-checkbox');
+		const vaultCheckboxes = screen.getAllByTestId('vault-checkbox');
 		expect(vaultCheckboxes).toHaveLength(2);
 
 		// Select first vault to test basic selection functionality
 		await userEvent.click(vaultCheckboxes[0]);
 		expect(vaultCheckboxes[0]).toBeChecked();
+		// Second checkbox should be disabled (different network) and show tooltip on hover
+		expect(vaultCheckboxes[1]).toBeDisabled();
+		await userEvent.hover(vaultCheckboxes[1]);
+		await waitFor(() =>
+		  expect(screen.getByText('This vault is on a different network')).toBeInTheDocument()
+		);
 	});
 
 	it('disables selection for zero-balance vaults and shows tooltip', async () => {
@@ -295,7 +301,7 @@ describe('VaultsListTable', () => {
 
 		render(VaultsListTable, defaultProps as unknown as VaultsListTableProps);
 
-		const vaultCheckboxes = screen.getAllByRole('vault-checkbox');
+		const vaultCheckboxes = screen.getAllByTestId('vault-checkbox');
 		const firstCheckbox = vaultCheckboxes[0];
 		// Wait for vault table checkbox to render and be disabled
 		await waitFor(() => {
@@ -354,11 +360,11 @@ describe('VaultsListTable', () => {
 
 		// Wait for vault table checkboxes to render
 		await waitFor(() => {
-			const vaultCheckboxes = screen.getAllByRole('vault-checkbox');
+			const vaultCheckboxes = screen.getAllByTestId('vault-checkbox');
 			expect(vaultCheckboxes).toHaveLength(3);
 		});
 
-		const vaultCheckboxes = screen.getAllByRole('vault-checkbox');
+		const vaultCheckboxes = screen.getAllByTestId('vault-checkbox');
 
 		// Select first two vaults
 		await userEvent.click(vaultCheckboxes[0]);

--- a/packages/ui-components/src/__tests__/VaultsListTable.test.ts
+++ b/packages/ui-components/src/__tests__/VaultsListTable.test.ts
@@ -247,7 +247,7 @@ describe('VaultsListTable', () => {
 
 		// Wait for component to render
 		await waitFor(() => {
-			expect(screen.getByText('Ethereum')).toBeInTheDocument();
+			expect(screen.getByText('Input For')).toBeInTheDocument();
 		});
 
 		// Check that both vaults are displayed (different networks)
@@ -267,9 +267,6 @@ describe('VaultsListTable', () => {
 		await waitFor(() =>
 			expect(screen.getByText('This vault is on a different network')).toBeInTheDocument()
 		);
-		// Clicking a disabled checkbox should have no effect
-		await userEvent.click(vaultCheckboxes[1]);
-		expect(vaultCheckboxes[1]).not.toBeChecked();
 	});
 
 	it('disables selection for zero-balance vaults and shows tooltip', async () => {

--- a/packages/ui-components/src/__tests__/VaultsListTable.test.ts
+++ b/packages/ui-components/src/__tests__/VaultsListTable.test.ts
@@ -265,8 +265,11 @@ describe('VaultsListTable', () => {
 		expect(vaultCheckboxes[1]).toBeDisabled();
 		await userEvent.hover(vaultCheckboxes[1]);
 		await waitFor(() =>
-		  expect(screen.getByText('This vault is on a different network')).toBeInTheDocument()
+			expect(screen.getByText('This vault is on a different network')).toBeInTheDocument()
 		);
+		// Clicking a disabled checkbox should have no effect
+		await userEvent.click(vaultCheckboxes[1]);
+		expect(vaultCheckboxes[1]).not.toBeChecked();
 	});
 
 	it('disables selection for zero-balance vaults and shows tooltip', async () => {

--- a/packages/ui-components/src/__tests__/VaultsListTable.test.ts
+++ b/packages/ui-components/src/__tests__/VaultsListTable.test.ts
@@ -82,8 +82,7 @@ const defaultProps = {
 	showMyItemsOnly: mockShowMyItemsOnlyStore
 };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type VaultsListTableProps = ComponentProps<VaultsListTable<any>>;
+type VaultsListTableProps = ComponentProps<VaultsListTable>;
 
 describe('VaultsListTable', () => {
 	beforeEach(() => {

--- a/packages/ui-components/src/__tests__/VaultsListTable.test.ts
+++ b/packages/ui-components/src/__tests__/VaultsListTable.test.ts
@@ -262,7 +262,7 @@ describe('VaultsListTable', () => {
 		await userEvent.click(vaultCheckboxes[0]);
 		expect(vaultCheckboxes[0]).toBeChecked();
 		// Second checkbox should be disabled (different network) and show tooltip on hover
-		expect(vaultCheckboxes[1]).toBeDisabled();
+		await waitFor(() => expect(vaultCheckboxes[1]).toBeDisabled());
 		await userEvent.hover(vaultCheckboxes[1]);
 		await waitFor(() =>
 			expect(screen.getByText('This vault is on a different network')).toBeInTheDocument()

--- a/packages/ui-components/src/__tests__/VaultsListTable.test.ts
+++ b/packages/ui-components/src/__tests__/VaultsListTable.test.ts
@@ -20,10 +20,6 @@ vi.mock('$lib/providers/toasts/useToasts', () => ({
 const mockMatchesAccount = vi.fn();
 const mockAccountStore = readable('0xabcdef1234567890abcdef1234567890abcdef12');
 
-vi.mock('$lib/providers/wallet/useAccount', () => ({
-	useAccount: vi.fn()
-}));
-
 vi.mock('$lib/hooks/useRaindexClient', () => ({
 	useRaindexClient: () => ({
 		getUniqueChainIds: vi.fn(() => ({
@@ -61,7 +57,7 @@ const mockVault = {
 } as unknown as RaindexVault;
 
 const mockVaultsList = {
-	items: [mockVault],
+	items: [mockVault]
 } as unknown as RaindexVaultsList;
 
 vi.mock('@tanstack/svelte-query');
@@ -207,7 +203,7 @@ describe('VaultsListTable', () => {
 		mockQuery.createInfiniteQuery = vi.fn((__options, _queryClient) => ({
 			subscribe: (fn: (value: any) => void) => {
 				fn({
-					data: { pages: [[]] },
+					data: { pages: [{ items: [] }] },
 					status: 'success',
 					isFetching: false,
 					isFetched: true

--- a/packages/ui-components/src/__tests__/VaultsListTable.test.ts
+++ b/packages/ui-components/src/__tests__/VaultsListTable.test.ts
@@ -3,13 +3,18 @@ import { render, screen, waitFor } from '@testing-library/svelte';
 import { describe, it, expect, vi, type Mock } from 'vitest';
 import VaultsListTable from '../lib/components/tables/VaultsListTable.svelte';
 import { readable } from 'svelte/store';
-import type { RaindexVault } from '@rainlanguage/orderbook';
+import { Float, type RaindexVault, type RaindexVaultsList } from '@rainlanguage/orderbook';
 import type { ComponentProps } from 'svelte';
 import userEvent from '@testing-library/user-event';
 import { useAccount } from '$lib/providers/wallet/useAccount';
+import { useToasts } from '$lib/providers/toasts/useToasts';
 
 vi.mock('$lib/providers/wallet/useAccount', () => ({
 	useAccount: vi.fn()
+}));
+
+vi.mock('$lib/providers/toasts/useToasts', () => ({
+	useToasts: vi.fn()
 }));
 
 const mockMatchesAccount = vi.fn();
@@ -41,7 +46,7 @@ const mockVault = {
 	id: '0x1234567890abcdef1234567890abcdef12345678',
 	owner: '0xabcdef1234567890abcdef1234567890abcdef12',
 	vaultId: BigInt(42),
-	balance: BigInt('1000000000000000000'),
+	balance: Float.parse('1000000000000000000').value,
 	formattedBalance: '1',
 	token: {
 		id: '0x1111111111111111111111111111111111111111',
@@ -54,6 +59,10 @@ const mockVault = {
 	ordersAsInput: [],
 	ordersAsOutput: []
 } as unknown as RaindexVault;
+
+const mockVaultsList = {
+	items: [mockVault],
+} as unknown as RaindexVaultsList;
 
 vi.mock('@tanstack/svelte-query');
 
@@ -91,6 +100,12 @@ describe('VaultsListTable', () => {
 			matchesAccount: mockMatchesAccount,
 			account: mockAccountStore
 		});
+		(useToasts as Mock).mockReturnValue({
+			errToast: vi.fn(),
+			successToast: vi.fn(),
+			warningToast: vi.fn(),
+			infoToast: vi.fn()
+		});
 	});
 	it('displays vault information correctly', async () => {
 		const mockQuery = vi.mocked(await import('@tanstack/svelte-query'));
@@ -98,7 +113,7 @@ describe('VaultsListTable', () => {
 		mockQuery.createInfiniteQuery = vi.fn((__options, _queryClient) => ({
 			subscribe: (fn: (value: any) => void) => {
 				fn({
-					data: { pages: [[mockVault]] },
+					data: { pages: [mockVaultsList] },
 					status: 'success',
 					isFetching: false,
 					isFetched: true
@@ -122,7 +137,7 @@ describe('VaultsListTable', () => {
 		mockQuery.createInfiniteQuery = vi.fn((__options, _queryClient) => ({
 			subscribe: (fn: (value: any) => void) => {
 				fn({
-					data: { pages: [[mockVault]] },
+					data: { pages: [mockVaultsList] },
 					status: 'success',
 					isFetching: false,
 					isFetched: true
@@ -151,7 +166,7 @@ describe('VaultsListTable', () => {
 		mockQuery.createInfiniteQuery = vi.fn((__options, _queryClient) => ({
 			subscribe: (fn: (value: any) => void) => {
 				fn({
-					data: { pages: [[mockVault]] },
+					data: { pages: [mockVaultsList] },
 					status: 'success',
 					isFetching: false,
 					isFetched: true

--- a/packages/ui-components/src/lib/components/ListViewOrderbookFilters.svelte
+++ b/packages/ui-components/src/lib/components/ListViewOrderbookFilters.svelte
@@ -1,4 +1,4 @@
-<script lang="ts" generics="T">
+<script lang="ts">
 	import { useRaindexClient } from '$lib/hooks/useRaindexClient';
 	import type { QueryObserverResult } from '@tanstack/svelte-query';
 	import type { Readable } from 'svelte/store';

--- a/packages/ui-components/src/lib/components/TanstackAppTable.svelte
+++ b/packages/ui-components/src/lib/components/TanstackAppTable.svelte
@@ -14,9 +14,9 @@
 	export let query: CreateInfiniteQueryResult<InfiniteData<InputData, unknown>, Error>;
 	export let emptyMessage: string = 'None found';
 	export let rowHoverable = true;
-	// Selector to extract T[] from each page of type R
-	export let dataSelector: (pageData: InputData) => DataItem[] = (data) =>
-		data as unknown as DataItem[];
+	// Selector to extract DataItem[] from each page of type InputData
+	export let dataSelector: (pageData: InputData) => DataItem[] = (pageData) =>
+		Array.isArray(pageData) ? (pageData as unknown as DataItem[]) : [];
 
 	// Transform the query data by applying dataSelector to each page
 	$: data = $query.data

--- a/packages/ui-components/src/lib/components/TanstackAppTable.svelte
+++ b/packages/ui-components/src/lib/components/TanstackAppTable.svelte
@@ -42,7 +42,7 @@
 		}}
 	/>
 </div>
-{#if data?.pages[0].length === 0}
+{#if (data?.pages?.[0]?.length ?? 0) === 0}
 	<div data-testid="emptyMessage" class="text-center text-gray-900 dark:text-white">
 		{emptyMessage}
 	</div>
@@ -56,7 +56,6 @@
 		</TableHead>
 		<TableBody>
 			{#each data.pages as page}
-				<!-- {#each dataSelector($query)?.pages as page} -->
 				{#each page as item}
 					<TableBodyRow
 						class="whitespace-nowrap"

--- a/packages/ui-components/src/lib/components/TanstackAppTable.svelte
+++ b/packages/ui-components/src/lib/components/TanstackAppTable.svelte
@@ -1,4 +1,4 @@
-<script lang="ts" generics="T">
+<script lang="ts" generics="DataItem, InputData = DataItem[]">
 	import { invalidateTanstackQueries } from '$lib/queries/queryClient';
 	import Refresh from './icon/Refresh.svelte';
 	import type { CreateInfiniteQueryResult, InfiniteData } from '@tanstack/svelte-query';
@@ -11,10 +11,20 @@
 	const dispatch = createEventDispatcher();
 
 	export let queryKey: string;
-	// eslint-disable-next-line no-undef
-	export let query: CreateInfiniteQueryResult<InfiniteData<T[], unknown>, Error>;
+	export let query: CreateInfiniteQueryResult<InfiniteData<InputData, unknown>, Error>;
 	export let emptyMessage: string = 'None found';
 	export let rowHoverable = true;
+	// Selector to extract T[] from each page of type R
+	export let dataSelector: (pageData: InputData) => DataItem[] = (data) =>
+		data as unknown as DataItem[];
+
+	// Transform the query data by applying dataSelector to each page
+	$: data = $query.data
+		? {
+				...$query.data,
+				pages: $query.data.pages.map((page) => dataSelector(page))
+			}
+		: undefined;
 </script>
 
 <div data-testid="title" class="flex h-16 w-full items-center justify-end">
@@ -32,11 +42,11 @@
 		}}
 	/>
 </div>
-{#if $query.data?.pages[0].length === 0}
+{#if data?.pages[0].length === 0}
 	<div data-testid="emptyMessage" class="text-center text-gray-900 dark:text-white">
 		{emptyMessage}
 	</div>
-{:else if $query.data}
+{:else if data}
 	<Table
 		divClass="cursor-pointer rounded-lg overflow-auto dark:border-none border"
 		hoverable={rowHoverable}
@@ -45,7 +55,8 @@
 			<slot name="head" />
 		</TableHead>
 		<TableBody>
-			{#each $query.data?.pages as page}
+			{#each data.pages as page}
+				<!-- {#each dataSelector($query)?.pages as page} -->
 				{#each page as item}
 					<TableBodyRow
 						class="whitespace-nowrap"

--- a/packages/ui-components/src/lib/components/charts/LightweightChart.svelte
+++ b/packages/ui-components/src/lib/components/charts/LightweightChart.svelte
@@ -1,4 +1,4 @@
-<script lang="ts" generics="T extends keyof SeriesOptionsMap, D, O">
+<script lang="ts" generics="T extends keyof SeriesOptionsMap, O">
 	import type { Readable } from 'svelte/store';
 
 	// eslint-disable-next-line no-undef

--- a/packages/ui-components/src/lib/components/detail/TanstackOrderQuote.svelte
+++ b/packages/ui-components/src/lib/components/detail/TanstackOrderQuote.svelte
@@ -1,4 +1,4 @@
-<script lang="ts" generics="T">
+<script lang="ts">
 	import { useToasts } from '$lib/providers/toasts/useToasts';
 	import { invalidateTanstackQueries } from '$lib/queries/queryClient';
 	import Refresh from '../icon/Refresh.svelte';

--- a/packages/ui-components/src/lib/components/tables/OrderTradesListTable.svelte
+++ b/packages/ui-components/src/lib/components/tables/OrderTradesListTable.svelte
@@ -56,9 +56,11 @@
 			return lastPage.length === DEFAULT_PAGE_SIZE ? lastPageParam + 1 : undefined;
 		}
 	});
+
+	const AppTable = TanstackAppTable<RaindexTrade>;
 </script>
 
-<TanstackAppTable
+<AppTable
 	query={orderTradesQuery}
 	emptyMessage="No trades found"
 	rowHoverable={false}
@@ -126,4 +128,4 @@
 			</TableBodyCell>
 		{/if}
 	</svelte:fragment>
-</TanstackAppTable>
+</AppTable>

--- a/packages/ui-components/src/lib/components/tables/OrdersListTable.svelte
+++ b/packages/ui-components/src/lib/components/tables/OrdersListTable.svelte
@@ -1,4 +1,4 @@
-<script lang="ts" generics="T">
+<script lang="ts">
 	import { getNetworkName } from '$lib/utils/getNetworkName';
 	import { goto } from '$app/navigation';
 	import { DotsVerticalOutline } from 'flowbite-svelte-icons';

--- a/packages/ui-components/src/lib/components/tables/VaultBalanceChangesTable.svelte
+++ b/packages/ui-components/src/lib/components/tables/VaultBalanceChangesTable.svelte
@@ -1,4 +1,4 @@
-<script lang="ts" generics="T">
+<script lang="ts">
 	import { Heading, TableHeadCell, TableBodyCell } from 'flowbite-svelte';
 	import { createInfiniteQuery } from '@tanstack/svelte-query';
 	import { RaindexVault, type RaindexVaultBalanceChange } from '@rainlanguage/orderbook';

--- a/packages/ui-components/src/lib/components/tables/VaultsListTable.svelte
+++ b/packages/ui-components/src/lib/components/tables/VaultsListTable.svelte
@@ -240,8 +240,9 @@
 					disabled={isDisabled(item, selectedVaultsOnChainId)}
 					on:change={getToggleSelectVaultHandler(item.id, item.chainId)}
 					on:click={stopPropagation}
+					aria-label={`Select vault ${item.id}`}
 				/>
-				{#if isDisabled(item, selectedVaultsOnChainId)}
+				{#if $account === item.owner && isDisabled(item, selectedVaultsOnChainId)}
 					<Tooltip>
 						{isZeroBalance(item)
 							? 'This vault has a zero balance'

--- a/packages/ui-components/src/lib/components/tables/VaultsListTable.svelte
+++ b/packages/ui-components/src/lib/components/tables/VaultsListTable.svelte
@@ -239,14 +239,14 @@
 			<TableBodyCell tdClass="px-0" on:click={stopPropagation}>
 				<Checkbox
 					data-testid="vault-checkbox"
-					class={`block px-2 py-4 ${$account !== item.owner ? 'invisible' : ''}`}
+					class={`block px-2 py-4 ${$account?.toLowerCase() !== item.owner.toLowerCase() ? 'invisible' : ''}`}
 					checked={selectedVaults.has(item.id)}
 					disabled={isDisabled(item, selectedVaultsOnChainId)}
 					on:change={getToggleSelectVaultHandler(item.id, item.chainId)}
 					on:click={stopPropagation}
 					aria-label={`Select vault ${item.id}`}
 				/>
-				{#if $account === item.owner && isDisabled(item, selectedVaultsOnChainId)}
+				{#if $account?.toLowerCase() === item.owner.toLowerCase() && isDisabled(item, selectedVaultsOnChainId)}
 					<Tooltip>
 						{isZeroBalance(item)
 							? 'This vault has a zero balance'

--- a/packages/ui-components/src/lib/components/tables/VaultsListTable.svelte
+++ b/packages/ui-components/src/lib/components/tables/VaultsListTable.svelte
@@ -220,7 +220,7 @@
 			</div>
 		</svelte:fragment>
 		<svelte:fragment slot="head">
-			<TableHeadCell padding="p-0"></TableHeadCell>
+			<TableHeadCell padding="p-0"><span class="sr-only">Select</span></TableHeadCell>
 			<TableHeadCell padding="p-4">Network</TableHeadCell>
 			<TableHeadCell padding="px-4 py-4">Vault ID</TableHeadCell>
 			<TableHeadCell padding="px-4 py-4">Orderbook</TableHeadCell>

--- a/packages/ui-components/src/lib/components/tables/VaultsListTable.svelte
+++ b/packages/ui-components/src/lib/components/tables/VaultsListTable.svelte
@@ -146,6 +146,10 @@
 				<RaindexVaultsList[]>[]
 			);
 			// Now we can combine filtered VaultLists into one
+			if (filteredVaultListResults.length === 0) {
+				errToast('No selected vaults found in the loaded pages. Please refresh and try again.');
+				return;
+			}
 			const [first, ...rest] = filteredVaultListResults;
 			const combinedVaultsList = rest.reduce((prev, cur) => {
 				const result = prev.concat(cur);
@@ -230,7 +234,7 @@
 		<svelte:fragment slot="bodyRow" let:item>
 			<TableBodyCell tdClass="px-0" on:click={stopPropagation}>
 				<Checkbox
-					role="vault-checkbox"
+					data-testid="vault-checkbox"
 					class={`block px-2 py-4 ${$account !== item.owner ? 'invisible' : ''}`}
 					checked={selectedVaults.has(item.id)}
 					disabled={isDisabled(item)}

--- a/packages/ui-components/src/lib/components/tables/VaultsListTable.svelte
+++ b/packages/ui-components/src/lib/components/tables/VaultsListTable.svelte
@@ -1,4 +1,4 @@
-<script lang="ts" generics="T">
+<script lang="ts">
 	import { toHex } from 'viem';
 	import { useRaindexClient } from '$lib/hooks/useRaindexClient';
 	import { Button, Dropdown, DropdownItem, TableBodyCell, TableHeadCell } from 'flowbite-svelte';
@@ -10,7 +10,7 @@
 	import OrderOrVaultHash from '../OrderOrVaultHash.svelte';
 	import Hash, { HashType } from '../Hash.svelte';
 	import { DEFAULT_PAGE_SIZE, DEFAULT_REFRESH_INTERVAL } from '../../queries/constants';
-	import { RaindexVault } from '@rainlanguage/orderbook';
+	import { RaindexVault, RaindexVaultsList } from '@rainlanguage/orderbook';
 	import { QKEY_TOKENS, QKEY_VAULTS } from '../../queries/keys';
 	import type { AppStoresInterface } from '$lib/types/appStores.ts';
 	import { useAccount } from '$lib/providers/wallet/useAccount';
@@ -83,13 +83,13 @@
 		},
 		initialPageParam: 0,
 		getNextPageParam(lastPage, _allPages, lastPageParam) {
-			return lastPage.length === DEFAULT_PAGE_SIZE ? lastPageParam + 1 : undefined;
+			return lastPage.items.length === DEFAULT_PAGE_SIZE ? lastPageParam + 1 : undefined;
 		},
 		refetchInterval: DEFAULT_REFRESH_INTERVAL,
 		enabled: true
 	});
 
-	const AppTable = TanstackAppTable<RaindexVault>;
+	const AppTable = TanstackAppTable<RaindexVault, RaindexVaultsList>;
 </script>
 
 {#if $query}
@@ -106,6 +106,7 @@
 	/>
 	<AppTable
 		{query}
+		dataSelector={(page) => page.items}
 		queryKey={QKEY_VAULTS}
 		emptyMessage="No Vaults Found"
 		on:clickRow={(e) => {

--- a/packages/ui-components/src/lib/components/tables/VaultsListTable.svelte
+++ b/packages/ui-components/src/lib/components/tables/VaultsListTable.svelte
@@ -113,7 +113,7 @@
 			}
 		} else {
 			selectedVaults.add(vaultId);
-			if (!selectedVaultsOnChainId) {
+			if (selectedVaultsOnChainId === null) {
 				selectedVaultsOnChainId = chainId;
 			}
 		}
@@ -212,9 +212,7 @@
 					<Tooltip>
 						{isZeroBalance(item)
 							? 'This vault has a zero balance'
-							: !isSameChainId(item)
-								? 'This vault is on a different network'
-								: 'This vault has a non-zero balance'}
+							: 'This vault is on a different network'}
 					</Tooltip>
 				{/if}
 			</TableBodyCell>

--- a/packages/ui-components/src/lib/components/tables/VaultsListTable.svelte
+++ b/packages/ui-components/src/lib/components/tables/VaultsListTable.svelte
@@ -230,6 +230,7 @@
 		<svelte:fragment slot="bodyRow" let:item>
 			<TableBodyCell tdClass="px-0" on:click={stopPropagation}>
 				<Checkbox
+					role="vault-checkbox"
 					class={`block px-2 py-4 ${$account !== item.owner ? 'invisible' : ''}`}
 					checked={selectedVaults.has(item.id)}
 					disabled={isDisabled(item)}

--- a/packages/ui-components/src/lib/components/tables/VaultsListTable.svelte
+++ b/packages/ui-components/src/lib/components/tables/VaultsListTable.svelte
@@ -171,11 +171,11 @@
 		if (!ZERO_FLOAT) return true;
 		return item.balance.eq(ZERO_FLOAT).value;
 	};
-	const isSameChainId = (item: RaindexVault) => {
-		return selectedVaultsOnChainId === null || selectedVaultsOnChainId === item.chainId;
+	const isSameChainId = (item: RaindexVault, chainId: number | null) => {
+		return chainId === null || chainId === item.chainId;
 	};
-	const isDisabled = (item: RaindexVault) => {
-		return !isSameChainId(item) || isZeroBalance(item);
+	const isDisabled = (item: RaindexVault, chainId: number | null) => {
+		return !isSameChainId(item, chainId) || isZeroBalance(item);
 	};
 	const AppTable = TanstackAppTable<RaindexVault, RaindexVaultsList>;
 </script>
@@ -237,11 +237,11 @@
 					data-testid="vault-checkbox"
 					class={`block px-2 py-4 ${$account !== item.owner ? 'invisible' : ''}`}
 					checked={selectedVaults.has(item.id)}
-					disabled={isDisabled(item)}
+					disabled={isDisabled(item, selectedVaultsOnChainId)}
 					on:change={getToggleSelectVaultHandler(item.id, item.chainId)}
 					on:click={stopPropagation}
 				/>
-				{#if isDisabled(item)}
+				{#if isDisabled(item, selectedVaultsOnChainId)}
 					<Tooltip>
 						{isZeroBalance(item)
 							? 'This vault has a zero balance'

--- a/packages/webapp/src/routes/vaults/+page.svelte
+++ b/packages/webapp/src/routes/vaults/+page.svelte
@@ -26,6 +26,10 @@
 	const { manager } = useTransactions();
 
 	async function onWithdrawAll(raindexClient: RaindexClient, vaultsList: RaindexVaultsList) {
+		if (!$account) {
+			errToast('Please connect your wallet to withdraw');
+			return;
+		}
 		await handleVaultsWithdrawAll({
 			raindexClient,
 			vaultsList,

--- a/packages/webapp/src/routes/vaults/+page.svelte
+++ b/packages/webapp/src/routes/vaults/+page.svelte
@@ -1,5 +1,11 @@
 <script lang="ts">
-	import { PageHeader, VaultsListTable } from '@rainlanguage/ui-components';
+	import {
+		PageHeader,
+		useAccount,
+		useToasts,
+		useTransactions,
+		VaultsListTable
+	} from '@rainlanguage/ui-components';
 	import { page } from '$app/stores';
 	import {
 		hideZeroBalanceVaults,
@@ -8,8 +14,28 @@
 		activeTokens
 	} from '$lib/stores/settings';
 	import { selectedChainIds } from '$lib/stores/settings';
+	import { handleTransactionConfirmationModal, handleWithdrawAllModal } from '$lib/services/modal';
+	import type { RaindexClient, RaindexVaultsList } from '@rainlanguage/orderbook';
+	import { handleVaultsWithdrawAll } from '../../lib/services/handleVaultsWithdrawAll';
+	import type { Hex } from 'viem';
 
 	const { activeAccountsItems, showInactiveOrders } = $page.data.stores;
+
+	const { account } = useAccount();
+	const { errToast } = useToasts();
+	const { manager } = useTransactions();
+
+	async function onWithdrawAll(raindexClient: RaindexClient, vaultsList: RaindexVaultsList) {
+		await handleVaultsWithdrawAll({
+			raindexClient,
+			vaultsList,
+			handleWithdrawAllModal,
+			handleTransactionConfirmationModal,
+			errToast,
+			manager,
+			account: $account as Hex
+		});
+	}
 </script>
 
 <PageHeader title="Vaults" pathname={$page.url.pathname} />
@@ -22,4 +48,5 @@
 	{hideZeroBalanceVaults}
 	{activeTokens}
 	{selectedChainIds}
+	{onWithdrawAll}
 />

--- a/packages/webapp/src/routes/vaults/+page.svelte
+++ b/packages/webapp/src/routes/vaults/+page.svelte
@@ -16,7 +16,7 @@
 	import { selectedChainIds } from '$lib/stores/settings';
 	import { handleTransactionConfirmationModal, handleWithdrawAllModal } from '$lib/services/modal';
 	import type { RaindexClient, RaindexVaultsList } from '@rainlanguage/orderbook';
-	import { handleVaultsWithdrawAll } from '../../lib/services/handleVaultsWithdrawAll';
+	import { handleVaultsWithdrawAll } from '$lib/services/handleVaultsWithdrawAll';
 	import type { Hex } from 'viem';
 
 	const { activeAccountsItems, showInactiveOrders } = $page.data.stores;


### PR DESCRIPTION
## Motivation
It closes #1963 

## Solution
- Added checkboxes on Vaults page to select vaults
- After clicking on "Withdraw selected" button it runs the same flow as already exist (in Order details page)
- This PR introduces `RaindexVaultsList.pickByIds` method, that filters out internal `Vec<RaindexVault>` by ids and returns a new instance of `RaindexVaultsList`. This way it makes it possible to withdraw multiple vaults using the existing flow.
- It also makes checkboxes disabled and shows tooltip with the reason in two cases: you have selected vaults on different network, or it has zero balance.

<img width="487" height="492" alt="image" src="https://github.com/user-attachments/assets/d5672212-f995-462d-8926-897acf823b36" />

## Checks
By submitting this for review, I'm confirming I've done the following:
- [X] made this PR as small as possible
- [X] unit-tested any new functionality
- [X] linked any relevant issues or PRs
- [X] included screenshots (if this involves a front-end change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Vaults page: select multiple vaults (same network only) and withdraw them together with confirmation modal and toasts.
  * Vaults list: new wrapper for vault results exposing pick-by-IDs and concat operations usable from JS/WASM.

* **Refactor**
  * Vault queries now return the new wrapped list; tables adapted to handle per-page shaping and cross-page selection.

* **Tests**
  * Unit and wasm tests updated for the wrapped list shape; added coverage for selection, disabled-state, tooltips, cross-network, and withdraw flows.

* **Chores**
  * ESLint/Svelte config tweaks and removal/simplification of several component generics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->