### PR TITLE
Convert account balance from U256 to Float

### DIFF
--- a/crates/js_api/src/gui/select_tokens.rs
+++ b/crates/js_api/src/gui/select_tokens.rs
@@ -1,12 +1,11 @@
 use super::*;
 use futures::StreamExt;
+use rain_math_float::Float;
 use rain_orderbook_app_settings::{
     deployment::DeploymentCfg, gui::GuiSelectTokensCfg, network::NetworkCfg, order::OrderCfg,
     token::TokenCfg, yaml::YamlParsableHash,
 };
-use rain_orderbook_common::{
-    raindex_client::vaults::AccountBalance, utils::amount_formatter::format_amount_u256,
-};
+use rain_orderbook_common::raindex_client::vaults::AccountBalance;
 use std::str::FromStr;
 
 const MAX_CONCURRENT_FETCHES: usize = 5;
@@ -419,11 +418,9 @@ impl DotrainOrderGui {
         let balance = erc20
             .get_account_balance(Address::from_str(&owner)?)
             .await?;
+        let float_balance = Float::from_fixed_decimal(balance, decimals)?;
 
-        Ok(AccountBalance::new(
-            balance,
-            format_amount_u256(balance, decimals)?,
-        ))
+        Ok(AccountBalance::new(float_balance, float_balance.format()?))
     }
 }
 

--- a/packages/orderbook/test/js_api/gui.test.ts
+++ b/packages/orderbook/test/js_api/gui.test.ts
@@ -1142,7 +1142,7 @@ ${dotrain}`;
 
 			let dotrain2 = `
       ${guiConfig2}
-      
+
       ${dotrain}
       `;
 			const result = await DotrainOrderGui.newWithDeployment(dotrain2, 'other-deployment');
@@ -1610,7 +1610,7 @@ ${dotrainWithoutVaultIds}`;
 
 			let testDotrain = `
           ${guiConfig2}
-          
+
           ${dotrainWithoutVaultIds}
           `;
 			let guiResult = await DotrainOrderGui.newWithDeployment(
@@ -2042,7 +2042,7 @@ ${dotrainWithoutVaultIds}`;
 					'0x1234567890abcdef1234567890abcdef12345678'
 				)
 			);
-			assert.equal(result.balance, BigInt(1000));
+			assert.equal(result.balance.toFixedDecimal(18).value, BigInt(1000));
 			assert.equal(result.formattedBalance, '0.000000000000001');
 		});
 	});

--- a/packages/orderbook/test/js_api/raindexClient.test.ts
+++ b/packages/orderbook/test/js_api/raindexClient.test.ts
@@ -1948,8 +1948,7 @@ describe('Rain Orderbook JS API Package Bindgen Tests - Raindex Client', async f
 			);
 
 			const res = extractWasmEncodedData(await vault.getOwnerBalance());
-			assert.equal(typeof res.balance, 'bigint');
-			assert.equal(res.balance, BigInt(1000));
+			assert.equal(res.balance.toFixedDecimal(18).value, BigInt(1000));
 			assert.equal(res.formattedBalance, '0.000000000000001');
 		});
 	});

--- a/packages/ui-components/src/__tests__/SelectToken.test.ts
+++ b/packages/ui-components/src/__tests__/SelectToken.test.ts
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import SelectToken from '../lib/components/deployment/SelectToken.svelte';
 import type { ComponentProps } from 'svelte';
-import type { AccountBalance, DotrainOrderGui } from '@rainlanguage/orderbook';
+import { Float, type AccountBalance, type DotrainOrderGui } from '@rainlanguage/orderbook';
 import { useGui } from '$lib/hooks/useGui';
 import type { TokenBalance } from '$lib/types/tokenBalance';
 
@@ -40,6 +40,12 @@ const mockGui: DotrainOrderGui = {
 		]
 	})
 } as unknown as DotrainOrderGui;
+
+vi.mock('@rainlanguage/orderbook', async (importOriginal) => {
+	return {
+		...(await importOriginal())
+	};
+});
 
 vi.mock('../lib/hooks/useGui', () => ({
 	useGui: vi.fn()
@@ -325,7 +331,7 @@ describe('SelectToken', () => {
 			const tokenBalances = new Map<string, TokenBalance>();
 			tokenBalances.set('input', {
 				value: {
-					balance: BigInt('1000000000000000000'),
+					balance: Float.parse('1').value,
 					formattedBalance: '1'
 				} as AccountBalance,
 				loading: false,
@@ -360,7 +366,7 @@ describe('SelectToken', () => {
 			const tokenBalances = new Map<string, TokenBalance>();
 			tokenBalances.set('input', {
 				value: {
-					balance: BigInt(0),
+					balance: Float.parse('0').value,
 					formattedBalance: '0'
 				} as AccountBalance,
 				loading: true,
@@ -395,7 +401,7 @@ describe('SelectToken', () => {
 			const tokenBalances = new Map<string, TokenBalance>();
 			tokenBalances.set('input', {
 				value: {
-					balance: BigInt(0),
+					balance: Float.parse('0').value,
 					formattedBalance: '0'
 				} as AccountBalance,
 				loading: false,
@@ -430,7 +436,7 @@ describe('SelectToken', () => {
 			const tokenBalances = new Map<string, TokenBalance>();
 			tokenBalances.set('input', {
 				value: {
-					balance: BigInt('1500000'),
+					balance: Float.parse('1.5').value,
 					formattedBalance: '1.5'
 				} as AccountBalance,
 				loading: false,

--- a/packages/ui-components/src/__tests__/TokenBalance.test.ts
+++ b/packages/ui-components/src/__tests__/TokenBalance.test.ts
@@ -3,13 +3,19 @@ import { describe, it, expect } from 'vitest';
 import TokenBalance from '../lib/components/deployment/TokenBalance.svelte';
 import type { ComponentProps } from 'svelte';
 import type { TokenBalance as TokenBalanceType } from '$lib/types/tokenBalance';
-import type { AccountBalance } from '@rainlanguage/orderbook';
+import { Float, type AccountBalance } from '@rainlanguage/orderbook';
 
 type TokenBalanceComponentProps = ComponentProps<TokenBalance>;
 
+vi.mock('@rainlanguage/orderbook', async (importOriginal) => {
+	return {
+		...(await importOriginal())
+	};
+});
+
 describe('TokenBalance', () => {
 	const createMockTokenBalance = (
-		balance: bigint = BigInt(0),
+		balance = Float.parse('0').value,
 		formattedBalance: string = '0',
 		loading: boolean = false,
 		error: string = ''
@@ -26,7 +32,7 @@ describe('TokenBalance', () => {
 	it('renders loading state correctly', () => {
 		const props: TokenBalanceComponentProps = {
 			...defaultProps,
-			tokenBalance: createMockTokenBalance(BigInt(0), '0', true, '')
+			tokenBalance: createMockTokenBalance(Float.parse('0').value, '0', true, '')
 		};
 
 		render(TokenBalance, { props });
@@ -37,7 +43,7 @@ describe('TokenBalance', () => {
 	it('renders balance when balance is non-zero', () => {
 		const props: TokenBalanceComponentProps = {
 			...defaultProps,
-			tokenBalance: createMockTokenBalance(BigInt(1000), '1000', false, '')
+			tokenBalance: createMockTokenBalance(Float.parse('1000').value, '1000', false, '')
 		};
 
 		render(TokenBalance, { props });
@@ -48,7 +54,12 @@ describe('TokenBalance', () => {
 	it('renders error state correctly', () => {
 		const props: TokenBalanceComponentProps = {
 			...defaultProps,
-			tokenBalance: createMockTokenBalance(BigInt(0), '0', false, 'Failed to fetch balance')
+			tokenBalance: createMockTokenBalance(
+				Float.parse('0').value,
+				'0',
+				false,
+				'Failed to fetch balance'
+			)
 		};
 
 		render(TokenBalance, { props });
@@ -60,7 +71,7 @@ describe('TokenBalance', () => {
 		const { container } = render(TokenBalance, {
 			props: {
 				...defaultProps,
-				tokenBalance: createMockTokenBalance(BigInt(1000), '1,000.00', false, '')
+				tokenBalance: createMockTokenBalance(Float.parse('1000').value, '1,000.00', false, '')
 			}
 		});
 
@@ -71,7 +82,7 @@ describe('TokenBalance', () => {
 		const { container } = render(TokenBalance, {
 			props: {
 				...defaultProps,
-				tokenBalance: createMockTokenBalance(BigInt(0), '0', false, 'Error message')
+				tokenBalance: createMockTokenBalance(Float.parse('0').value, '0', false, 'Error message')
 			}
 		});
 
@@ -81,7 +92,12 @@ describe('TokenBalance', () => {
 	it('prioritizes error display over balance when both exist', () => {
 		const props: TokenBalanceComponentProps = {
 			...defaultProps,
-			tokenBalance: createMockTokenBalance(BigInt(1000), '1000', false, 'Network error')
+			tokenBalance: createMockTokenBalance(
+				Float.parse('1000').value,
+				'1000',
+				false,
+				'Network error'
+			)
 		};
 
 		render(TokenBalance, { props });

--- a/packages/ui-components/src/__tests__/TokenIOInput.test.ts
+++ b/packages/ui-components/src/__tests__/TokenIOInput.test.ts
@@ -2,13 +2,16 @@ import { render, fireEvent, waitFor } from '@testing-library/svelte';
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import TokenIOInput from '../lib/components/deployment/TokenIOInput.svelte';
 import type { ComponentProps } from 'svelte';
-import { AccountBalance, DotrainOrderGui } from '@rainlanguage/orderbook';
+import { AccountBalance, DotrainOrderGui, Float } from '@rainlanguage/orderbook';
 import { useGui } from '$lib/hooks/useGui';
 import type { TokenBalance } from '$lib/types/tokenBalance';
 
-vi.mock('@rainlanguage/orderbook', () => ({
-	DotrainOrderGui: vi.fn()
-}));
+vi.mock('@rainlanguage/orderbook', async (importOriginal) => {
+	return {
+		...(await importOriginal()),
+		DotrainOrderGui: vi.fn()
+	};
+});
 
 vi.mock('$lib/hooks/useGui', () => ({
 	useGui: vi.fn()
@@ -125,7 +128,7 @@ describe('TokenInput', () => {
 			const tokenBalances = new Map<string, TokenBalance>();
 			tokenBalances.set('test', {
 				value: {
-					balance: BigInt('1000000000000000000'),
+					balance: Float.parse('1').value,
 					formattedBalance: '1'
 				} as AccountBalance,
 				loading: false,
@@ -147,7 +150,7 @@ describe('TokenInput', () => {
 			const tokenBalances = new Map<string, TokenBalance>();
 			tokenBalances.set('test', {
 				value: {
-					balance: BigInt(0),
+					balance: Float.parse('0').value,
 					formattedBalance: '0'
 				} as AccountBalance,
 				loading: true,
@@ -169,7 +172,7 @@ describe('TokenInput', () => {
 			const tokenBalances = new Map<string, TokenBalance>();
 			tokenBalances.set('test', {
 				value: {
-					balance: BigInt(0),
+					balance: Float.parse('0').value,
 					formattedBalance: '0'
 				} as AccountBalance,
 				loading: false,

--- a/packages/ui-components/src/__tests__/VaultIdInformation.test.ts
+++ b/packages/ui-components/src/__tests__/VaultIdInformation.test.ts
@@ -2,9 +2,15 @@ import { render, screen } from '@testing-library/svelte';
 import { describe, it, expect } from 'vitest';
 import type { ComponentProps } from 'svelte';
 import VaultIdInformation from '$lib/components/deployment/VaultIdInformation.svelte';
-import type { AccountBalance } from '@rainlanguage/orderbook';
+import { Float, type AccountBalance } from '@rainlanguage/orderbook';
 
 export type VaultIdInformationComponentProps = ComponentProps<VaultIdInformation>;
+
+vi.mock('@rainlanguage/orderbook', async (importOriginal) => {
+	return {
+		...(await importOriginal())
+	};
+});
 
 describe('VaultIdInformation', () => {
 	const defaultProps: VaultIdInformationComponentProps = {
@@ -12,7 +18,7 @@ describe('VaultIdInformation', () => {
 		description: 'Test Description',
 		tokenBalance: {
 			value: {
-				balance: 1000n,
+				balance: Float.parse('100').value,
 				formattedBalance: '100'
 			} as AccountBalance,
 			loading: false,
@@ -33,7 +39,7 @@ describe('VaultIdInformation', () => {
 			...defaultProps,
 			tokenBalance: {
 				value: {
-					balance: 0n,
+					balance: Float.parse('0').value,
 					formattedBalance: '0'
 				} as AccountBalance,
 				loading: true,
@@ -51,7 +57,7 @@ describe('VaultIdInformation', () => {
 			...defaultProps,
 			tokenBalance: {
 				value: {
-					balance: 0n,
+					balance: Float.parse('0').value,
 					formattedBalance: '0'
 				} as AccountBalance,
 				loading: false,

--- a/packages/ui-components/src/lib/components/deployment/DeploymentSteps.svelte
+++ b/packages/ui-components/src/lib/components/deployment/DeploymentSteps.svelte
@@ -11,7 +11,8 @@
 		type OrderIOCfg,
 		DotrainOrderGui,
 		RaindexClient,
-		AccountBalance
+		AccountBalance,
+		Float
 	} from '@rainlanguage/orderbook';
 	import WalletConnect from '../wallet/WalletConnect.svelte';
 	import { type Writable } from 'svelte/store';
@@ -129,7 +130,7 @@
 
 		const balances = tokenBalances;
 		balances.set(tokenInfo.key, {
-			value: { balance: BigInt(0), formattedBalance: '0' } as AccountBalance,
+			value: { balance: Float.parse('0').value, formattedBalance: '0' } as AccountBalance,
 			loading: true,
 			error: ''
 		});
@@ -140,7 +141,7 @@
 		);
 		if (error) {
 			balances.set(tokenInfo.key, {
-				value: { balance: BigInt(0), formattedBalance: '0' } as AccountBalance,
+				value: { balance: Float.parse('0').value, formattedBalance: '0' } as AccountBalance,
 				loading: false,
 				error: error.readableMsg
 			});

--- a/packages/webapp/src/__tests__/DepositModal.test.ts
+++ b/packages/webapp/src/__tests__/DepositModal.test.ts
@@ -26,7 +26,7 @@ describe('DepositModal', () => {
 		},
 		getOwnerBalance: vi.fn().mockResolvedValue({
 			value: {
-				balance: BigInt('1000000000000000000'), // 1 token
+				balance: Float.parse('1').value, // 1 token
 				formattedBalance: '1'
 			}
 		}),
@@ -78,7 +78,7 @@ describe('DepositModal', () => {
 	it('shows error when amount exceeds balance', async () => {
 		(mockVault.getOwnerBalance as Mock).mockResolvedValue({
 			value: {
-				balance: BigInt('500000000000000000'), // 0.5 tokens
+				balance: Float.parse('0.5').value, // 0.5 tokens
 				formattedBalance: '0.5'
 			}
 		});
@@ -113,7 +113,7 @@ describe('DepositModal', () => {
 	it('disables continue button when amount exceeds balance', async () => {
 		(mockVault.getOwnerBalance as Mock).mockResolvedValue({
 			value: {
-				balance: BigInt('500000000000000000'), // 0.5 tokens
+				balance: Float.parse('0.5').value, // 0.5 tokens
 				formattedBalance: '0.5'
 			}
 		});
@@ -134,7 +134,7 @@ describe('DepositModal', () => {
 	it('handles zero user balance correctly', async () => {
 		(mockVault.getOwnerBalance as Mock).mockResolvedValue({
 			value: {
-				balance: BigInt('0'),
+				balance: Float.parse('0').value,
 				formattedBalance: '0'
 			}
 		});
@@ -157,10 +157,9 @@ describe('DepositModal', () => {
 	});
 
 	it('displays user balance correctly', async () => {
-		const userBalanceAmount = BigInt('2500000000000000000'); // 2.5 tokens
 		(mockVault.getOwnerBalance as Mock).mockResolvedValue({
 			value: {
-				balance: userBalanceAmount,
+				balance: Float.parse('2.5').value,
 				formattedBalance: '2.5'
 			}
 		});
@@ -192,7 +191,7 @@ describe('DepositModal', () => {
 	it('shows wallet address in truncated form', async () => {
 		(mockVault.getOwnerBalance as Mock).mockResolvedValue({
 			value: {
-				balance: BigInt('1000000000000000000'), // 1 token
+				balance: Float.parse('1').value, // 1 token
 				formattedBalance: '1'
 			}
 		});

--- a/packages/webapp/src/__tests__/WithdrawModal.test.ts
+++ b/packages/webapp/src/__tests__/WithdrawModal.test.ts
@@ -28,7 +28,7 @@ describe('WithdrawModal', () => {
 		},
 		getOwnerBalance: vi.fn().mockResolvedValue({
 			value: {
-				balance: BigInt('1000000000000000000'), // 1 token
+				balance: Float.parse('1').value, // 1 token
 				formattedBalance: '1'
 			}
 		}),

--- a/packages/webapp/src/lib/components/DepositModal.svelte
+++ b/packages/webapp/src/lib/components/DepositModal.svelte
@@ -23,7 +23,7 @@
 
 	let amount: Float = Float.parse('0').value as Float;
 	let userBalance: AccountBalance = {
-		balance: BigInt(0),
+		balance: Float.parse('0').value,
 		formattedBalance: '0'
 	} as unknown as AccountBalance;
 	let errorMessage = '';
@@ -49,10 +49,7 @@
 		amount = Float.parse('0').value as Float;
 	}
 
-	$: validation = validateAmount(
-		amount,
-		Float.fromFixedDecimal(userBalance.balance, vault.token.decimals).value as Float
-	);
+	$: validation = validateAmount(amount, userBalance.balance);
 </script>
 
 <Modal bind:open autoclose={false} size="md">
@@ -91,7 +88,7 @@
 		<InputTokenAmount
 			bind:value={amount}
 			symbol={vault.token.symbol}
-			maxValue={Float.fromFixedDecimal(userBalance.balance, vault.token.decimals).value}
+			maxValue={userBalance.balance}
 		/>
 		<div class="flex flex-col justify-end gap-2">
 			<div class="flex gap-2">

--- a/packages/webapp/src/lib/components/WithdrawModal.svelte
+++ b/packages/webapp/src/lib/components/WithdrawModal.svelte
@@ -23,7 +23,7 @@
 
 	let amount: Float = Float.parse('0').value as Float;
 	let userBalance: AccountBalance = {
-		balance: 0n,
+		balance: Float.parse('0').value,
 		formattedBalance: '0'
 	} as unknown as AccountBalance;
 	let errorMessage = '';

--- a/tauri-app/src/lib/components/ModalVaultDeposit.svelte
+++ b/tauri-app/src/lib/components/ModalVaultDeposit.svelte
@@ -21,7 +21,7 @@
   let isSubmitting = false;
   let selectWallet = false;
   let userBalance: AccountBalance = {
-    balance: BigInt(0),
+    balance: Float.parse('0').value,
     formattedBalance: '0',
   } as unknown as AccountBalance;
 
@@ -155,7 +155,7 @@
         <InputTokenAmount
           bind:value={amount}
           symbol={vault.token.symbol}
-          maxValue={Float.fromFixedDecimal(userBalance.balance, vault.token.decimals).value}
+          maxValue={userBalance.balance}
         />
       </ButtonGroup>
     </div>


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

See issue: https://github.com/rainlanguage/rain.orderbook/issues/2067

  The existing vault account balance system was using U256 integers to represent token balances, which required
  complex conversion logic when interfacing with the Float math system used throughout the application. This
   created inconsistencies and required error-prone conversions between fixed-point integers and floating-point
  representations, particularly when displaying formatted balances to users.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

- Refactored the AccountBalance struct to use Float directly instead of U256
- Update UI and tests

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)

fix https://github.com/rainlanguage/rain.orderbook/issues/2067