### PR TITLE
Fixes the missing IO column in orders table when IO tokens are the same

### DIFF
--- a/packages/ui-components/src/__tests__/OrdersListTable.test.ts
+++ b/packages/ui-components/src/__tests__/OrdersListTable.test.ts
@@ -175,6 +175,90 @@ describe('OrdersListTable', () => {
 		expect(screen.queryByText('Strategy Balance:')).not.toBeInTheDocument();
 	});
 
+	it('displays multiple tokens correctly in grid layout with shared IO', async () => {
+		const orderWithMultipleTokens = {
+			...mockOrder,
+			inputs: [
+				{
+					token: { symbol: 'ETH' },
+					formattedBalance: '1.5'
+				},
+				{
+					token: { symbol: 'USDC' },
+					formattedBalance: '100.0'
+				}
+			],
+			outputs: [
+				{
+					token: { symbol: 'DAI' },
+					formattedBalance: '2500.0'
+				},
+				{
+					token: { symbol: 'USDC' },
+					formattedBalance: '100.0'
+				}
+			],
+			inputsList: {
+				...mockVaultsList(),
+				items: [
+					{
+						token: { symbol: 'ETH', address: '0xeth' },
+						formattedBalance: '1.5'
+					},
+				]
+			},
+			outputsList: {
+				...mockVaultsList(),
+				items: [
+					{
+						token: { symbol: 'DAI', address: '0xdai' },
+						formattedBalance: '2500.0'
+					},
+				]
+			},
+			inputsOutputsList: {
+				...mockVaultsList(),
+				items: [
+					{
+						token: { symbol: 'USDC', address: '0xusdc' },
+						formattedBalance: '100.0'
+					}
+				]
+			}
+		};
+
+		const mockQuery = vi.mocked(await import('@tanstack/svelte-query'));
+		// eslint-disable-next-line @typescript-eslint/no-unused-vars
+		mockQuery.createInfiniteQuery = vi.fn((__options, _queryClient) => ({
+			subscribe: (fn: (value: any) => void) => {
+				fn({
+					data: { pages: [[orderWithMultipleTokens]] },
+					status: 'success',
+					isFetching: false,
+					isFetched: true
+				});
+				return { unsubscribe: () => {} };
+			}
+		})) as Mock;
+		render(OrdersListTable, defaultProps as OrdersListTableProps);
+
+		// Verify all tokens are displayed in vault cards
+		const vaultCards = screen.getAllByTestId('vault-card');
+		expect(vaultCards).toHaveLength(4); // 2 inputs + 2 outputs (1 is shared between IO)
+
+		// Verify all input tokens are displayed
+		expect(screen.getByText('ETH')).toBeInTheDocument();
+		expect(screen.getByText('1.5')).toBeInTheDocument();
+
+		// Verify all output tokens are displayed
+		expect(screen.getByText('DAI')).toBeInTheDocument();
+		expect(screen.getByText('2500.0')).toBeInTheDocument();
+
+		// Verify shared token is displayed for input and output
+		expect(screen.getAllByText('USDC')).toHaveLength(2);
+		expect(screen.getAllByText('100.0')).toHaveLength(2);
+	});
+
 	it('displays multiple tokens correctly in grid layout', async () => {
 		const orderWithMultipleTokens = {
 			...mockOrder,

--- a/packages/ui-components/src/lib/components/tables/OrdersListTable.svelte
+++ b/packages/ui-components/src/lib/components/tables/OrdersListTable.svelte
@@ -169,6 +169,11 @@
 				{#each item.inputsList.items as vault}
 					<VaultCard {vault} />
 				{/each}
+				{#each item.vaultsList.items as vault}
+					{#if !item.inputsList.items.find((v) => v.token.address === vault.token.address)}
+						<VaultCard {vault} />
+					{/if}
+				{/each}
 			</div>
 		</TableBodyCell>
 
@@ -176,6 +181,11 @@
 			<div class="grid w-full grid-cols-1 gap-2 sm:grid-cols-2">
 				{#each item.outputsList.items as vault}
 					<VaultCard {vault} />
+				{/each}
+				{#each item.vaultsList.items as vault}
+					{#if !item.outputsList.items.find((v) => v.token.address === vault.token.address)}
+						<VaultCard {vault} />
+					{/if}
 				{/each}
 			</div>
 		</TableBodyCell>

--- a/packages/ui-components/src/lib/components/tables/OrdersListTable.svelte
+++ b/packages/ui-components/src/lib/components/tables/OrdersListTable.svelte
@@ -169,7 +169,7 @@
 				{#each item.inputsList.items as vault}
 					<VaultCard {vault} />
 				{/each}
-				{#each item.vaultsList.items as vault}
+				{#each item.inputsOutputsList.items as vault}
 					{#if !item.inputsList.items.find((v) => v.token.address === vault.token.address)}
 						<VaultCard {vault} />
 					{/if}
@@ -182,7 +182,7 @@
 				{#each item.outputsList.items as vault}
 					<VaultCard {vault} />
 				{/each}
-				{#each item.vaultsList.items as vault}
+				{#each item.inputsOutputsList.items as vault}
 					{#if !item.outputsList.items.find((v) => v.token.address === vault.token.address)}
 						<VaultCard {vault} />
 					{/if}


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation
resolves #2130 
This PR fixes the missing IO column in orders table for orders that have same IO token.
This is because `RaindexVault` wasm class has 3 vault getters, `inputVaults`, `outputVaults` and `inputOutputVaults`, and tokens that are shared in inputs and outs vaults are not stored in `inputVaults`/`outputVaults`, but rather only stored in `inputOutputVaults`.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
For fixing this issue, we simply will show vaults in `inputOutputVaults` that are not already shown from `inputVaults` and `outputVaults`

<img width="1769" height="599" alt="Screenshot 2025-09-05 at 11 21 57 PM" src="https://github.com/user-attachments/assets/8005f9f9-74e2-476a-afa4-7e6c50d45d22" />

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [x] included screenshots (if this involves a front-end change)
