### PR TITLE
Updating workflows for fork PRs

### DIFF
--- a/.github/workflows/git-clean.yaml
+++ b/.github/workflows/git-clean.yaml
@@ -1,5 +1,9 @@
 name: Git is clean
-on: [push]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 concurrency:
   group: ${{ github.ref }}-git-clean

--- a/.github/workflows/rainix.yaml
+++ b/.github/workflows/rainix.yaml
@@ -49,6 +49,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       COMMIT_SHA: ${{ github.sha }}
+      # This is the address of a metaboard on Sepolia. It's needed for the sol
+      # artifact deploy dry run.
+      DEPLOY_METABOARD_ADDRESS: "0x77991674ca8887D4ee1b583DB7324B41d5f894c4"
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/rainix.yaml
+++ b/.github/workflows/rainix.yaml
@@ -1,5 +1,9 @@
 name: Rainix CI
-on: [push]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 concurrency:
   group: ${{ github.ref }}-rainix
@@ -44,15 +48,6 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}
     env:
-      DEPLOYMENT_KEY: ${{ github.ref == 'refs/heads/main' && secrets.PRIVATE_KEY || secrets.PRIVATE_KEY_DEV }}
-      DEPLOY_METABOARD_ADDRESS: ${{ vars.CI_DEPLOY_SEPOLIA_METABOARD_ADDRESS }}
-      CI_FORK_SEPOLIA_BLOCK_NUMBER: ${{ vars.CI_FORK_SEPOLIA_BLOCK_NUMBER }}
-      CI_FORK_SEPOLIA_DEPLOYER_ADDRESS: ${{ vars.CI_FORK_SEPOLIA_DEPLOYER_ADDRESS }}
-      CI_DEPLOY_SEPOLIA_RPC_URL: ${{ secrets.CI_DEPLOY_SEPOLIA_RPC_URL || vars.CI_DEPLOY_SEPOLIA_RPC_URL }}
-      CI_SEPOLIA_METABOARD_URL: ${{ vars.CI_SEPOLIA_METABOARD_URL }}
-      CI_DEPLOY_POLYGON_RPC_URL: ${{ secrets.CI_DEPLOY_POLYGON_RPC_URL }}
-      RPC_URL_ETHEREUM_FORK: ${{ secrets.RPC_URL_ETHEREUM_FORK }}
-      CI_DEPLOY_FLARE_RPC_URL: ${{ secrets.CI_DEPLOY_FLARE_RPC_URL }}
       COMMIT_SHA: ${{ github.sha }}
     steps:
       - uses: actions/checkout@v4
@@ -97,9 +92,5 @@ jobs:
       - run: ./pointers.sh
 
       - name: Run ${{ matrix.task }}
-        env:
-          ETH_RPC_URL: ${{ secrets.CI_DEPLOY_SEPOLIA_RPC_URL || vars.CI_DEPLOY_SEPOLIA_RPC_URL }}
-          ETHERSCAN_API_KEY: ${{ secrets.EXPLORER_VERIFICATION_KEY }}
-          DEPLOY_VERIFIER: ""
 
         run: nix develop -c ${{ matrix.task }}

--- a/.github/workflows/rainix.yaml
+++ b/.github/workflows/rainix.yaml
@@ -105,5 +105,7 @@ jobs:
           echo "Generated ephemeral deployment key for this run"
 
       - name: Run ${{ matrix.task }}
+        env:
+          ETH_RPC_URL: ${{ secrets.CI_DEPLOY_SEPOLIA_RPC_URL || vars.CI_DEPLOY_SEPOLIA_RPC_URL }}
 
         run: nix develop -c ${{ matrix.task }}

--- a/.github/workflows/rainix.yaml
+++ b/.github/workflows/rainix.yaml
@@ -49,6 +49,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       COMMIT_SHA: ${{ github.sha }}
+      # This is a test key, we don't broadcast our deploys during automated runs,
+      # but we still need a key to run the script. Should go without saying, but
+      # NEVER USE THIS IN PRODUCTION FOR ANYTHING.
+      DEPLOYMENT_KEY: "0xa590156781b232f3fc5361e153ab2c35ac94d172949d9e983bcbc4a29770c06b"
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/rainix.yaml
+++ b/.github/workflows/rainix.yaml
@@ -51,8 +51,7 @@ jobs:
       COMMIT_SHA: ${{ github.sha }}
       # This is the address of a metaboard on Sepolia. It's needed for the sol
       # artifact deploy dry run.
-      DEPLOY_METABOARD_ADDRESS: "0x77991674ca8887D4ee1b583DB7324B41d5f894c4"
-    steps:
+      DEPLOY_METABOARD_ADDRESS: ${{ vars.CI_DEPLOY_SEPOLIA_METABOARD_ADDRESS || '0x77991674ca8887D4ee1b583DB7324B41d5f894c4' }}    steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive

--- a/.github/workflows/rainix.yaml
+++ b/.github/workflows/rainix.yaml
@@ -49,10 +49,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       COMMIT_SHA: ${{ github.sha }}
-      # This is a test key, we don't broadcast our deploys during automated runs,
-      # but we still need a key to run the script. Should go without saying, but
-      # NEVER USE THIS IN PRODUCTION FOR ANYTHING.
-      DEPLOYMENT_KEY: "0xa590156781b232f3fc5361e153ab2c35ac94d172949d9e983bcbc4a29770c06b"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -94,6 +90,19 @@ jobs:
           gc-max-store-size-linux: 10G
 
       - run: ./pointers.sh
+
+      - name: Generate ephemeral deployment key
+        run: |
+          # Generate wallet within nix develop environment
+          WALLET_OUTPUT=$(nix develop -c cast wallet new)
+
+          # Extract the private key
+          KEY=$(echo "$WALLET_OUTPUT" | grep "Private key:" | awk '{print $3}')
+
+          # Store in GitHub environment (overwrites the hardcoded test key)
+          echo "DEPLOYMENT_KEY=$KEY" >> "$GITHUB_ENV"
+
+          echo "Generated ephemeral deployment key for this run"
 
       - name: Run ${{ matrix.task }}
 

--- a/.github/workflows/rainix.yaml
+++ b/.github/workflows/rainix.yaml
@@ -51,7 +51,8 @@ jobs:
       COMMIT_SHA: ${{ github.sha }}
       # This is the address of a metaboard on Sepolia. It's needed for the sol
       # artifact deploy dry run.
-      DEPLOY_METABOARD_ADDRESS: ${{ vars.CI_DEPLOY_SEPOLIA_METABOARD_ADDRESS || '0x77991674ca8887D4ee1b583DB7324B41d5f894c4' }}    steps:
+      DEPLOY_METABOARD_ADDRESS: ${{ vars.CI_DEPLOY_SEPOLIA_METABOARD_ADDRESS || '0x77991674ca8887D4ee1b583DB7324B41d5f894c4' }}
+    steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive

--- a/.github/workflows/rainix.yaml
+++ b/.github/workflows/rainix.yaml
@@ -109,6 +109,6 @@ jobs:
 
       - name: Run ${{ matrix.task }}
         env:
-          ETH_RPC_URL: ${{ secrets.CI_DEPLOY_SEPOLIA_RPC_URL || vars.CI_DEPLOY_SEPOLIA_RPC_URL }}
+          ETH_RPC_URL: ${{ secrets.CI_DEPLOY_SEPOLIA_RPC_URL || vars.CI_DEPLOY_SEPOLIA_RPC_URL || 'https://sepolia.gateway.tenderly.co' }}
 
         run: nix develop -c ${{ matrix.task }}

--- a/.github/workflows/tauri.yaml
+++ b/.github/workflows/tauri.yaml
@@ -1,5 +1,9 @@
 name: Tauri builds
-on: [push]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 concurrency:
   group: ${{ github.ref }}-tauri-build
@@ -24,13 +28,6 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     env:
-      DEPLOY_METABOARD_ADDRESS: ${{ vars.CI_DEPLOY_SEPOLIA_METABOARD_ADDRESS }}
-      CI_FORK_SEPOLIA_BLOCK_NUMBER: ${{ vars.CI_FORK_SEPOLIA_BLOCK_NUMBER }}
-      CI_FORK_SEPOLIA_DEPLOYER_ADDRESS: ${{ vars.CI_FORK_SEPOLIA_DEPLOYER_ADDRESS }}
-      CI_DEPLOY_SEPOLIA_RPC_URL: ${{ vars.CI_DEPLOY_SEPOLIA_RPC_URL }}
-      CI_SEPOLIA_METABOARD_URL: ${{ vars.CI_SEPOLIA_METABOARD_URL }}
-      CI_DEPLOY_POLYGON_RPC_URL: ${{ secrets.CI_DEPLOY_POLYGON_RPC_URL }}
-      RPC_URL_ETHEREUM_FORK: ${{ secrets.RPC_URL_ETHEREUM_FORK }}
       COMMIT_SHA: ${{ github.sha }}
     steps:
       - name: Free up disk space in action runner (Ubuntu)
@@ -83,14 +80,14 @@ jobs:
 
       - run: ./prep-all.sh
         env:
-          PUBLIC_WALLETCONNECT_PROJECT_ID: ${{ secrets.WALLETCONNECT_PROJECT_ID }}
+          PUBLIC_WALLETCONNECT_PROJECT_ID: ${{ secrets.WALLETCONNECT_PROJECT_ID || 'test' }}
 
       - run: nix develop .#tauri-shell -c ob-tauri-unit-test
 
       - run: nix develop .#tauri-shell --command ob-tauri-before-build-ci
         working-directory: ./tauri-app
         env:
-          WALLETCONNECT_PROJECT_ID: ${{ secrets.WALLETCONNECT_PROJECT_ID }}
+          WALLETCONNECT_PROJECT_ID: ${{ secrets.WALLETCONNECT_PROJECT_ID || 'test' }}
       - run: nix develop .#tauri-shell --command npm run svelte-lint-format-check
         working-directory: ./tauri-app
 
@@ -101,4 +98,3 @@ jobs:
       - run: rm -rf tauri-app/src-tauri/target/debug tauri-app/src-tauri/target/release
 
       - run: nix develop .#tauri-shell --command tauri-rs-test
-

--- a/.github/workflows/test-subgraph.yml
+++ b/.github/workflows/test-subgraph.yml
@@ -1,5 +1,9 @@
 name: Subgraph unit tests
-on: [push]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 concurrency:
   group: ${{ github.ref }}-subgraph

--- a/.github/workflows/test-ui-components.yaml
+++ b/.github/workflows/test-ui-components.yaml
@@ -1,5 +1,9 @@
 name: Test ui-components
-on: [push]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 concurrency:
   group: ${{ github.ref }}-ui-components
@@ -38,7 +42,7 @@ jobs:
 
       - run: ./prep-all.sh
         env:
-          PUBLIC_WALLETCONNECT_PROJECT_ID: ${{ secrets.WALLETCONNECT_PROJECT_ID }}
+          PUBLIC_WALLETCONNECT_PROJECT_ID: ${{ secrets.WALLETCONNECT_PROJECT_ID || 'test' }}
 
       - run: nix develop -c npm run svelte-lint-format-check
         working-directory: packages/ui-components

--- a/.github/workflows/test-webapp.yaml
+++ b/.github/workflows/test-webapp.yaml
@@ -1,5 +1,9 @@
 name: Test webapp
-on: [push]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 concurrency:
   group: ${{ github.ref }}-webapp
@@ -38,14 +42,14 @@ jobs:
 
       - run: ./prep-all.sh
         env:
-          PUBLIC_WALLETCONNECT_PROJECT_ID: ${{ secrets.WALLETCONNECT_PROJECT_ID }}
+          PUBLIC_WALLETCONNECT_PROJECT_ID: ${{ secrets.WALLETCONNECT_PROJECT_ID || 'test' }}
 
       - run: nix develop -c npm run svelte-lint-format-check
         working-directory: packages/webapp
         env:
-          PUBLIC_WALLETCONNECT_PROJECT_ID: ${{ secrets.WALLETCONNECT_PROJECT_ID }}
+          PUBLIC_WALLETCONNECT_PROJECT_ID: ${{ secrets.WALLETCONNECT_PROJECT_ID || 'test' }}
 
       - run: nix develop -c npm run test
         working-directory: packages/webapp
         env:
-          PUBLIC_WALLETCONNECT_PROJECT_ID: ${{ secrets.WALLETCONNECT_PROJECT_ID }}
+          PUBLIC_WALLETCONNECT_PROJECT_ID: ${{ secrets.WALLETCONNECT_PROJECT_ID || 'test' }}

--- a/.github/workflows/vercel-preview-pr-target.yaml
+++ b/.github/workflows/vercel-preview-pr-target.yaml
@@ -50,13 +50,6 @@ jobs:
           nix_conf: |
             keep-env-derivations = true
             keep-outputs = true
-      - name: Restore and save Nix store
-        uses: nix-community/cache-nix-action@v6
-        with:
-          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-
-          gc-max-store-size-linux: 1G
-
       - run: ./prep-all.sh
         env:
           PUBLIC_WALLETCONNECT_PROJECT_ID: test

--- a/.github/workflows/vercel-preview-pr-target.yaml
+++ b/.github/workflows/vercel-preview-pr-target.yaml
@@ -33,6 +33,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
        contents: read
+    env:
+      COMMIT_SHA: ${{ github.sha }}
     environment: vercel-preview
     steps:
       - name: Checkout PR head

--- a/.github/workflows/vercel-preview-pr-target.yaml
+++ b/.github/workflows/vercel-preview-pr-target.yaml
@@ -71,9 +71,9 @@ jobs:
         shell: bash --noprofile --norc -euo pipefail {0}
         run: |
           VERCEL_DIR="$(mktemp -d)"
-          npm install --no-audit --no-fund --no-save --prefix "$VERCEL_DIR" vercel@33.4.1
+          npm install --no-audit --no-fund --no-save --ignore-scripts --prefix "$VERCEL_DIR" vercel@33.4.1
           echo "VERCEL_BIN=$VERCEL_DIR/node_modules/.bin/vercel" >> "$GITHUB_ENV"
-      - name: Pull Vercel Environment Information
+          test -x "$VERCEL_DIR/node_modules/.bin/vercel"
         shell: bash --noprofile --norc -euo pipefail {0}
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID_PREVIEWS }}

--- a/.github/workflows/vercel-preview-pr-target.yaml
+++ b/.github/workflows/vercel-preview-pr-target.yaml
@@ -1,42 +1,49 @@
 ##
-## SECURITY MODEL FOR VERCEL PREVIEW DEPLOYS FOR INTERNAL BRANCHES (READ BEFORE EDITING)
+## SECURITY MODEL FOR VERCEL PREVIEW DEPLOYS (PR TARGET) — READ BEFORE EDITING
 ##
-## This workflow runs on non-main branch pushes in this repository (not forks):
-##  - PR-target preview deploys (for forks) are isolated in a separate workflow
-##    file and use a different Vercel org and project.
-##  - Regardless, secrets are passed only to the Vercel CLI steps (not to build/test steps).
+## This workflow allows preview deploys for fork PRs with strict safeguards:
+##  - Uses pull_request_target so secrets are available only in the base repo context.
+##  - Additionally requires a maintainer to add the 'vercel-preview' label AND approve the 'vercel-preview' environment.
+##  - Never runs when files in '.github/workflows/**' change (paths-ignore).
+##  - Builds PR code WITHOUT secrets using a placeholder env value.
+##  - Secrets are passed only to the Vercel CLI steps (not to build/test steps).
 ##  - Shell runs with 'bash --noprofile --norc -euo pipefail'.
 ##  - The Vercel CLI is invoked via an absolute path stored in $VERCEL_BIN to avoid PATH hijacking.
 ##
 ## WARNING: Changing any of the following may break the security model:
-##  - Triggers and environment usage.
+##  - Triggers (pull_request_target), label requirement, or environment approval.
+##  - The '.github/workflows/**' paths-ignore.
 ##  - Introducing PR-controlled inputs into steps that use secrets.
 ##  - Relaxing the shell/ PATH hardening, or calling 'vercel' via PATH.
 ##  - Moving secrets to top-level env or earlier steps.
 ## If you modify this file, re-validate these invariants.
-name: GitHub Actions Vercel Preview Deployment
+##
+name: GitHub Actions Vercel Preview Deployment (PR Target)
 on:
-  push:
-    branches-ignore:
-      - main
+  pull_request_target:
+    types: [opened, synchronize, reopened, labeled]
+    paths-ignore:
+      - ".github/workflows/**"
 concurrency:
-  group: ${{ format('{0}-vercel-preview', github.ref) }}
+  group: ${{ format('pr-{0}-vercel-preview', github.event.pull_request.number) }}
   cancel-in-progress: true
 jobs:
-  Deploy-Preview-Push:
-    if: github.event_name == 'push'
+  Deploy-Preview-PR:
+    if: contains(github.event.pull_request.labels.*.name, 'vercel-preview')
     runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: read
+    environment: vercel-preview
     env:
       COMMIT_SHA: ${{ github.sha }}
     steps:
-      - name: Checkout repository
+      - name: Checkout PR head
         uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: nixbuild/nix-quick-install-action@v30
         with:
@@ -46,23 +53,18 @@ jobs:
       - name: Restore and save Nix store
         uses: nix-community/cache-nix-action@v6
         with:
-          # restore and save a cache using this key
           primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
-          # if there's no cache hit, restore a cache by this prefix
           restore-prefixes-first-match: nix-${{ runner.os }}-
-          # collect garbage until the Nix store size (in bytes) is at most this number
-          # before trying to save a new cache
-          # 1G = 1073741824
           gc-max-store-size-linux: 1G
 
       - run: ./prep-all.sh
         env:
-          PUBLIC_WALLETCONNECT_PROJECT_ID: ${{ secrets.WALLETCONNECT_PROJECT_ID }}
+          PUBLIC_WALLETCONNECT_PROJECT_ID: test
 
       - run: nix develop .#webapp-shell -c npm run build
         working-directory: packages/webapp
         env:
-          PUBLIC_WALLETCONNECT_PROJECT_ID: ${{ secrets.WALLETCONNECT_PROJECT_ID }}
+          PUBLIC_WALLETCONNECT_PROJECT_ID: test
 
       - name: Install Vercel CLI (local, pinned)
         shell: bash --noprofile --norc -euo pipefail {0}
@@ -73,16 +75,16 @@ jobs:
       - name: Pull Vercel Environment Information
         shell: bash --noprofile --norc -euo pipefail {0}
         env:
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID_PREVIEWS }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_PREVIEWS }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PREVIEWS }}
         run: |
           "$VERCEL_BIN" pull --yes --environment=preview --token="$VERCEL_TOKEN"
       - name: Deploy Project Artifacts to Vercel
         shell: bash --noprofile --norc -euo pipefail {0}
         env:
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID_PREVIEWS }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_PREVIEWS }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PREVIEWS }}
         run: |
           "$VERCEL_BIN" deploy --prebuilt --token="$VERCEL_TOKEN" packages/webapp

--- a/.github/workflows/vercel-preview-pr-target.yaml
+++ b/.github/workflows/vercel-preview-pr-target.yaml
@@ -32,8 +32,8 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'vercel-preview')
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
-      contents: read
+     permissions:
+       contents: read
     environment: vercel-preview
     env:
       COMMIT_SHA: ${{ github.sha }}

--- a/.github/workflows/vercel-preview-pr-target.yaml
+++ b/.github/workflows/vercel-preview-pr-target.yaml
@@ -32,7 +32,6 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'vercel-preview')
     runs-on: ubuntu-latest
     permissions:
-     permissions:
        contents: read
     environment: vercel-preview
     env:

--- a/.github/workflows/vercel-preview-pr-target.yaml
+++ b/.github/workflows/vercel-preview-pr-target.yaml
@@ -32,7 +32,7 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'vercel-preview')
     runs-on: ubuntu-latest
     permissions:
-       contents: read
+      contents: read
     env:
       COMMIT_SHA: ${{ github.sha }}
     environment: vercel-preview
@@ -73,6 +73,7 @@ jobs:
           npm install --no-audit --no-fund --no-save --ignore-scripts --prefix "$VERCEL_DIR" vercel@33.4.1
           echo "VERCEL_BIN=$VERCEL_DIR/node_modules/.bin/vercel" >> "$GITHUB_ENV"
           test -x "$VERCEL_DIR/node_modules/.bin/vercel"
+      - name: Pull Vercel Environment Information
         shell: bash --noprofile --norc -euo pipefail {0}
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID_PREVIEWS }}

--- a/.github/workflows/vercel-preview-pr-target.yaml
+++ b/.github/workflows/vercel-preview-pr-target.yaml
@@ -43,8 +43,9 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.sha }}
-
+          persist-credentials: false
       - uses: nixbuild/nix-quick-install-action@v30
         with:
           nix_conf: |

--- a/.github/workflows/vercel-preview-pr-target.yaml
+++ b/.github/workflows/vercel-preview-pr-target.yaml
@@ -34,8 +34,6 @@ jobs:
     permissions:
        contents: read
     environment: vercel-preview
-    env:
-      COMMIT_SHA: ${{ github.sha }}
     steps:
       - name: Checkout PR head
         uses: actions/checkout@v4

--- a/.github/workflows/vercel-preview.yaml
+++ b/.github/workflows/vercel-preview.yaml
@@ -7,8 +7,8 @@
 ##  - Never runs when files in '.github/workflows/**' change (paths-ignore).
 ##  - Builds PR code WITHOUT secrets using a placeholder env value.
 ##  - Secrets are passed only to the Vercel CLI steps (not to build/test steps).
-##  - Shell runs with 'bash --noprofile --norc -euo pipefail' and a minimal PATH.
-##  - The Vercel CLI is invoked by absolute path '/usr/local/bin/vercel' to avoid PATH hijacking.
+##  - Shell runs with 'bash --noprofile --norc -euo pipefail'.
+##  - The Vercel CLI is invoked via an absolute path stored in $VERCEL_BIN to avoid PATH hijacking.
 ##
 ## WARNING: Changing any of the following may break the security model:
 ##  - Triggers (pull_request_target), label requirement, or environment approval.

--- a/.github/workflows/vercel-preview.yaml
+++ b/.github/workflows/vercel-preview.yaml
@@ -27,7 +27,7 @@ jobs:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
+    permissions:
       contents: read
     env:
       COMMIT_SHA: ${{ github.sha }}

--- a/.github/workflows/vercel-preview.yaml
+++ b/.github/workflows/vercel-preview.yaml
@@ -1,17 +1,40 @@
+##
+## SECURITY MODEL FOR VERCEL PREVIEW DEPLOYS (READ BEFORE EDITING)
+##
+## This workflow allows preview deploys for fork PRs with strict safeguards:
+##  - Uses pull_request_target so secrets are available only in the base repo context.
+##  - Additionally requires a maintainer to add the 'vercel-preview' label AND approve the 'vercel-preview' environment.
+##  - Never runs when files in '.github/workflows/**' change (paths-ignore).
+##  - Builds PR code WITHOUT secrets using a placeholder env value.
+##  - Secrets are passed only to the Vercel CLI steps (not to build/test steps).
+##  - Shell runs with 'bash --noprofile --norc -euo pipefail' and a minimal PATH.
+##  - The Vercel CLI is invoked by absolute path '/usr/local/bin/vercel' to avoid PATH hijacking.
+##
+## WARNING: Changing any of the following may break the security model:
+##  - Triggers (pull_request_target), label requirement, or environment approval.
+##  - The '.github/workflows/**' paths-ignore.
+##  - Introducing PR-controlled inputs into steps that use secrets.
+##  - Relaxing the shell/ PATH hardening, or calling 'vercel' via PATH.
+##  - Moving secrets to top-level env or earlier steps.
+## If you modify this file, re-validate these invariants.
 name: GitHub Actions Vercel Preview Deployment
-env:
-  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 on:
   push:
     branches-ignore:
       - main
+    paths-ignore:
+      - ".github/workflows/**"
+  pull_request_target:
+    types: [opened, synchronize, reopened, labeled]
+    paths-ignore:
+      - ".github/workflows/**"
 concurrency:
   group: ${{ github.ref }}-vercel-preview
   cancel-in-progress: true
 
 jobs:
-  Deploy-Preview:
+  Deploy-Preview-Push:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -19,7 +42,8 @@ jobs:
     env:
       COMMIT_SHA: ${{ github.sha }}
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 0
@@ -43,16 +67,112 @@ jobs:
 
       - run: ./prep-all.sh
         env:
-          PUBLIC_WALLETCONNECT_PROJECT_ID: ${{ secrets.WALLETCONNECT_PROJECT_ID }}
+          PUBLIC_WALLETCONNECT_PROJECT_ID: test
 
       - run: nix develop .#webapp-shell -c npm run build
         working-directory: packages/webapp
         env:
-          PUBLIC_WALLETCONNECT_PROJECT_ID: ${{ secrets.WALLETCONNECT_PROJECT_ID }}
+          PUBLIC_WALLETCONNECT_PROJECT_ID: test
 
       - name: Install Vercel CLI
-        run: npm install --global vercel@canary
+        shell: bash --noprofile --norc -euo pipefail {0}
+        working-directory: /tmp
+        env:
+          NPM_CONFIG_USERCONFIG: /dev/null
+          NPM_CONFIG_GLOBALCONFIG: /dev/null
+          NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
+          NPM_CONFIG_PREFIX: /usr/local
+          PATH: /usr/local/bin:/usr/bin:/bin
+        run: |
+          npm install --global vercel@canary --registry="$NPM_CONFIG_REGISTRY" --prefix="$NPM_CONFIG_PREFIX"
       - name: Pull Vercel Environment Information
-        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+        shell: bash --noprofile --norc -euo pipefail {0}
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          export PATH="/usr/local/bin:/usr/bin:/bin"
+          /usr/local/bin/vercel pull --yes --environment=preview --token="$VERCEL_TOKEN"
       - name: Deploy Project Artifacts to Vercel
-        run: vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }} packages/webapp
+        shell: bash --noprofile --norc -euo pipefail {0}
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          export PATH="/usr/local/bin:/usr/bin:/bin"
+          /usr/local/bin/vercel deploy --prebuilt --token="$VERCEL_TOKEN" packages/webapp
+
+  Deploy-Preview-PR:
+    if: ${{ github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'vercel-preview') }}
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    environment: vercel-preview
+    env:
+      COMMIT_SHA: ${{ github.sha }}
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: nixbuild/nix-quick-install-action@v30
+        with:
+          nix_conf: |
+            keep-env-derivations = true
+            keep-outputs = true
+      - name: Restore and save Nix store
+        uses: nix-community/cache-nix-action@v6
+        with:
+          # restore and save a cache using this key
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          # if there's no cache hit, restore a cache by this prefix
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          # collect garbage until the Nix store size (in bytes) is at most this number
+          # before trying to save a new cache
+          # 1G = 1073741824
+          gc-max-store-size-linux: 1G
+
+      - run: ./prep-all.sh
+        env:
+          PUBLIC_WALLETCONNECT_PROJECT_ID: ${{ secrets.WALLETCONNECT_PROJECT_ID != '' && secrets.WALLETCONNECT_PROJECT_ID || 'test' }}
+
+      - run: nix develop .#webapp-shell -c npm run build
+        working-directory: packages/webapp
+        env:
+          PUBLIC_WALLETCONNECT_PROJECT_ID: ${{ secrets.WALLETCONNECT_PROJECT_ID != '' && secrets.WALLETCONNECT_PROJECT_ID || 'test' }}
+
+      - name: Install Vercel CLI
+        shell: bash --noprofile --norc -euo pipefail {0}
+        working-directory: /tmp
+        env:
+          NPM_CONFIG_USERCONFIG: /dev/null
+          NPM_CONFIG_GLOBALCONFIG: /dev/null
+          NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
+          NPM_CONFIG_PREFIX: /usr/local
+          PATH: /usr/local/bin:/usr/bin:/bin
+        run: |
+          npm install --global vercel@canary --registry="$NPM_CONFIG_REGISTRY" --prefix="$NPM_CONFIG_PREFIX"
+      - name: Pull Vercel Environment Information
+        shell: bash --noprofile --norc -euo pipefail {0}
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          export PATH="/usr/local/bin:/usr/bin:/bin"
+          /usr/local/bin/vercel pull --yes --environment=preview --token="$VERCEL_TOKEN"
+      - name: Deploy Project Artifacts to Vercel
+        shell: bash --noprofile --norc -euo pipefail {0}
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          export PATH="/usr/local/bin:/usr/bin:/bin"
+          /usr/local/bin/vercel deploy --prebuilt --token="$VERCEL_TOKEN" packages/webapp

--- a/.github/workflows/vercel-preview.yaml
+++ b/.github/workflows/vercel-preview.yaml
@@ -27,10 +27,7 @@ jobs:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
-    permissions:
       contents: read
-    env:
-      COMMIT_SHA: ${{ github.sha }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/vercel-preview.yaml
+++ b/.github/workflows/vercel-preview.yaml
@@ -28,6 +28,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      COMMIT_SHA: ${{ github.sha }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/vercel-preview.yaml
+++ b/.github/workflows/vercel-preview.yaml
@@ -29,9 +29,10 @@ on:
     paths-ignore:
       - ".github/workflows/**"
 concurrency:
-  group: ${{ github.ref }}-vercel-preview
+  group: ${{ github.event_name == 'pull_request_target'
+              && format('pr-{0}-vercel-preview', github.event.pull_request.number)
+              || format('{0}-vercel-preview', github.ref) }}
   cancel-in-progress: true
-
 jobs:
   Deploy-Preview-Push:
     if: github.event_name == 'push'

--- a/.github/workflows/vercel-preview.yaml
+++ b/.github/workflows/vercel-preview.yaml
@@ -74,17 +74,12 @@ jobs:
         env:
           PUBLIC_WALLETCONNECT_PROJECT_ID: test
 
-      - name: Install Vercel CLI
+      - name: Install Vercel CLI (local, pinned)
         shell: bash --noprofile --norc -euo pipefail {0}
-        working-directory: /tmp
-        env:
-          NPM_CONFIG_USERCONFIG: /dev/null
-          NPM_CONFIG_GLOBALCONFIG: /dev/null
-          NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
-          NPM_CONFIG_PREFIX: /usr/local
-          PATH: /usr/local/bin:/usr/bin:/bin
         run: |
-          npm install --global vercel@canary --registry="$NPM_CONFIG_REGISTRY" --prefix="$NPM_CONFIG_PREFIX"
+          VERCEL_DIR="$(mktemp -d)"
+          npm install --no-audit --no-fund --no-save --prefix "$VERCEL_DIR" vercel@33.4.1
+          echo "VERCEL_BIN=$VERCEL_DIR/node_modules/.bin/vercel" >> "$GITHUB_ENV"
       - name: Pull Vercel Environment Information
         shell: bash --noprofile --norc -euo pipefail {0}
         env:
@@ -92,8 +87,7 @@ jobs:
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: |
-          export PATH="/usr/local/bin:/usr/bin:/bin"
-          /usr/local/bin/vercel pull --yes --environment=preview --token="$VERCEL_TOKEN"
+          "$VERCEL_BIN" pull --yes --environment=preview --token="$VERCEL_TOKEN"
       - name: Deploy Project Artifacts to Vercel
         shell: bash --noprofile --norc -euo pipefail {0}
         env:
@@ -101,8 +95,7 @@ jobs:
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: |
-          export PATH="/usr/local/bin:/usr/bin:/bin"
-          /usr/local/bin/vercel deploy --prebuilt --token="$VERCEL_TOKEN" packages/webapp
+          "$VERCEL_BIN" deploy --prebuilt --token="$VERCEL_TOKEN" packages/webapp
 
   Deploy-Preview-PR:
     if: ${{ github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'vercel-preview') }}
@@ -140,24 +133,19 @@ jobs:
 
       - run: ./prep-all.sh
         env:
-          PUBLIC_WALLETCONNECT_PROJECT_ID: ${{ secrets.WALLETCONNECT_PROJECT_ID != '' && secrets.WALLETCONNECT_PROJECT_ID || 'test' }}
+          PUBLIC_WALLETCONNECT_PROJECT_ID: test
 
       - run: nix develop .#webapp-shell -c npm run build
         working-directory: packages/webapp
         env:
-          PUBLIC_WALLETCONNECT_PROJECT_ID: ${{ secrets.WALLETCONNECT_PROJECT_ID != '' && secrets.WALLETCONNECT_PROJECT_ID || 'test' }}
+          PUBLIC_WALLETCONNECT_PROJECT_ID: test
 
-      - name: Install Vercel CLI
+      - name: Install Vercel CLI (local, pinned)
         shell: bash --noprofile --norc -euo pipefail {0}
-        working-directory: /tmp
-        env:
-          NPM_CONFIG_USERCONFIG: /dev/null
-          NPM_CONFIG_GLOBALCONFIG: /dev/null
-          NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
-          NPM_CONFIG_PREFIX: /usr/local
-          PATH: /usr/local/bin:/usr/bin:/bin
         run: |
-          npm install --global vercel@canary --registry="$NPM_CONFIG_REGISTRY" --prefix="$NPM_CONFIG_PREFIX"
+          VERCEL_DIR="$(mktemp -d)"
+          npm install --no-audit --no-fund --no-save --prefix "$VERCEL_DIR" vercel@33.4.1
+          echo "VERCEL_BIN=$VERCEL_DIR/node_modules/.bin/vercel" >> "$GITHUB_ENV"
       - name: Pull Vercel Environment Information
         shell: bash --noprofile --norc -euo pipefail {0}
         env:
@@ -165,8 +153,7 @@ jobs:
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: |
-          export PATH="/usr/local/bin:/usr/bin:/bin"
-          /usr/local/bin/vercel pull --yes --environment=preview --token="$VERCEL_TOKEN"
+          "$VERCEL_BIN" pull --yes --environment=preview --token="$VERCEL_TOKEN"
       - name: Deploy Project Artifacts to Vercel
         shell: bash --noprofile --norc -euo pipefail {0}
         env:
@@ -174,5 +161,4 @@ jobs:
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: |
-          export PATH="/usr/local/bin:/usr/bin:/bin"
-          /usr/local/bin/vercel deploy --prebuilt --token="$VERCEL_TOKEN" packages/webapp
+          "$VERCEL_BIN" deploy --prebuilt --token="$VERCEL_TOKEN" packages/webapp


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

Our CI won't run for forks as the `push` event only works for the target repo.

## Solution

- Changed to the `pull_request` event for all test workflows and removed all secrets/vars (doesn't seem like they were being used anyway).
- Updated the Vercel Preview workflow, splitting it into two
  - One that runs on push as normal
  - One that runs on `pull_request_target`. After approval this runs on our repo so it has access to our secrets.

The preview workflow needed additional security constraints
- Only exposes secrets to the Vercel deploy step
- Uses an absolute path for the Vercel bin
- Will require approval to run, also requires that the PR has a label, therefore unlikely to be approved to run accidentally.
- Won't run at all if the workflow file itself has changed

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [x] included screenshots (if this involves a front-end change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CI now runs on pull requests and on pushes to main; new secure PR-target Vercel preview workflow added.
  * WalletConnect project ID now falls back to 'test' when the secret is absent.

* **Chores**
  * Reduced secret exposure via ephemeral per-run deployment keys and stricter per-step secret scoping.
  * Added cancel-in-progress concurrency, local pinned Vercel CLI, Nix caching for reproducible previews, and improved RPC fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->