### PR TITLE
Add SQL commands for local database operations

### DIFF
--- a/crates/cli/.gitignore
+++ b/crates/cli/.gitignore
@@ -1,5 +1,5 @@
-# Event output files
 src/commands/local_db/events_*.json
 src/commands/local_db/decoded_events.json
 src/commands/local_db/decoded_events_*.json
 src/commands/local_db/events_*.sql
+src/commands/local_db/local_db_*

--- a/crates/cli/.gitignore
+++ b/crates/cli/.gitignore
@@ -2,3 +2,4 @@
 src/commands/local_db/events_*.json
 src/commands/local_db/decoded_events.json
 src/commands/local_db/decoded_events_*.json
+src/commands/local_db/events_*.sql

--- a/crates/cli/src/commands/local_db/decode_events.rs
+++ b/crates/cli/src/commands/local_db/decode_events.rs
@@ -5,6 +5,7 @@ use rain_orderbook_common::{
 };
 use std::fs::File;
 use std::io::{BufReader, Write};
+use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone, Parser)]
 #[command(about = "Decode events from a JSON file and save the results")]
@@ -30,17 +31,25 @@ impl DecodeEvents {
         let decoded_result = decode_events(&events)
             .map_err(|e| anyhow::anyhow!("Failed to decode events: {}", e))?;
 
-        let output_filename = self
-            .output_file
-            .unwrap_or_else(|| "decoded_events.json".to_string());
+        let output_filename = self.output_file.map(PathBuf::from).unwrap_or_else(|| {
+            let input_path = Path::new(&self.input_file);
+            input_path
+                .parent()
+                .map(|dir| dir.join("decoded_events.json"))
+                .unwrap_or_else(|| PathBuf::from("decoded_events.json"))
+        });
 
         let mut file = File::create(&output_filename)
-            .with_context(|| format!("Failed to create {}", output_filename))?;
-        serde_json::to_writer_pretty(&mut file, &decoded_result)
-            .with_context(|| format!("Failed to write decoded events to {}", output_filename))?;
+            .with_context(|| format!("Failed to create {}", output_filename.display()))?;
+        serde_json::to_writer_pretty(&mut file, &decoded_result).with_context(|| {
+            format!(
+                "Failed to write decoded events to {}",
+                output_filename.display()
+            )
+        })?;
         writeln!(file)?;
 
-        println!("Decoded events saved to: {}", output_filename);
+        println!("Decoded events saved to: {}", output_filename.display());
         Ok(())
     }
 }
@@ -166,14 +175,7 @@ mod tests {
             output_file: None,
         };
 
-        let original_dir = std::env::current_dir()?;
-        std::env::set_current_dir(&temp_dir)?;
-
-        let result = cmd.execute().await;
-
-        std::env::set_current_dir(original_dir)?;
-
-        result?;
+        cmd.execute().await?;
 
         assert!(expected_output.exists());
         let parsed_output = decoded_output(&expected_output);

--- a/crates/cli/src/commands/local_db/decoded_events_to_sql.rs
+++ b/crates/cli/src/commands/local_db/decoded_events_to_sql.rs
@@ -1,8 +1,12 @@
 use anyhow::{Context, Result};
 use clap::Args;
-use rain_orderbook_common::raindex_client::sqlite_web::insert::decoded_events_to_sql;
+use rain_orderbook_common::raindex_client::sqlite_web::{
+    decode::{DecodedEvent, DecodedEventData},
+    insert::decoded_events_to_sql,
+};
 use std::fs::{write, File};
 use std::io::BufReader;
+use std::path::{Path, PathBuf};
 
 #[derive(Args)]
 pub struct DecodedEventsToSql {
@@ -24,18 +28,24 @@ impl DecodedEventsToSql {
             .with_context(|| format!("Failed to open input file: {:?}", self.input_file))?;
         let reader = BufReader::new(file);
 
-        let data: serde_json::Value =
-            serde_json::from_reader(reader).context("Failed to parse JSON")?;
+        let decoded_events: Vec<DecodedEventData<DecodedEvent>> =
+            serde_json::from_reader(reader).context("Failed to parse decoded events JSON")?;
 
-        let sql_statements = decoded_events_to_sql(data, self.end_block)
+        let sql_statements = decoded_events_to_sql(&decoded_events, self.end_block)
             .map_err(|e| anyhow::anyhow!("Failed to generate SQL: {}", e))?;
 
-        let output_path = self.output_file.unwrap_or_else(|| "events.sql".to_string());
+        let output_path = self.output_file.map(PathBuf::from).unwrap_or_else(|| {
+            let input_path = Path::new(&self.input_file);
+            input_path
+                .parent()
+                .map(|dir| dir.join("events.sql"))
+                .unwrap_or_else(|| PathBuf::from("events.sql"))
+        });
 
         write(&output_path, sql_statements)
-            .with_context(|| format!("Failed to write output file: {:?}", output_path))?;
+            .with_context(|| format!("Failed to write output file: {}", output_path.display()))?;
 
-        println!("SQL statements written to {:?}", output_path);
+        println!("SQL statements written to {}", output_path.display());
         Ok(())
     }
 }
@@ -43,9 +53,25 @@ impl DecodedEventsToSql {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_json::json;
+    use rain_orderbook_common::raindex_client::sqlite_web::decode::{
+        DecodedEvent, DecodedEventData, EventType, UnknownEventDecoded,
+    };
     use std::fs;
     use tempfile::TempDir;
+
+    fn sample_unknown_event() -> DecodedEventData<DecodedEvent> {
+        DecodedEventData {
+            event_type: EventType::Unknown,
+            block_number: "0x1".to_string(),
+            block_timestamp: "0x2".to_string(),
+            transaction_hash: "0xabc".to_string(),
+            log_index: "0x0".to_string(),
+            decoded_data: DecodedEvent::Unknown(UnknownEventDecoded {
+                raw_data: "0x0".to_string(),
+                note: "test".to_string(),
+            }),
+        }
+    }
 
     #[tokio::test]
     async fn test_execute_with_custom_output_file() -> Result<()> {
@@ -53,11 +79,8 @@ mod tests {
         let input_file = temp_dir.path().join("input.json");
         let output_file = temp_dir.path().join("custom_output.sql");
 
-        let test_data = json!([
-            {"type": "test_event", "data": {"value": 123}}
-        ]);
-
-        fs::write(&input_file, serde_json::to_string(&test_data)?)?;
+        let events = vec![sample_unknown_event()];
+        fs::write(&input_file, serde_json::to_string(&events)?)?;
 
         let cmd = DecodedEventsToSql {
             input_file: input_file.to_string_lossy().to_string(),
@@ -80,11 +103,8 @@ mod tests {
         let input_file = temp_dir.path().join("input.json");
         let expected_output = temp_dir.path().join("events.sql");
 
-        let test_data = json!([
-            {"type": "test_event", "data": {"value": 456}}
-        ]);
-
-        fs::write(&input_file, serde_json::to_string(&test_data)?)?;
+        let events = vec![sample_unknown_event()];
+        fs::write(&input_file, serde_json::to_string(&events)?)?;
 
         let cmd = DecodedEventsToSql {
             input_file: input_file.to_string_lossy().to_string(),
@@ -92,14 +112,7 @@ mod tests {
             end_block: 2000,
         };
 
-        let original_dir = std::env::current_dir()?;
-        std::env::set_current_dir(&temp_dir)?;
-
-        let result = cmd.execute().await;
-
-        std::env::set_current_dir(original_dir)?;
-
-        result?;
+        cmd.execute().await?;
 
         assert!(expected_output.exists());
         let output_content = fs::read_to_string(&expected_output)?;

--- a/crates/cli/src/commands/local_db/decoded_events_to_sql.rs
+++ b/crates/cli/src/commands/local_db/decoded_events_to_sql.rs
@@ -1,0 +1,141 @@
+use anyhow::{Context, Result};
+use clap::Args;
+use rain_orderbook_common::raindex_client::sqlite_web::insert::decoded_events_to_sql;
+use std::fs::{write, File};
+use std::io::BufReader;
+
+#[derive(Args)]
+pub struct DecodedEventsToSql {
+    #[arg(long)]
+    pub input_file: String,
+
+    #[arg(long)]
+    pub output_file: Option<String>,
+
+    #[arg(long)]
+    pub end_block: u64,
+}
+
+impl DecodedEventsToSql {
+    pub async fn execute(self) -> Result<()> {
+        println!("Generating SQL statements...");
+
+        let file = File::open(&self.input_file)
+            .with_context(|| format!("Failed to open input file: {:?}", self.input_file))?;
+        let reader = BufReader::new(file);
+
+        let data: serde_json::Value =
+            serde_json::from_reader(reader).context("Failed to parse JSON")?;
+
+        let sql_statements = decoded_events_to_sql(data, self.end_block)
+            .map_err(|e| anyhow::anyhow!("Failed to generate SQL: {}", e))?;
+
+        let output_path = self.output_file.unwrap_or_else(|| "events.sql".to_string());
+
+        write(&output_path, sql_statements)
+            .with_context(|| format!("Failed to write output file: {:?}", output_path))?;
+
+        println!("SQL statements written to {:?}", output_path);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn test_execute_with_custom_output_file() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let input_file = temp_dir.path().join("input.json");
+        let output_file = temp_dir.path().join("custom_output.sql");
+
+        let test_data = json!([
+            {"type": "test_event", "data": {"value": 123}}
+        ]);
+
+        fs::write(&input_file, serde_json::to_string(&test_data)?)?;
+
+        let cmd = DecodedEventsToSql {
+            input_file: input_file.to_string_lossy().to_string(),
+            output_file: Some(output_file.to_string_lossy().to_string()),
+            end_block: 1000,
+        };
+
+        cmd.execute().await?;
+
+        assert!(output_file.exists());
+        let output_content = fs::read_to_string(&output_file)?;
+        assert!(!output_content.is_empty());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_execute_with_default_output_file() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let input_file = temp_dir.path().join("input.json");
+        let expected_output = temp_dir.path().join("events.sql");
+
+        let test_data = json!([
+            {"type": "test_event", "data": {"value": 456}}
+        ]);
+
+        fs::write(&input_file, serde_json::to_string(&test_data)?)?;
+
+        let cmd = DecodedEventsToSql {
+            input_file: input_file.to_string_lossy().to_string(),
+            output_file: None,
+            end_block: 2000,
+        };
+
+        let original_dir = std::env::current_dir()?;
+        std::env::set_current_dir(&temp_dir)?;
+
+        let result = cmd.execute().await;
+
+        std::env::set_current_dir(original_dir)?;
+
+        result?;
+
+        assert!(expected_output.exists());
+        let output_content = fs::read_to_string(&expected_output)?;
+        assert!(!output_content.is_empty());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_execute_with_invalid_input_file() {
+        let cmd = DecodedEventsToSql {
+            input_file: "nonexistent_file.json".to_string(),
+            output_file: None,
+            end_block: 1000,
+        };
+
+        let result = cmd.execute().await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_execute_with_invalid_json() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let input_file = temp_dir.path().join("invalid.json");
+
+        fs::write(&input_file, "invalid json content")?;
+
+        let cmd = DecodedEventsToSql {
+            input_file: input_file.to_string_lossy().to_string(),
+            output_file: None,
+            end_block: 1000,
+        };
+
+        let result = cmd.execute().await;
+        assert!(result.is_err());
+
+        Ok(())
+    }
+}

--- a/crates/cli/src/commands/local_db/dump.rs
+++ b/crates/cli/src/commands/local_db/dump.rs
@@ -56,3 +56,158 @@ impl DbDump {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::Path;
+    use tempfile::TempDir;
+
+    const TEST_TABLE_SCHEMA: &str = r#"
+CREATE TABLE test_orders (
+    id INTEGER PRIMARY KEY,
+    vault_id TEXT NOT NULL,
+    owner TEXT NOT NULL,
+    amount INTEGER NOT NULL
+);
+CREATE TABLE test_trades (
+    id INTEGER PRIMARY KEY,
+    order_id INTEGER NOT NULL,
+    amount INTEGER NOT NULL,
+    FOREIGN KEY (order_id) REFERENCES test_orders(id)
+);
+"#;
+
+    const TEST_DATA_SQL: &str = r#"
+INSERT INTO test_orders (vault_id, owner, amount) VALUES 
+    ('vault1', 'owner1', 100),
+    ('vault2', 'owner2', 200);
+INSERT INTO test_trades (order_id, amount) VALUES 
+    (1, 50),
+    (2, 75);
+"#;
+
+    fn create_test_files(temp_dir: &TempDir) -> (String, String) {
+        let schema_path = temp_dir.path().join("schema.sql");
+        let data_path = temp_dir.path().join("data.sql");
+
+        fs::write(&schema_path, TEST_TABLE_SCHEMA).unwrap();
+        fs::write(&data_path, TEST_DATA_SQL).unwrap();
+
+        (
+            schema_path.to_string_lossy().to_string(),
+            data_path.to_string_lossy().to_string(),
+        )
+    }
+
+    #[tokio::test]
+    async fn test_default_paths() {
+        let temp_dir = TempDir::new().unwrap();
+        let (schema_path, data_path) = create_test_files(&temp_dir);
+
+        let dump = DbDump {
+            input_file: data_path,
+            table_schema_file: schema_path,
+            end_block: 12345,
+            db_path: None,
+            dump_file_path: None,
+        };
+
+        let result = dump.execute().await;
+        assert!(result.is_ok());
+
+        assert!(Path::new("src/commands/local_db/local_db_12345.db").exists());
+        assert!(Path::new("src/commands/local_db/local_db_12345.sql.gz").exists());
+
+        let _ = fs::remove_file("src/commands/local_db/local_db_12345.db");
+        let _ = fs::remove_file("src/commands/local_db/local_db_12345.sql.gz");
+    }
+
+    #[tokio::test]
+    async fn test_custom_paths() {
+        let temp_dir = TempDir::new().unwrap();
+        let (schema_path, data_path) = create_test_files(&temp_dir);
+
+        let custom_db_path = temp_dir.path().join("custom_test.db");
+        let custom_dump_path = temp_dir.path().join("custom_dump.sql");
+
+        let dump = DbDump {
+            input_file: data_path,
+            table_schema_file: schema_path,
+            end_block: 12345,
+            db_path: Some(custom_db_path.to_string_lossy().to_string()),
+            dump_file_path: Some(custom_dump_path.to_string_lossy().to_string()),
+        };
+
+        let result = dump.execute().await;
+        assert!(result.is_ok());
+
+        assert!(custom_db_path.exists());
+        assert!(temp_dir.path().join("custom_dump.sql.gz").exists());
+    }
+
+    #[tokio::test]
+    async fn test_end_to_end_workflow() {
+        let temp_dir = TempDir::new().unwrap();
+        let (schema_path, data_path) = create_test_files(&temp_dir);
+
+        let db_path = temp_dir.path().join("test_workflow.db");
+        let dump_path = temp_dir.path().join("test_dump.sql");
+
+        let dump = DbDump {
+            input_file: data_path,
+            table_schema_file: schema_path,
+            end_block: 99999,
+            db_path: Some(db_path.to_string_lossy().to_string()),
+            dump_file_path: Some(dump_path.to_string_lossy().to_string()),
+        };
+
+        let result = dump.execute().await;
+        assert!(result.is_ok());
+
+        assert!(db_path.exists());
+
+        let gz_path = temp_dir.path().join("test_dump.sql.gz");
+        assert!(gz_path.exists());
+
+        let output = std::process::Command::new("gunzip")
+            .arg("-c")
+            .arg(&gz_path)
+            .output()
+            .unwrap();
+
+        let dump_content = String::from_utf8(output.stdout).unwrap();
+        assert!(dump_content.contains("test_orders"));
+        assert!(dump_content.contains("test_trades"));
+        assert!(dump_content.contains("vault1"));
+        assert!(dump_content.contains("owner1"));
+    }
+
+    #[tokio::test]
+    async fn test_database_cleanup() {
+        let temp_dir = TempDir::new().unwrap();
+        let (schema_path, data_path) = create_test_files(&temp_dir);
+
+        let db_path = temp_dir.path().join("cleanup_test.db");
+        let dump_path = temp_dir.path().join("cleanup_dump.sql");
+
+        fs::write(&db_path, "dummy content").unwrap();
+        assert!(db_path.exists());
+
+        let dump = DbDump {
+            input_file: data_path,
+            table_schema_file: schema_path,
+            end_block: 77777,
+            db_path: Some(db_path.to_string_lossy().to_string()),
+            dump_file_path: Some(dump_path.to_string_lossy().to_string()),
+        };
+
+        let result = dump.execute().await;
+        assert!(result.is_ok());
+
+        assert!(db_path.exists());
+        let db_content = fs::read(&db_path).unwrap();
+        assert!(db_content.starts_with(b"SQLite format 3"));
+    }
+}

--- a/crates/cli/src/commands/local_db/dump.rs
+++ b/crates/cli/src/commands/local_db/dump.rs
@@ -1,0 +1,58 @@
+use anyhow::Result;
+use clap::Parser;
+use std::fs;
+use std::process::Command;
+
+#[derive(Parser)]
+pub struct DbDump {
+    #[clap(long)]
+    pub input_file: String,
+    #[clap(long)]
+    pub table_schema_file: String,
+    #[clap(long)]
+    pub end_block: u64,
+    #[clap(long)]
+    pub db_path: Option<String>,
+    #[clap(long)]
+    pub dump_file_path: Option<String>,
+}
+
+impl DbDump {
+    pub async fn execute(self) -> Result<()> {
+        let sql_file_path = &self.input_file;
+        let db_path = self
+            .db_path
+            .unwrap_or_else(|| format!("src/commands/local_db/local_db_{}.db", self.end_block));
+        let dump_file_path = self
+            .dump_file_path
+            .unwrap_or_else(|| format!("src/commands/local_db/local_db_{}.sql", self.end_block));
+
+        let _ = fs::remove_file(&db_path);
+
+        let tables_sql_path = &self.table_schema_file;
+
+        let _ = Command::new("sqlite3")
+            .arg(&db_path)
+            .arg(format!(".read {}", tables_sql_path))
+            .status()?;
+
+        let _ = Command::new("sqlite3")
+            .arg(&db_path)
+            .arg(format!(".read {}", sql_file_path))
+            .status()?;
+
+        let output = Command::new("sqlite3")
+            .arg(&db_path)
+            .arg(".dump")
+            .output()?;
+
+        fs::write(&dump_file_path, output.stdout)?;
+
+        Command::new("gzip")
+            .arg("-f")
+            .arg(&dump_file_path)
+            .status()?;
+
+        Ok(())
+    }
+}

--- a/crates/cli/src/commands/local_db/mod.rs
+++ b/crates/cli/src/commands/local_db/mod.rs
@@ -1,7 +1,9 @@
 pub mod decode_events;
 pub mod decoded_events_to_sql;
+pub mod dump;
 pub mod fetch_events;
 
 pub use decode_events::DecodeEvents;
 pub use decoded_events_to_sql::DecodedEventsToSql;
+pub use dump::DbDump;
 pub use fetch_events::FetchEvents;

--- a/crates/cli/src/commands/local_db/mod.rs
+++ b/crates/cli/src/commands/local_db/mod.rs
@@ -1,5 +1,7 @@
 pub mod decode_events;
+pub mod decoded_events_to_sql;
 pub mod fetch_events;
 
 pub use decode_events::DecodeEvents;
+pub use decoded_events_to_sql::DecodedEventsToSql;
 pub use fetch_events::FetchEvents;

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1,4 +1,4 @@
-use crate::commands::local_db::{DecodeEvents, FetchEvents};
+use crate::commands::local_db::{DecodeEvents, DecodedEventsToSql, FetchEvents};
 use crate::commands::{Chart, Order, Subgraph, Trade, Vault, Words};
 use crate::execute::Execute;
 use anyhow::Result;
@@ -12,6 +12,8 @@ pub enum LocalDb {
     FetchEvents(FetchEvents),
     #[command(name = "decode-events")]
     DecodeEvents(DecodeEvents),
+    #[command(name = "decoded-events-to-sql")]
+    DecodedEventsToSql(DecodedEventsToSql),
 }
 
 impl LocalDb {
@@ -19,6 +21,7 @@ impl LocalDb {
         match self {
             LocalDb::FetchEvents(fetch_events) => fetch_events.execute().await,
             LocalDb::DecodeEvents(decode_events) => decode_events.execute().await,
+            LocalDb::DecodedEventsToSql(decoded_events_to_sql) => decoded_events_to_sql.execute().await,
         }
     }
 }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -21,7 +21,9 @@ impl LocalDb {
         match self {
             LocalDb::FetchEvents(fetch_events) => fetch_events.execute().await,
             LocalDb::DecodeEvents(decode_events) => decode_events.execute().await,
-            LocalDb::DecodedEventsToSql(decoded_events_to_sql) => decoded_events_to_sql.execute().await,
+            LocalDb::DecodedEventsToSql(decoded_events_to_sql) => {
+                decoded_events_to_sql.execute().await
+            }
         }
     }
 }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1,4 +1,4 @@
-use crate::commands::local_db::{DecodeEvents, DecodedEventsToSql, FetchEvents};
+use crate::commands::local_db::{DbDump, DecodeEvents, DecodedEventsToSql, FetchEvents};
 use crate::commands::{Chart, Order, Subgraph, Trade, Vault, Words};
 use crate::execute::Execute;
 use anyhow::Result;
@@ -14,6 +14,8 @@ pub enum LocalDb {
     DecodeEvents(DecodeEvents),
     #[command(name = "decoded-events-to-sql")]
     DecodedEventsToSql(DecodedEventsToSql),
+    #[command(name = "dump")]
+    Dump(DbDump),
 }
 
 impl LocalDb {
@@ -24,6 +26,7 @@ impl LocalDb {
             LocalDb::DecodedEventsToSql(decoded_events_to_sql) => {
                 decoded_events_to_sql.execute().await
             }
+            LocalDb::Dump(dump) => dump.execute().await,
         }
     }
 }

--- a/crates/common/src/raindex_client/sqlite_web/decode.rs
+++ b/crates/common/src/raindex_client/sqlite_web/decode.rs
@@ -11,7 +11,7 @@ use rain_orderbook_bindings::{
     },
     OrderBook::MetaV1_2,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, thiserror::Error)]
 pub enum DecodeError {
@@ -21,7 +21,7 @@ pub enum DecodeError {
     AbiDecode(String),
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum EventType {
     AddOrderV3,
     TakeOrderV3,
@@ -67,8 +67,8 @@ impl EventType {
     }
 }
 
-#[derive(Debug, Clone, Serialize)]
-#[serde(bound(serialize = "T: Serialize"))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(bound(serialize = "T: Serialize", deserialize = "T: Deserialize<'de>"))]
 pub struct DecodedEventData<T> {
     pub event_type: EventType,
     pub block_number: String,
@@ -78,7 +78,7 @@ pub struct DecodedEventData<T> {
     pub decoded_data: T,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum DecodedEvent {
     AddOrderV3(Box<AddOrderV3>),
@@ -159,7 +159,7 @@ pub fn decode_events(
     Ok(decoded_events)
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UnknownEventDecoded {
     pub raw_data: String,
     pub note: String,

--- a/crates/common/src/raindex_client/sqlite_web/sql/tables.sql
+++ b/crates/common/src/raindex_client/sqlite_web/sql/tables.sql
@@ -154,3 +154,11 @@ CREATE INDEX idx_after_clear_block ON after_clear_v2_events(block_number);
 
 CREATE INDEX idx_meta_subject ON meta_events(subject);
 CREATE INDEX idx_meta_block ON meta_events(block_number);
+
+CREATE TABLE IF NOT EXISTS sync_status (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    last_synced_block INTEGER NOT NULL DEFAULT 0,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+INSERT OR IGNORE INTO sync_status (id, last_synced_block) VALUES (1, 0);


### PR DESCRIPTION
> [!CAUTION]
> **Chained PR**
> Do not merge before https://github.com/rainlanguage/rain.orderbook/pull/2104

> [!NOTE]
> This PR https://github.com/rainlanguage/rainix/pull/88 also needs to be merged to enable sqlite3 command in nix shell


<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Previously, we could fetch and decode events but lacked the ability to convert decoded events to SQL
  format and create complete database dumps.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

  This PR adds two new CLI commands for local database SQL operations:

  1. decoded-events-to-sql - Converts decoded JSON events to SQL INSERT statements with configurable output file
  and end block parameters
  2. dump - Creates complete database dumps by setting up schema, importing data, and generating compressed SQL
  dumps

  Key changes include:
  - Added DecodedEventsToSql command with comprehensive test coverage for JSON parsing, file I/O, and error
  handling
  - Added DbDump command that orchestrates schema creation, data import, and database dumping with gzip compression
  - Enhanced .gitignore to exclude generated SQL files and database artifacts
  - Added sync status table to the database schema for tracking synchronization state
  - Both commands include extensive unit tests covering success scenarios, error conditions, and edge cases

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added CLI commands to convert decoded event JSON into SQL and to export the local DB as a gzipped SQL dump.
  - Added a sync_status table to track last synced block and timestamp.
  - Added deserialization support for decoded event types to enable round-trip JSON handling.

- Improvements
  - Improved default output path resolution and status messages for local DB/event commands.

- Chores
  - Expanded .gitignore to exclude generated local DB artifacts and SQL event outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->