### PR TITLE
Fix deposit null pointer error

### DIFF
--- a/crates/common/src/raindex_client/vaults.rs
+++ b/crates/common/src/raindex_client/vaults.rs
@@ -326,7 +326,7 @@ impl RaindexVault {
         Ok(balance_changes)
     }
 
-    fn validate_amount(&self, amount: Float) -> Result<(), RaindexError> {
+    fn validate_amount(&self, amount: &Float) -> Result<(), RaindexError> {
         let zero_float = Float::parse("0".to_string())?;
         if amount.is_zero()? {
             return Err(RaindexError::ZeroAmount);
@@ -360,7 +360,7 @@ impl RaindexVault {
     )]
     pub async fn get_deposit_calldata(
         &self,
-        #[wasm_export(param_description = "Amount to deposit in Float value")] amount: Float,
+        #[wasm_export(param_description = "Amount to deposit in Float value")] amount: &Float,
     ) -> Result<Bytes, RaindexError> {
         self.validate_amount(amount)?;
         let (deposit_args, _) = self.get_deposit_and_transaction_args(amount).await?;
@@ -391,14 +391,14 @@ impl RaindexVault {
     )]
     pub async fn get_withdraw_calldata(
         &self,
-        #[wasm_export(param_description = "Amount to withdraw in Float value")] amount: Float,
+        #[wasm_export(param_description = "Amount to withdraw in Float value")] amount: &Float,
     ) -> Result<Bytes, RaindexError> {
         self.validate_amount(amount)?;
         Ok(Bytes::copy_from_slice(
             &WithdrawArgs {
                 token: self.token.address,
                 vault_id: B256::from(self.vault_id),
-                target_amount: amount,
+                target_amount: amount.clone(),
             }
             .get_withdraw_calldata()
             .await?,
@@ -407,7 +407,7 @@ impl RaindexVault {
 
     async fn get_deposit_and_transaction_args(
         &self,
-        amount: Float,
+        amount: &Float,
     ) -> Result<(DepositArgs, TransactionArgs), RaindexError> {
         let rpcs = {
             let raindex_client = self
@@ -420,7 +420,7 @@ impl RaindexVault {
         let deposit_args = DepositArgs {
             token: self.token.address,
             vault_id: B256::from(self.vault_id),
-            amount,
+            amount: amount.clone(),
             decimals: self.token.decimals,
         };
 
@@ -457,7 +457,7 @@ impl RaindexVault {
     pub async fn get_approval_calldata(
         &self,
         #[wasm_export(param_description = "Amount requiring approval in Float value")]
-        amount: Float,
+        amount: &Float,
     ) -> Result<Bytes, RaindexError> {
         self.validate_amount(amount)?;
 
@@ -469,7 +469,7 @@ impl RaindexVault {
             .await?;
         let allowance_float = Float::from_fixed_decimal(allowance, self.token.decimals)?;
 
-        if allowance_float.gte(amount)? {
+        if allowance_float.gte(*amount)? {
             return Err(RaindexError::ExistingAllowance);
         }
 
@@ -504,7 +504,7 @@ impl RaindexVault {
     )]
     pub async fn get_allowance(&self) -> Result<RaindexVaultAllowance, RaindexError> {
         let (deposit_args, transaction_args) = self
-            .get_deposit_and_transaction_args(Float::parse("0".to_string())?)
+            .get_deposit_and_transaction_args(&Float::parse("0".to_string())?)
             .await?;
         let allowance = deposit_args
             .read_allowance(self.owner, transaction_args.clone())
@@ -1945,7 +1945,7 @@ mod tests {
                 .await
                 .unwrap();
             let result = vault
-                .get_deposit_calldata(Float::parse("500".to_string()).unwrap())
+                .get_deposit_calldata(&Float::parse("500".to_string()).unwrap())
                 .await
                 .unwrap();
             assert_eq!(
@@ -1963,7 +1963,7 @@ mod tests {
             );
 
             let err = vault
-                .get_deposit_calldata(Float::parse("0".to_string()).unwrap())
+                .get_deposit_calldata(&Float::parse("0".to_string()).unwrap())
                 .await
                 .unwrap_err();
             assert_eq!(err.to_string(), RaindexError::ZeroAmount.to_string());
@@ -2010,7 +2010,7 @@ mod tests {
                 .await
                 .unwrap();
             let amount: Float = Float::parse("0.0000000000000005".to_string()).unwrap();
-            let result = vault.get_withdraw_calldata(amount).await.unwrap();
+            let result = vault.get_withdraw_calldata(&amount).await.unwrap();
             assert_eq!(
                 result,
                 Bytes::copy_from_slice(
@@ -2026,7 +2026,7 @@ mod tests {
             );
 
             let err = vault
-                .get_withdraw_calldata(Float::parse("0".to_string()).unwrap())
+                .get_withdraw_calldata(&Float::parse("0".to_string()).unwrap())
                 .await
                 .unwrap_err();
             assert_eq!(err.to_string(), RaindexError::ZeroAmount.to_string());
@@ -2073,7 +2073,7 @@ mod tests {
                 .await
                 .unwrap();
             let result = vault
-                .get_approval_calldata(Float::parse("600".to_string()).unwrap())
+                .get_approval_calldata(&Float::parse("600".to_string()).unwrap())
                 .await
                 .unwrap();
             assert_eq!(
@@ -2088,19 +2088,19 @@ mod tests {
             );
 
             let err = vault
-                .get_approval_calldata(Float::parse("0".to_string()).unwrap())
+                .get_approval_calldata(&Float::parse("0".to_string()).unwrap())
                 .await
                 .unwrap_err();
             assert_eq!(err.to_string(), RaindexError::ZeroAmount.to_string());
 
             let err = vault
-                .get_approval_calldata(Float::parse("90".to_string()).unwrap())
+                .get_approval_calldata(&Float::parse("90".to_string()).unwrap())
                 .await
                 .unwrap_err();
             assert_eq!(err.to_string(), RaindexError::ExistingAllowance.to_string());
 
             let err = vault
-                .get_approval_calldata(Float::parse("100".to_string()).unwrap())
+                .get_approval_calldata(&Float::parse("100".to_string()).unwrap())
                 .await
                 .unwrap_err();
             assert_eq!(err.to_string(), RaindexError::ExistingAllowance.to_string());

--- a/crates/common/src/raindex_client/vaults_list.rs
+++ b/crates/common/src/raindex_client/vaults_list.rs
@@ -60,7 +60,7 @@ impl RaindexVaultsList {
         }
         // Generate multicall calldata for all vaults
         for vault in vaults_to_withdraw {
-            match vault.get_withdraw_calldata(vault.balance()).await {
+            match vault.get_withdraw_calldata(&vault.balance()).await {
                 Ok(calldata) => calldatas.push(calldata),
                 Err(e) => return Err(VaultsListError::WithdrawMulticallError(e.to_readable_msg())),
             }


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation
resolves #2129 

This PR fixes the null pointer error when trying to deposit into a vault, this happens because `Float` wasm class ownership is given to the rust function when creating approve tx and ten same instance which is now a null pointer is given to deposit tx creation method.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
To fix this, we should simply use refs for `Float` args in deposit approval and similar method that use it.


https://github.com/user-attachments/assets/85f64b1c-4c0b-488a-a7f1-01538e610023

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [x] included screenshots (if this involves a front-end change)
