### PR TITLE
Add decode-events CLI command for processing JSON event files

### DIFF
--- a/crates/cli/.gitignore
+++ b/crates/cli/.gitignore
@@ -1,2 +1,4 @@
 # Event output files
 src/commands/local_db/events_*.json
+src/commands/local_db/decoded_events.json
+src/commands/local_db/decoded_events_*.json

--- a/crates/cli/src/commands/local_db/decode_events.rs
+++ b/crates/cli/src/commands/local_db/decode_events.rs
@@ -1,0 +1,41 @@
+use anyhow::Result;
+use clap::Parser;
+use rain_orderbook_common::raindex_client::sqlite_web::decode::decode_events;
+use std::fs::File;
+use std::io::{BufReader, Write};
+
+#[derive(Debug, Clone, Parser)]
+#[command(about = "Decode events from a JSON file and save the results")]
+pub struct DecodeEvents {
+    #[clap(long)]
+    pub input_file: String,
+    #[clap(long)]
+    pub output_file: Option<String>,
+}
+
+impl DecodeEvents {
+    pub async fn execute(self) -> Result<()> {
+        println!("Reading events from: {}", self.input_file);
+
+        let file = File::open(&self.input_file)?;
+        let reader = BufReader::new(file);
+        let events: Vec<serde_json::Value> = serde_json::from_reader(reader)?;
+
+        println!("Processing {} events...", events.len());
+
+        let events_value = serde_json::Value::Array(events);
+
+        let decoded_result = decode_events(events_value)
+            .map_err(|e| anyhow::anyhow!("Failed to decode events: {}", e))?;
+
+        let output_filename = self
+            .output_file
+            .unwrap_or_else(|| "decoded_events.json".to_string());
+
+        let mut file = File::create(&output_filename)?;
+        file.write_all(serde_json::to_string_pretty(&decoded_result)?.as_bytes())?;
+
+        println!("Decoded events saved to: {}", output_filename);
+        Ok(())
+    }
+}

--- a/crates/cli/src/commands/local_db/decode_events.rs
+++ b/crates/cli/src/commands/local_db/decode_events.rs
@@ -39,3 +39,183 @@ impl DecodeEvents {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn test_execute_with_custom_output_file() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let input_file = temp_dir.path().join("input.json");
+        let output_file = temp_dir.path().join("custom_output.json");
+
+        let test_events = vec![json!({"type": "test_event", "data": {"value": 123}})];
+
+        fs::write(&input_file, serde_json::to_string(&test_events)?)?;
+
+        let cmd = DecodeEvents {
+            input_file: input_file.to_string_lossy().to_string(),
+            output_file: Some(output_file.to_string_lossy().to_string()),
+        };
+
+        cmd.execute().await?;
+
+        assert!(output_file.exists());
+        let output_content = fs::read_to_string(&output_file)?;
+        let parsed_output: serde_json::Value = serde_json::from_str(&output_content)?;
+
+        assert!(parsed_output.is_object() || parsed_output.is_array());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_execute_with_default_output_file() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let input_file = temp_dir.path().join("input.json");
+        let expected_output = temp_dir.path().join("decoded_events.json");
+
+        let test_events = vec![json!({"type": "test_event", "data": {"value": 456}})];
+
+        fs::write(&input_file, serde_json::to_string(&test_events)?)?;
+
+        let cmd = DecodeEvents {
+            input_file: input_file.to_string_lossy().to_string(),
+            output_file: None,
+        };
+
+        let original_dir = std::env::current_dir()?;
+        std::env::set_current_dir(&temp_dir)?;
+
+        let result = cmd.execute().await;
+
+        std::env::set_current_dir(original_dir)?;
+
+        result?;
+
+        assert!(expected_output.exists());
+        let output_content = fs::read_to_string(&expected_output)?;
+        let parsed_output: serde_json::Value = serde_json::from_str(&output_content)?;
+
+        assert!(parsed_output.is_object() || parsed_output.is_array());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_execute_with_empty_events() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let input_file = temp_dir.path().join("empty_input.json");
+        let output_file = temp_dir.path().join("empty_output.json");
+
+        let empty_events: Vec<serde_json::Value> = vec![];
+        fs::write(&input_file, serde_json::to_string(&empty_events)?)?;
+
+        let cmd = DecodeEvents {
+            input_file: input_file.to_string_lossy().to_string(),
+            output_file: Some(output_file.to_string_lossy().to_string()),
+        };
+
+        cmd.execute().await?;
+
+        assert!(output_file.exists());
+        let output_content = fs::read_to_string(&output_file)?;
+        let parsed_output: serde_json::Value = serde_json::from_str(&output_content)?;
+
+        assert!(parsed_output.is_object() || parsed_output.is_array());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_execute_with_multiple_events() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let input_file = temp_dir.path().join("multi_input.json");
+        let output_file = temp_dir.path().join("multi_output.json");
+
+        let test_events = vec![
+            json!({"type": "event1", "data": "test1"}),
+            json!({"type": "event2", "data": "test2"}),
+            json!({"type": "event3", "data": {"nested": true}}),
+        ];
+
+        fs::write(&input_file, serde_json::to_string(&test_events)?)?;
+
+        let cmd = DecodeEvents {
+            input_file: input_file.to_string_lossy().to_string(),
+            output_file: Some(output_file.to_string_lossy().to_string()),
+        };
+
+        cmd.execute().await?;
+
+        assert!(output_file.exists());
+        let output_content = fs::read_to_string(&output_file)?;
+        let parsed_output: serde_json::Value = serde_json::from_str(&output_content)?;
+
+        assert!(parsed_output.is_object() || parsed_output.is_array());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_execute_with_nonexistent_input_file() {
+        let cmd = DecodeEvents {
+            input_file: "/path/that/does/not/exist.json".to_string(),
+            output_file: Some("output.json".to_string()),
+        };
+
+        let result = cmd.execute().await;
+        assert!(result.is_err());
+
+        let error_msg = result.unwrap_err().to_string();
+        assert!(error_msg.contains("No such file") || error_msg.contains("not found"));
+    }
+
+    #[tokio::test]
+    async fn test_execute_with_invalid_json() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let input_file = temp_dir.path().join("invalid.json");
+        let output_file = temp_dir.path().join("output.json");
+
+        fs::write(&input_file, "{ invalid json content")?;
+
+        let cmd = DecodeEvents {
+            input_file: input_file.to_string_lossy().to_string(),
+            output_file: Some(output_file.to_string_lossy().to_string()),
+        };
+
+        let result = cmd.execute().await;
+        assert!(result.is_err());
+
+        let error_msg = result.unwrap_err().to_string();
+        assert!(!error_msg.is_empty());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_execute_with_json_not_array() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let input_file = temp_dir.path().join("not_array.json");
+        let output_file = temp_dir.path().join("output.json");
+
+        fs::write(&input_file, r#"{"events": "not an array"}"#)?;
+
+        let cmd = DecodeEvents {
+            input_file: input_file.to_string_lossy().to_string(),
+            output_file: Some(output_file.to_string_lossy().to_string()),
+        };
+
+        let result = cmd.execute().await;
+        assert!(result.is_err());
+
+        let error_msg = result.unwrap_err().to_string();
+        assert!(!error_msg.is_empty());
+
+        Ok(())
+    }
+}

--- a/crates/cli/src/commands/local_db/mod.rs
+++ b/crates/cli/src/commands/local_db/mod.rs
@@ -1,3 +1,5 @@
+pub mod decode_events;
 pub mod fetch_events;
 
+pub use decode_events::DecodeEvents;
 pub use fetch_events::FetchEvents;

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1,4 +1,4 @@
-use crate::commands::local_db::FetchEvents;
+use crate::commands::local_db::{DecodeEvents, FetchEvents};
 use crate::commands::{Chart, Order, Subgraph, Trade, Vault, Words};
 use crate::execute::Execute;
 use anyhow::Result;
@@ -10,12 +10,15 @@ use rain_orderbook_quote::cli::Quoter;
 pub enum LocalDb {
     #[command(name = "fetch-events")]
     FetchEvents(FetchEvents),
+    #[command(name = "decode-events")]
+    DecodeEvents(DecodeEvents),
 }
 
 impl LocalDb {
     pub async fn execute(self) -> Result<()> {
         match self {
             LocalDb::FetchEvents(fetch_events) => fetch_events.execute().await,
+            LocalDb::DecodeEvents(decode_events) => decode_events.execute().await,
         }
     }
 }


### PR DESCRIPTION
> [!CAUTION]
> **Chained PR** - Do not merge before https://github.com/rainlanguage/rain.orderbook/pull/2102

<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

The CLI needed a way to decode events that have been previously fetched and stored in JSON format. This
  functionality allows users to take raw event data and decode it into a more usable format, completing the
  workflow of fetching and then processing events locally.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

  - Reads events from a JSON input file
  - Processes the events using the existing decode_events function from rain_orderbook_common::raindex_client
  - Outputs the decoded results to a JSON file (with configurable output filename)
  - Includes comprehensive error handling for file operations and JSON parsing
  - Added appropriate gitignore entries for decoded event output files

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)
