### PR TITLE
feat: Add price ratio functionality to DotrainOrderGuide

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,40 @@ We use wasm-bindgen to create the `orderbook` package from our Rust crates, whic
 
 This same package is [published to npm](https://www.npmjs.com/package/@rainlanguage/orderbook), allowing developers to more easily create their own frontends for Raindex.
 
+## New Features
+
+### 🎯 Dynamic Price Ratio Support
+
+The DotrainOrderGui now supports dynamic price ratio resolution using `${io-ratio(input, output)}` expressions in YAML configurations. This allows strategy writers to reference real-time market prices without hardcoding values.
+
+**Key Benefits:**
+- **Automatic Price Fetching**: Strategies can automatically use current market prices
+- **User-Friendly Defaults**: No more manual price lookups for users
+- **Flexible Integration**: Works with any price API (SushiSwap, 1inch, CoinGecko, etc.)
+- **Error Handling**: Comprehensive error handling for network issues and invalid data
+
+**Quick Example:**
+```yaml
+fields:
+  - binding: initial-io
+    name: Kickoff ${order.inputs.0.token.symbol} per ${order.outputs.0.token.symbol}
+    description: Current market price: ${io-ratio(order.inputs.0.address, order.outputs.0.address)}
+    default: ${io-ratio(order.inputs.0.address, order.outputs.0.address)}
+```
+
+```javascript
+const priceCallback = async (inputTokenAddress, outputTokenAddress) => {
+  const response = await fetch(`/api/price/${inputTokenAddress}/${outputTokenAddress}`);
+  return (await response.json()).ratio.toString();
+};
+
+const gui = await DotrainOrderGui.newWithDeploymentAndPriceCallback(
+  yaml, deployment, stateCallback, priceCallback
+);
+```
+
+📚 **Learn More**: See [docs/price-ratio-functionality.md](docs/price-ratio-functionality.md) for complete documentation and [examples/](examples/) for implementation examples.
+
 ## Setup for local development
 
 ### Environment Setup

--- a/crates/js_api/src/gui/state_management.rs
+++ b/crates/js_api/src/gui/state_management.rs
@@ -224,6 +224,43 @@ impl DotrainOrderGui {
         #[wasm_export(param_description = "Optional callback for future state changes")]
         state_update_callback: Option<js_sys::Function>,
     ) -> Result<DotrainOrderGui, GuiError> {
+        Self::new_from_state_with_price_callback(dotrain, serialized, state_update_callback, None)
+            .await
+    }
+
+    /// Restores a GUI instance from previously serialized state with price callback support.
+    ///
+    /// Creates a new GUI instance with all configuration restored from a saved state and
+    /// includes support for price callbacks to resolve ${io-ratio(input, output)} expressions.
+    ///
+    /// ## Examples
+    ///
+    /// ```javascript
+    /// const priceCallback = async (inputTokenAddress, outputTokenAddress) => {
+    ///   return await fetchPriceRatio(inputTokenAddress, outputTokenAddress);
+    /// };
+    ///
+    /// const result = await DotrainOrderGui.newFromStateWithPriceCallback(
+    ///   dotrainYaml,
+    ///   savedState,
+    ///   stateCallback,
+    ///   priceCallback
+    /// );
+    /// ```
+    #[wasm_export(
+        js_name = "newFromStateWithPriceCallback",
+        preserve_js_class,
+        return_description = "Fully restored GUI instance with price callback support"
+    )]
+    pub async fn new_from_state_with_price_callback(
+        #[wasm_export(param_description = "Must match the original dotrain content exactly")]
+        dotrain: String,
+        #[wasm_export(param_description = "Previously serialized state string")] serialized: String,
+        #[wasm_export(param_description = "Optional callback for future state changes")]
+        state_update_callback: Option<js_sys::Function>,
+        #[wasm_export(param_description = "Optional function for fetching price ratios")]
+        price_callback: Option<js_sys::Function>,
+    ) -> Result<DotrainOrderGui, GuiError> {
         let compressed = URL_SAFE.decode(serialized)?;
 
         let mut decoder = GzDecoder::new(&compressed[..]);
@@ -256,6 +293,7 @@ impl DotrainOrderGui {
             deposits,
             selected_deployment: state.selected_deployment.clone(),
             state_update_callback,
+            price_callback,
         };
 
         let deployment_select_tokens = GuiCfg::parse_select_tokens(

--- a/crates/settings/src/gui.rs
+++ b/crates/settings/src/gui.rs
@@ -840,6 +840,7 @@ impl YamlParseableValue for GuiCfg {
                         };
 
                         let default = optional_string(field_yaml, "default");
+                        let interpolated_default = default.map(|default| context.interpolate(&default)).transpose()?;
                         let show_custom_field = optional_string(field_yaml, "show-custom-field").map(|v| v.eq("true"));
 
                         let validation = optional_hash(field_yaml, "validation").map(|validation_yaml| {
@@ -853,7 +854,7 @@ impl YamlParseableValue for GuiCfg {
                             name: interpolated_name,
                             description: interpolated_description,
                             presets,
-                            default,
+                            default: interpolated_default,
                             show_custom_field,
                             validation,
                         };

--- a/docs/price-ratio-functionality.md
+++ b/docs/price-ratio-functionality.md
@@ -1,0 +1,286 @@
+# Price Ratio Functionality in DotrainOrderGui
+
+## Overview
+
+The DotrainOrderGui now supports dynamic price ratio resolution using the `${io-ratio(input, output)}` syntax in YAML configurations. This feature allows strategy writers to reference external price data without hardcoding values, making strategies more dynamic and user-friendly.
+
+## Key Features
+
+- **Dynamic Price Resolution**: Automatically fetch current market prices for token pairs
+- **YAML Integration**: Use `${io-ratio(input, output)}` expressions in field names, descriptions, and default values
+- **Error Handling**: Comprehensive error handling for network issues, invalid addresses, and callback failures
+- **Backward Compatibility**: Existing YAML configurations continue to work without changes
+
+## Usage
+
+### JavaScript Integration
+
+When creating a DotrainOrderGui instance, provide a price callback function:
+
+```javascript
+// Define your price callback function
+const priceCallback = async (inputTokenAddress, outputTokenAddress) => {
+  try {
+    // Example using SushiSwap API
+    const response = await fetch(
+      `https://api.sushi.com/price/${inputTokenAddress}/${outputTokenAddress}`
+    );
+    const data = await response.json();
+    return data.ratio.toString();
+  } catch (error) {
+    throw new Error(`Failed to fetch price: ${error.message}`);
+  }
+};
+
+// Create GUI instance with price callback
+const result = await DotrainOrderGui.newWithDeploymentAndPriceCallback(
+  dotrainYaml,
+  "mainnet-deployment",
+  (serializedState) => {
+    localStorage.setItem('orderState', serializedState);
+  },
+  priceCallback
+);
+
+if (result.error) {
+  console.error("Failed to initialize GUI:", result.error.readableMsg);
+} else {
+  const gui = result.value;
+  // Use the GUI instance...
+}
+```
+
+### YAML Configuration Examples
+
+#### 1. Default Field Values
+
+```yaml
+deployments:
+  auction-dca:
+    name: Auction DCA Strategy
+    description: Dollar-cost averaging using auctions
+    fields:
+      - binding: initial-io
+        name: Kickoff ${order.inputs.0.token.symbol} per ${order.outputs.0.token.symbol}
+        description: |
+          The initial ${order.inputs.0.token.symbol} per ${order.outputs.0.token.symbol} to kickoff the first auction.
+          
+          This ratio is calculated in the same way as the baseline ratio.
+          It must be greater than the baseline ratio, regardless of what you are selling or buying.
+        default: ${io-ratio(order.inputs.0.address, order.outputs.0.address)}
+```
+
+#### 2. Field Names and Descriptions
+
+```yaml
+deployments:
+  limit-order:
+    name: Limit Order
+    description: Deploy a limit order
+    fields:
+      - binding: fixed-io
+        name: ${order.inputs.0.token.symbol} per ${order.outputs.0.token.symbol}
+        description: |
+          Fixed exchange rate (${order.inputs.0.token.symbol} received per 1 ${order.outputs.0.token.symbol} sold).
+          
+          Current market price: ${io-ratio(order.inputs.0.address, order.outputs.0.address)}
+          
+          Set your desired rate above or below the current market price.
+```
+
+#### 3. Complex Strategy Example
+
+```yaml
+deployments:
+  dsf-strategy:
+    name: Dutch Auction Strategy
+    description: Automated Dutch auction with dynamic pricing
+    fields:
+      - binding: start-ratio
+        name: Starting ${order.inputs.0.token.symbol}/${order.outputs.0.token.symbol} Ratio
+        description: |
+          Starting price for the Dutch auction.
+          
+          Current market rate: ${io-ratio(order.inputs.0.address, order.outputs.0.address)}
+          
+          Recommended: Set 5-10% above market rate for better execution.
+        default: ${io-ratio(order.inputs.0.address, order.outputs.0.address)}
+        
+      - binding: end-ratio
+        name: Ending ${order.inputs.0.token.symbol}/${order.outputs.0.token.symbol} Ratio
+        description: |
+          Minimum acceptable price for the Dutch auction.
+          
+          Current market rate: ${io-ratio(order.inputs.0.address, order.outputs.0.address)}
+          
+          Recommended: Set at or slightly below market rate.
+```
+
+## Price Callback Implementation
+
+### Requirements
+
+Your price callback function must:
+
+1. **Accept two parameters**: `inputTokenAddress` and `outputTokenAddress` (both strings)
+2. **Return a Promise**: That resolves to a string representation of the price ratio
+3. **Handle errors**: Throw meaningful error messages for debugging
+
+### Example Implementations
+
+#### Using SushiSwap API
+
+```javascript
+const sushiPriceCallback = async (inputTokenAddress, outputTokenAddress) => {
+  const response = await fetch(
+    `https://api.sushi.com/price/${inputTokenAddress}/${outputTokenAddress}`
+  );
+  
+  if (!response.ok) {
+    throw new Error(`SushiSwap API error: ${response.status}`);
+  }
+  
+  const data = await response.json();
+  return data.price.toString();
+};
+```
+
+#### Using 1inch API
+
+```javascript
+const oneInchPriceCallback = async (inputTokenAddress, outputTokenAddress) => {
+  const response = await fetch(
+    `https://api.1inch.io/v5.0/1/quote?fromTokenAddress=${inputTokenAddress}&toTokenAddress=${outputTokenAddress}&amount=1000000000000000000`
+  );
+  
+  const data = await response.json();
+  const ratio = data.toTokenAmount / data.fromTokenAmount;
+  return ratio.toString();
+};
+```
+
+#### Using Multiple Sources with Fallback
+
+```javascript
+const robustPriceCallback = async (inputTokenAddress, outputTokenAddress) => {
+  const sources = [
+    () => fetchFromSushiSwap(inputTokenAddress, outputTokenAddress),
+    () => fetchFromUniswap(inputTokenAddress, outputTokenAddress),
+    () => fetchFromOneInch(inputTokenAddress, outputTokenAddress),
+  ];
+  
+  for (const source of sources) {
+    try {
+      return await source();
+    } catch (error) {
+      console.warn(`Price source failed: ${error.message}`);
+    }
+  }
+  
+  throw new Error('All price sources failed');
+};
+```
+
+## Error Handling
+
+The system provides comprehensive error handling:
+
+### Common Error Types
+
+1. **No Price Callback**: When `${io-ratio(...)}` is used but no callback was provided
+2. **Invalid Token Addresses**: When token addresses are empty or malformed
+3. **Network Errors**: When the price callback fails due to network issues
+4. **Invalid Response**: When the callback returns non-string or empty values
+5. **Invalid Expression**: When the `io-ratio` syntax is incorrect
+
+### Error Messages
+
+All errors include user-friendly messages:
+
+```javascript
+// Example error handling
+try {
+  const gui = await DotrainOrderGui.newWithDeploymentAndPriceCallback(
+    yaml, deployment, stateCallback, priceCallback
+  );
+} catch (error) {
+  if (error.message.includes('Price callback')) {
+    console.error('Price fetching failed:', error.message);
+    // Show user-friendly message about network connectivity
+  } else {
+    console.error('GUI initialization failed:', error.message);
+  }
+}
+```
+
+## Best Practices
+
+### 1. Robust Price Callbacks
+
+- Implement timeout handling
+- Use multiple price sources with fallbacks
+- Cache prices for a short duration to avoid rate limiting
+- Validate token addresses before making API calls
+
+### 2. YAML Configuration
+
+- Always provide fallback values for critical fields
+- Use descriptive field names and descriptions
+- Test configurations with different token pairs
+- Consider rate limiting when using multiple price ratios
+
+### 3. User Experience
+
+- Show loading states while fetching prices
+- Provide clear error messages for price fetching failures
+- Allow users to manually override price ratios if needed
+- Cache successful price fetches to improve performance
+
+## Migration Guide
+
+### From Hardcoded Values
+
+**Before:**
+```yaml
+- binding: initial-io
+  name: Initial USDC per WETH
+  default: "1800.0"
+```
+
+**After:**
+```yaml
+- binding: initial-io
+  name: Initial ${order.inputs.0.token.symbol} per ${order.outputs.0.token.symbol}
+  description: Current market price: ${io-ratio(order.inputs.0.address, order.outputs.0.address)}
+  default: ${io-ratio(order.inputs.0.address, order.outputs.0.address)}
+```
+
+### Updating JavaScript Code
+
+**Before:**
+```javascript
+const gui = await DotrainOrderGui.newWithDeployment(yaml, deployment, stateCallback);
+```
+
+**After:**
+```javascript
+const gui = await DotrainOrderGui.newWithDeploymentAndPriceCallback(
+  yaml, deployment, stateCallback, priceCallback
+);
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **"Price callback not available"**: Ensure you're using `newWithDeploymentAndPriceCallback` instead of `newWithDeployment`
+2. **"Invalid io-ratio expression"**: Check the syntax: `${io-ratio(input_path, output_path)}`
+3. **"Price callback failed"**: Check network connectivity and API endpoints
+4. **Empty price values**: Ensure your callback returns a non-empty string
+
+### Debug Tips
+
+- Test your price callback function independently
+- Use browser developer tools to inspect network requests
+- Check console for detailed error messages
+- Validate token addresses are correct format (0x...)

--- a/examples/price-callback-examples.js
+++ b/examples/price-callback-examples.js
@@ -1,0 +1,329 @@
+/**
+ * Price Callback Examples for DotrainOrderGui
+ * 
+ * This file demonstrates various implementations of price callback functions
+ * that can be used with the DotrainOrderGui price ratio functionality.
+ */
+
+// ============================================================================
+// Basic Price Callback Examples
+// ============================================================================
+
+/**
+ * Simple SushiSwap price callback
+ * Uses SushiSwap's API to fetch current token prices
+ */
+const sushiSwapPriceCallback = async (inputTokenAddress, outputTokenAddress) => {
+  try {
+    const response = await fetch(
+      `https://api.sushi.com/price/${inputTokenAddress}/${outputTokenAddress}`
+    );
+    
+    if (!response.ok) {
+      throw new Error(`SushiSwap API returned ${response.status}: ${response.statusText}`);
+    }
+    
+    const data = await response.json();
+    
+    if (!data.price) {
+      throw new Error('No price data returned from SushiSwap API');
+    }
+    
+    return data.price.toString();
+  } catch (error) {
+    throw new Error(`SushiSwap price fetch failed: ${error.message}`);
+  }
+};
+
+/**
+ * 1inch price callback with proper amount scaling
+ * Uses 1inch API to get accurate swap quotes
+ */
+const oneInchPriceCallback = async (inputTokenAddress, outputTokenAddress) => {
+  try {
+    // Use 1 ETH worth of tokens for quote (18 decimals)
+    const amount = '1000000000000000000';
+    
+    const response = await fetch(
+      `https://api.1inch.io/v5.0/1/quote?` +
+      `fromTokenAddress=${inputTokenAddress}&` +
+      `toTokenAddress=${outputTokenAddress}&` +
+      `amount=${amount}`
+    );
+    
+    if (!response.ok) {
+      throw new Error(`1inch API returned ${response.status}: ${response.statusText}`);
+    }
+    
+    const data = await response.json();
+    
+    if (!data.toTokenAmount || !data.fromTokenAmount) {
+      throw new Error('Invalid quote data from 1inch API');
+    }
+    
+    // Calculate price ratio
+    const ratio = parseFloat(data.toTokenAmount) / parseFloat(data.fromTokenAmount);
+    return ratio.toString();
+  } catch (error) {
+    throw new Error(`1inch price fetch failed: ${error.message}`);
+  }
+};
+
+// ============================================================================
+// Advanced Price Callback Examples
+// ============================================================================
+
+/**
+ * Multi-source price callback with fallback
+ * Tries multiple price sources and falls back if one fails
+ */
+const robustPriceCallback = async (inputTokenAddress, outputTokenAddress) => {
+  const sources = [
+    {
+      name: 'SushiSwap',
+      fetch: () => sushiSwapPriceCallback(inputTokenAddress, outputTokenAddress)
+    },
+    {
+      name: '1inch',
+      fetch: () => oneInchPriceCallback(inputTokenAddress, outputTokenAddress)
+    },
+    {
+      name: 'CoinGecko',
+      fetch: () => coinGeckoPriceCallback(inputTokenAddress, outputTokenAddress)
+    }
+  ];
+  
+  const errors = [];
+  
+  for (const source of sources) {
+    try {
+      console.log(`Trying ${source.name} for price data...`);
+      const price = await source.fetch();
+      console.log(`✅ ${source.name} returned price: ${price}`);
+      return price;
+    } catch (error) {
+      console.warn(`❌ ${source.name} failed: ${error.message}`);
+      errors.push(`${source.name}: ${error.message}`);
+    }
+  }
+  
+  throw new Error(`All price sources failed:\n${errors.join('\n')}`);
+};
+
+/**
+ * Cached price callback to avoid rate limiting
+ * Caches prices for a short duration to improve performance
+ */
+const cachedPriceCallback = (() => {
+  const cache = new Map();
+  const CACHE_DURATION = 30000; // 30 seconds
+  
+  return async (inputTokenAddress, outputTokenAddress) => {
+    const cacheKey = `${inputTokenAddress}-${outputTokenAddress}`;
+    const cached = cache.get(cacheKey);
+    
+    // Return cached price if still valid
+    if (cached && Date.now() - cached.timestamp < CACHE_DURATION) {
+      console.log(`📦 Using cached price for ${cacheKey}: ${cached.price}`);
+      return cached.price;
+    }
+    
+    try {
+      // Fetch fresh price
+      const price = await robustPriceCallback(inputTokenAddress, outputTokenAddress);
+      
+      // Cache the result
+      cache.set(cacheKey, {
+        price,
+        timestamp: Date.now()
+      });
+      
+      console.log(`💾 Cached new price for ${cacheKey}: ${price}`);
+      return price;
+    } catch (error) {
+      // If we have a stale cached price, use it as fallback
+      if (cached) {
+        console.warn(`⚠️ Using stale cached price due to fetch error: ${error.message}`);
+        return cached.price;
+      }
+      throw error;
+    }
+  };
+})();
+
+/**
+ * CoinGecko price callback (helper for robust callback)
+ * Uses CoinGecko's API for price data
+ */
+const coinGeckoPriceCallback = async (inputTokenAddress, outputTokenAddress) => {
+  try {
+    // Note: CoinGecko requires token IDs, not addresses
+    // This is a simplified example - you'd need to map addresses to CoinGecko IDs
+    const response = await fetch(
+      `https://api.coingecko.com/api/v3/simple/token_price/ethereum?` +
+      `contract_addresses=${inputTokenAddress},${outputTokenAddress}&` +
+      `vs_currencies=usd`
+    );
+    
+    if (!response.ok) {
+      throw new Error(`CoinGecko API returned ${response.status}: ${response.statusText}`);
+    }
+    
+    const data = await response.json();
+    
+    const inputPrice = data[inputTokenAddress.toLowerCase()]?.usd;
+    const outputPrice = data[outputTokenAddress.toLowerCase()]?.usd;
+    
+    if (!inputPrice || !outputPrice) {
+      throw new Error('Price data not available for one or both tokens');
+    }
+    
+    const ratio = inputPrice / outputPrice;
+    return ratio.toString();
+  } catch (error) {
+    throw new Error(`CoinGecko price fetch failed: ${error.message}`);
+  }
+};
+
+// ============================================================================
+// Usage Examples
+// ============================================================================
+
+/**
+ * Example: Creating DotrainOrderGui with price callback
+ */
+async function createGuiWithPricing() {
+  const dotrainYaml = `
+    # Your YAML configuration here
+    # Can include \${io-ratio(input, output)} expressions
+  `;
+  
+  try {
+    // Create GUI with cached price callback for best performance
+    const result = await DotrainOrderGui.newWithDeploymentAndPriceCallback(
+      dotrainYaml,
+      'auction-dca', // deployment name
+      (serializedState) => {
+        // State update callback
+        localStorage.setItem('orderState', serializedState);
+        console.log('State updated and saved');
+      },
+      cachedPriceCallback // Price callback
+    );
+    
+    if (result.error) {
+      console.error('❌ Failed to create GUI:', result.error.readableMsg);
+      return null;
+    }
+    
+    console.log('✅ GUI created successfully with price callback support');
+    return result.value;
+    
+  } catch (error) {
+    console.error('❌ Unexpected error:', error.message);
+    return null;
+  }
+}
+
+/**
+ * Example: Testing price callback independently
+ */
+async function testPriceCallback() {
+  const USDC = '0xA0b86a33E6441b8e776f89d2b5B977c737C5e5b5';
+  const WETH = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
+  
+  console.log('Testing price callbacks...');
+  
+  try {
+    // Test simple callback
+    console.log('\n--- Testing SushiSwap callback ---');
+    const sushiPrice = await sushiSwapPriceCallback(USDC, WETH);
+    console.log(`SushiSwap USDC/WETH price: ${sushiPrice}`);
+    
+    // Test robust callback
+    console.log('\n--- Testing robust callback ---');
+    const robustPrice = await robustPriceCallback(USDC, WETH);
+    console.log(`Robust USDC/WETH price: ${robustPrice}`);
+    
+    // Test cached callback
+    console.log('\n--- Testing cached callback ---');
+    const cachedPrice1 = await cachedPriceCallback(USDC, WETH);
+    console.log(`Cached USDC/WETH price (first call): ${cachedPrice1}`);
+    
+    const cachedPrice2 = await cachedPriceCallback(USDC, WETH);
+    console.log(`Cached USDC/WETH price (second call): ${cachedPrice2}`);
+    
+  } catch (error) {
+    console.error('❌ Price callback test failed:', error.message);
+  }
+}
+
+/**
+ * Example: Error handling for price callbacks
+ */
+async function handlePriceErrors() {
+  const invalidAddress = '0xinvalid';
+  const WETH = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
+  
+  try {
+    await robustPriceCallback(invalidAddress, WETH);
+  } catch (error) {
+    console.error('Expected error for invalid address:', error.message);
+    
+    // Show user-friendly error message
+    const userMessage = error.message.includes('price sources failed') 
+      ? 'Unable to fetch current market price. Please check your internet connection and try again.'
+      : 'Invalid token configuration. Please verify token addresses.';
+      
+    console.log('User-friendly message:', userMessage);
+  }
+}
+
+// ============================================================================
+// Export for use in other modules
+// ============================================================================
+
+// For ES6 modules
+export {
+  sushiSwapPriceCallback,
+  oneInchPriceCallback,
+  robustPriceCallback,
+  cachedPriceCallback,
+  createGuiWithPricing,
+  testPriceCallback,
+  handlePriceErrors
+};
+
+// For CommonJS
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {
+    sushiSwapPriceCallback,
+    oneInchPriceCallback,
+    robustPriceCallback,
+    cachedPriceCallback,
+    createGuiWithPricing,
+    testPriceCallback,
+    handlePriceErrors
+  };
+}
+
+// ============================================================================
+// Browser usage example
+// ============================================================================
+
+// If running in browser, you can test the callbacks
+if (typeof window !== 'undefined') {
+  window.priceCallbackExamples = {
+    sushiSwapPriceCallback,
+    oneInchPriceCallback,
+    robustPriceCallback,
+    cachedPriceCallback,
+    createGuiWithPricing,
+    testPriceCallback,
+    handlePriceErrors
+  };
+  
+  console.log('Price callback examples loaded. Try:');
+  console.log('- priceCallbackExamples.testPriceCallback()');
+  console.log('- priceCallbackExamples.createGuiWithPricing()');
+}

--- a/examples/price-ratio-example.yaml
+++ b/examples/price-ratio-example.yaml
@@ -1,0 +1,206 @@
+---
+# Example YAML configuration demonstrating price ratio functionality
+# This shows how to use ${io-ratio(input, output)} expressions in various contexts
+
+networks:
+  mainnet:
+    rpc: https://eth-mainnet.g.alchemy.com/v2/your-api-key
+    chain-id: 1
+
+tokens:
+  usdc:
+    network: mainnet
+    address: 0xA0b86a33E6441b8e776f89d2b5B977c737C5e5b5
+    symbol: USDC
+    decimals: 6
+    label: USD Coin
+
+  weth:
+    network: mainnet
+    address: 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2
+    symbol: WETH
+    decimals: 18
+    label: Wrapped Ether
+
+orders:
+  auction-order:
+    inputs:
+      - token: usdc
+        vault-id: 0x01
+    outputs:
+      - token: weth
+        vault-id: 0x02
+
+deployments:
+  # Example 1: Auction DCA Strategy with dynamic pricing
+  auction-dca:
+    name: Auction DCA Strategy
+    description: |
+      Dollar-cost averaging strategy using Dutch auctions.
+      Automatically starts auctions at current market prices.
+    order: auction-order
+    fields:
+      - binding: initial-io
+        name: Kickoff ${order.inputs.0.token.symbol} per ${order.outputs.0.token.symbol}
+        description: |
+          The initial ${order.inputs.0.token.symbol} per ${order.outputs.0.token.symbol} ratio to start the first auction.
+          
+          Current market price: ${io-ratio(order.inputs.0.address, order.outputs.0.address)}
+          
+          This should be set higher than the baseline ratio to ensure the auction starts 
+          at a favorable price and drops down to the baseline over time.
+          
+          Recommended: Set 2-5% above current market price.
+        default: ${io-ratio(order.inputs.0.address, order.outputs.0.address)}
+
+      - binding: baseline-io
+        name: Baseline ${order.inputs.0.token.symbol} per ${order.outputs.0.token.symbol}
+        description: |
+          The minimum acceptable ${order.inputs.0.token.symbol} per ${order.outputs.0.token.symbol} ratio.
+          
+          Current market price: ${io-ratio(order.inputs.0.address, order.outputs.0.address)}
+          
+          Auctions will drop from the initial ratio down to this baseline ratio.
+          Set this at or slightly below current market price.
+
+      - binding: auction-duration
+        name: Auction Duration (seconds)
+        description: How long each auction should run before reaching the baseline price.
+        default: "3600"
+
+  # Example 2: Limit Order with price reference
+  limit-order:
+    name: Limit Order
+    description: |
+      Simple limit order with current market price reference.
+      Set your desired exchange rate above or below market price.
+    order: auction-order
+    fields:
+      - binding: fixed-io
+        name: ${order.inputs.0.token.symbol} per ${order.outputs.0.token.symbol} Rate
+        description: |
+          Fixed exchange rate for this limit order.
+          
+          You will receive ${order.inputs.0.token.symbol} for every 1 ${order.outputs.0.token.symbol} you sell.
+          
+          📊 Current market price: ${io-ratio(order.inputs.0.address, order.outputs.0.address)}
+          
+          💡 Tip: Set above market price to sell at a premium, or below to buy at a discount.
+
+      - binding: amount
+        name: ${order.outputs.0.token.symbol} Amount to Sell
+        description: |
+          Amount of ${order.outputs.0.token.symbol} you want to sell.
+          
+          At current market price (${io-ratio(order.inputs.0.address, order.outputs.0.address)}), 
+          this would get you approximately [amount × current_price] ${order.inputs.0.token.symbol}.
+
+  # Example 3: Advanced Dutch Auction Strategy
+  dutch-auction-strategy:
+    name: Dutch Auction Strategy  
+    description: |
+      Advanced Dutch auction with multiple price points and dynamic pricing.
+      Perfect for large orders that need to be executed over time.
+    order: auction-order
+    fields:
+      - binding: start-premium
+        name: Starting Premium (%)
+        description: |
+          Percentage above current market price to start the auction.
+          
+          Current market price: ${io-ratio(order.inputs.0.address, order.outputs.0.address)} ${order.inputs.0.token.symbol}/${order.outputs.0.token.symbol}
+          
+          Example: 10% means auction starts at 110% of current market price.
+        default: "5"
+
+      - binding: end-discount
+        name: Ending Discount (%)
+        description: |
+          Percentage below current market price to end the auction.
+          
+          Current market price: ${io-ratio(order.inputs.0.address, order.outputs.0.address)} ${order.inputs.0.token.symbol}/${order.outputs.0.token.symbol}
+          
+          Example: 2% means auction ends at 98% of current market price.
+        default: "2"
+
+      - binding: auction-frequency
+        name: Auction Frequency (hours)
+        description: |
+          How often to start new auctions.
+          
+          With current market price at ${io-ratio(order.inputs.0.address, order.outputs.0.address)}, 
+          more frequent auctions may capture better price movements.
+        default: "24"
+
+  # Example 4: Cross-chain arbitrage strategy
+  arbitrage-strategy:
+    name: Cross-Chain Arbitrage
+    description: |
+      Automated arbitrage strategy that monitors price differences.
+      Uses current market prices to determine profitable opportunities.
+    order: auction-order
+    fields:
+      - binding: min-profit-threshold
+        name: Minimum Profit Threshold (%)
+        description: |
+          Minimum profit percentage required to execute arbitrage.
+          
+          Current ${order.inputs.0.token.symbol}/${order.outputs.0.token.symbol} rate: ${io-ratio(order.inputs.0.address, order.outputs.0.address)}
+          
+          Strategy will only execute when profit exceeds this threshold.
+        default: "0.5"
+
+      - binding: max-slippage
+        name: Maximum Slippage (%)
+        description: |
+          Maximum acceptable slippage during execution.
+          
+          Based on current liquidity and price ${io-ratio(order.inputs.0.address, order.outputs.0.address)}, 
+          consider market depth when setting this value.
+        default: "1.0"
+
+  # Example 5: DCA with price-based adjustments
+  smart-dca:
+    name: Smart DCA Strategy
+    description: |
+      Dollar-cost averaging with intelligent price-based position sizing.
+      Buys more when prices are low, less when prices are high.
+    order: auction-order
+    fields:
+      - binding: base-amount
+        name: Base ${order.outputs.0.token.symbol} Amount
+        description: |
+          Base amount of ${order.outputs.0.token.symbol} to sell in each DCA cycle.
+          
+          At current price ${io-ratio(order.inputs.0.address, order.outputs.0.address)}, 
+          this will acquire approximately [base_amount × current_price] ${order.inputs.0.token.symbol}.
+
+      - binding: price-multiplier
+        name: Price-Based Multiplier
+        description: |
+          Multiplier applied based on price deviation from moving average.
+          
+          Current price: ${io-ratio(order.inputs.0.address, order.outputs.0.address)}
+          
+          Values > 1.0 increase buying when price is below average.
+          Values < 1.0 decrease buying when price is above average.
+        default: "1.2"
+
+      - binding: dca-interval
+        name: DCA Interval (hours)
+        description: |
+          Time between DCA purchases.
+          
+          Consider market volatility and current price ${io-ratio(order.inputs.0.address, order.outputs.0.address)} 
+          when setting frequency.
+        default: "168"  # Weekly
+
+gui:
+  name: Dynamic Pricing Strategies
+  description: |
+    Advanced trading strategies with real-time price integration.
+    
+    All strategies automatically fetch current market prices to provide 
+    intelligent defaults and helpful context for your trading decisions.
+    
+    Current ${order.inputs.0.token.symbol}/${order.outputs.0.token.symbol} market rate: ${io-ratio(order.inputs.0.address, order.outputs.0.address)}


### PR DESCRIPTION
- Add support for ${io-ratio(input, output)} expressions in YAML configurations
- Extend Context system to parse and resolve price ratio expressions
- Add price callback support to DotrainOrderGui for external price fetching
- Implement comprehensive error handling for price callback failures
- Add backward-compatible API with newWithDeploymentAndPriceCallback method
- Include complete documentation and examples for price ratio usage
- Support dynamic field names, descriptions, and default values with market prices

Resolves #1998: Ability to reference price ratios in field names/descriptions and for default field values



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Dynamic price ratio resolution in the GUI using an external price callback.
  - YAML support for ${io-ratio(...)} expressions across names, descriptions, and defaults.
  - Optional pricing support when creating the GUI and when restoring from saved state.
  - Interpolated default values for GUI fields.

- Documentation
  - Added README section, comprehensive guide, JavaScript examples, and a YAML example demonstrating dynamic pricing.

- Tests
  - Added tests for price resolution, callback handling, and error cases.

- Chores
  - Updated external dependency reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->