### PR TITLE
Add agent guide, AI commands, and architecture docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- Solidity contracts: `src/`, tests in `test/` with fixtures in `test-resources/`.
+- Rust workspace: `crates/*` (e.g., `cli`, `common`, `bindings`, `js_api`, `quote`, `subgraph`, `settings`, `math`, `integration_tests`).
+- JavaScript/Svelte: `packages/*` — `webapp`, `ui-components`, `orderbook` (wasm wrapper published to npm).
+- Desktop app: `tauri-app` (Rust + Svelte; `src-tauri` excluded from Cargo workspace).
+- Subgraph and tooling: `subgraph/`, `script/`, helper scripts like `prep-all.sh`.
+
+## Build, Test, and Development Commands
+- Run everything inside a Nix shell. Either enter `nix develop` first and run commands normally, or prefix with `nix develop -c <cmd>`. Use shell attrs when needed (e.g., `nix develop .#tauri-shell`).
+- Bootstrap: `./prep-all.sh` (installs deps and builds workspaces).
+- Rust: `nix develop -c cargo build --workspace`; tests: `nix develop -c cargo test`.
+- Solidity (Foundry): `nix develop -c forge build`; tests: `nix develop -c forge test`.
+- Webapp: `cd packages/webapp && nix develop -c npm run dev`.
+- Tauri: `nix develop .#tauri-shell --command cargo tauri dev`.
+- JS workspaces (top-level): `npm run test`, `npm run build:ui`, `npm run build:orderbook`.
+- WASM bundle: `cd packages/orderbook && npm run build-wasm`.
+
+## Coding Style & Naming Conventions
+- Rust: format with `cargo fmt --all`; lint with `cargo clippy --all-targets -- -D warnings`. Crates/modules use `snake_case`; types `PascalCase`.
+- TS/Svelte: `npm run format`, `npm run lint`, `npm run check` in each package. Components `PascalCase.svelte`; files otherwise kebab/snake as appropriate.
+- Solidity: `forge fmt`; compiler `solc 0.8.25` (see `foundry.toml`).
+
+## Testing Guidelines
+- Rust: `cargo test`; integration tests live in `crates/integration_tests`. Prefer `insta` snapshots and `proptest` where helpful.
+- TS/Svelte: `npm run test` (Vitest). Name files `*.test.ts`/`*.spec.ts`.
+- Solidity: `forge test` (add fuzz/property tests where relevant).
+
+## Commit & Pull Request Guidelines
+- Use Conventional Commits: `feat:`, `fix:`, `chore:`, `docs:`, `test:`.
+- PRs must: describe scope/approach, link issues, include screenshots/GIFs for UI changes, update/ add tests, and pass CI.
+- Quick preflight: `nix develop -c npm run lint-format-check:all && nix develop -c cargo clippy -- -D warnings`.
+
+## Security & Configuration Tips
+- Never commit secrets. Copy `.env.example` files (root, `packages/webapp`, `tauri-app`) and populate `PUBLIC_WALLETCONNECT_PROJECT_ID` / `VITE_WALLETCONNECT_PROJECT_ID` as required.
+
+## Agent-Specific Instructions
+- Prefer syntax-aware search with ast-grep: Rust `sg --lang rust -p '<pattern>'`; TS `sg --lang ts -p '<pattern>'`. Use Nix shells for tool parity.
+- Architecture context: when working in any directory, check for an `ARCHITECTURE.md` file in the current working directory and read it first to understand local architecture before making changes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+Before working on anything in this repository, read and follow the AGENTS.md file.

--- a/ai_commands/generate-pr-content.md
+++ b/ai_commands/generate-pr-content.md
@@ -1,0 +1,118 @@
+Title: Generate PR Title and Description from Diff
+
+You are an engineering assistant. Your task is to generate a high‑quality Pull Request title and description using the repository’s PR template, based on a git diff. Start by asking the user which base branch to diff against and whether they want to provide additional motivation/context. Use the diff and any provided context to infer scope, summarize changes, and produce a conventional‑commit style title and a filled template.
+
+Interactive Start
+- Ask: “Which base branch should I compare against? Use `main` or specify another (e.g., `release/x.y` or a feature branch).”
+- Ask: “Do you want to provide any specific motivation (issue links, goals, context) to include?”
+- If motivation is unclear after the diff, ask a brief follow‑up before finalizing text.
+
+Inputs
+- Base branch to compare against (default: `main`).
+- Optional motivation/context and links (issues/PRs).
+
+Constraints & Repo Conventions
+- Use Conventional Commits for the title: `feat:`, `fix:`, `chore:`, `docs:`, `test:`, `refactor:`, `perf:`, `ci:`, `build:`.
+- Prefer syntax‑aware search with ast-grep when inspecting code structure:
+  - Rust: `sg --lang rust -p '<pattern>'`
+  - TypeScript: `sg --lang ts -p '<pattern>'`
+- When running builds/tests locally, use Nix shells (if needed for context): `nix develop -c <cmd>`.
+- Follow AGENTS.md tone: concise, accurate, minimal verbosity.
+
+High‑Level Goal
+1) Determine the correct base for the diff (default `main`).
+2) Summarize the changes and infer scope (crates/packages/areas touched).
+3) Generate a clear, conventional‑commit PR title with a scoped summary.
+4) Fill the PR description using the template below, incorporating user‑provided motivation and a crisp solution summary derived from the diff.
+
+Template (use exactly this in the PR body)
+```
+<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->
+
+## Motivation
+
+<!--
+Explain the context and why you're making that change. What is the problem
+you're trying to solve? In some cases there is not a problem and this can be
+thought of as being the motivation for your change.
+-->
+
+## Solution
+
+<!--
+Summarize the solution and provide any necessary context needed to understand
+the code change.
+-->
+
+## Checks
+<!-- It's important you've done these, or your PR will not be considered for review -->
+By submitting this for review, I'm confirming I've done the following:
+- [ ] made this PR as small as possible
+- [ ] unit-tested any new functionality
+- [ ] linked any relevant issues or PRs
+- [ ] included screenshots (if this involves a front-end change)
+```
+
+Procedure
+1) Confirm base branch
+   - If the user provides none, use `main`.
+   - Compute a local diff without network access.
+   - Preferred commands:
+     - List changed files: `git --no-pager diff --name-only <BASE>...HEAD`
+     - Short stats: `git --no-pager diff --stat <BASE>...HEAD`
+     - Commit context (optional): `git --no-pager log --oneline <BASE>..HEAD`
+
+2) Infer scope and impact
+   - Group changes by top-level path to derive scope keywords, e.g.:
+     - `crates/<name>` → Rust crate scope
+     - `packages/<name>` → npm/TS package scope
+     - `tauri-app` → desktop UI/app scope
+     - `src/`, `test/`, `subgraph/`, `script/` → other well-known areas
+   - Heuristics for commit type:
+     - `fix:` if tests mention a bug or diffs reverse/guard behavior; otherwise
+     - `feat:` if new files/exports/commands are added; otherwise
+     - `refactor:` if changes are structural without behavior; otherwise
+     - `docs:` if docs only; `test:` if tests only; `chore:` for tooling/infra.
+   - Optionally use ast‑grep to pull high-signal names to improve the title:
+     - Rust public items: `sg --lang rust -p 'pub (fn|struct|enum|trait) $NAME' <changed_paths>`
+     - TS exports: `sg --lang ts -p 'export (function|class|interface|type) $NAME' <changed_paths>`
+
+3) Draft the title
+   - Format: `<type>: <scope>: <concise summary>`
+   - Scope: prefer a short identifier like `common`, `js_api`, `orderbook`, `webapp`, `tauri-app`.
+   - Summary: 6–12 words, describe outcome, not implementation details.
+
+4) Fill the description template
+   - Motivation:
+     - Use user-provided context verbatim when given.
+     - If missing, infer a brief rationale from the diff; if unsure, add a one‑line prompt asking the user to confirm/clarify.
+   - Solution:
+     - Summarize what changed: key files/areas, notable functions/types touched, new behaviors or fixed defects.
+     - Mention tests updated/added and any important follow‑ups.
+     - If UI files changed under `packages/webapp` or `tauri-app`, include a note to attach screenshots.
+   - Keep paragraphs short and skimmable.
+
+5) Present results
+   - Return both:
+     - Title: a single line
+     - Description: the filled template body
+   - Optionally include a compact diff summary in your answer for the user’s review.
+
+Edge Cases & Guidance
+- If the diff is empty, say so and ask the user to confirm the base branch.
+- If there are many unrelated changes, propose splitting into multiple PRs and draft multiple candidate titles if appropriate.
+- Do not invent details. Prefer asking one concise follow‑up if motivation cannot be inferred reliably.
+- Keep style consistent with this repo’s PR expectations in AGENTS.md.
+
+Acceptance Criteria
+- Asks the user for base branch (`main` by default) and optional motivation before generating output.
+- Produces a conventional‑commit title reflecting scope and change intent.
+- Returns the description filled with the exact template, customized with inferred/provided context.
+- Summarizes solution grounded in the actual diff (files/areas touched), not speculation.
+- Notes when screenshots are relevant for front‑end changes.
+
+What to return
+- Title: `<type>: <scope>: <summary>`
+- Description: the filled template body text
+- Optional: a short “Diff summary” section to help reviewers sanity‑check scope
+

--- a/ai_commands/refresh-architecture.md
+++ b/ai_commands/refresh-architecture.md
@@ -1,0 +1,111 @@
+Title: Refresh ARCHITECTURE.md for a Given Directory
+
+You are an engineering assistant. Your task is to refresh the ARCHITECTURE.md file for a directory specified by the user. The document must accurately describe the current code and behavior in that directory. If the code has changed since the doc was written, identify discrepancies and update the doc to reflect the current state.
+
+Inputs
+- A path to the target directory inside this repository, provided by the user (e.g., `crates/common`, `packages/orderbook`, `tauri-app`).
+
+Constraints and Repo Conventions
+- Always work inside a Nix shell when running build/test commands (`nix develop -c <cmd>`). Do not fetch network resources.
+- Prefer syntax-aware searches with ast-grep for structured matching:
+  - Rust: `sg --lang rust -p '<pattern>'`
+  - TypeScript: `sg --lang ts -p '<pattern>'`
+  - Use plain file reads or simple text scans for languages not supported by ast-grep (e.g., Solidity, Svelte markup) when structural matching is not needed.
+- Follow AGENTS.md: if an `ARCHITECTURE.md` exists in the directory, read it first and preserve its voice, structure, and intent where still accurate.
+- Do not modify code; only update documentation. Do not commit secrets or change configs.
+
+High-Level Goal
+1) Read the existing `ARCHITECTURE.md` (or create a new one if missing) in the provided directory.
+2) Build a “current state” snapshot by examining the directory’s code, configuration, and exported surfaces.
+3) Compare the snapshot to the current document and list discrepancies.
+4) Update `ARCHITECTURE.md` to accurately represent the current state, keeping the style consistent with nearby docs in this repo.
+
+Procedure
+1) Verify input and locate doc
+   - Confirm the target path exists and is inside this repo.
+   - Look for `ARCHITECTURE.md` and also accept `architecture.md` (case-insensitive). If none exist, you will create `ARCHITECTURE.md`.
+
+2) Read local context
+   - Open and read the current `ARCHITECTURE.md` fully (if present).
+   - Skim `AGENTS.md` at repo root to align format and terminology.
+
+3) Build a current-state snapshot of the directory
+   - File/Folder layout: list primary files and subfolders (1–2 levels deep), excluding obvious build outputs (`target`, `dist`, `node_modules`, `out`).
+   - Language-specific cues:
+     - Rust: read `Cargo.toml`, list crate name, lib/bin targets, features. Use ast-grep to enumerate public surface and structure:
+       - Public items: `pub struct`, `pub enum`, `pub trait`, `pub fn` (top-level, module-level).
+       - CLI commands (if any): look for `clap::Parser` or `#[derive(Parser)]`.
+       - WASM exposure: `#[wasm_bindgen]`, `tsify`, feature flags gating.
+     - TypeScript/Svelte: read `package.json` (name, scripts, exports, types). Use ast-grep to find exported API (`export function`, `export class`, `export interface`, `export type`). Note Svelte components under `*.svelte` and any public entry points.
+     - Solidity: scan `src/**/*.sol` for `contract`, `interface`, `event` names; note Foundry config in `foundry.toml` and ABIs under `out/` if relevant.
+     - Subgraph: if present, capture `subgraph.yaml`, `schema.graphql`, and mapping entry points.
+     - Tauri: capture `src-tauri` Rust commands, and UI integration entry points.
+   - Behavior and flows: identify primary responsibilities, key data flows, important invariants, and external dependencies (internal crates, packages, providers) as reflected in code.
+   - Build/Test commands: derive correct commands from this repo’s conventions (Nix + cargo/forge/npm/tauri) relevant to this directory.
+
+4) Detect discrepancies between doc and code
+   - Outdated or missing sections: modules/types that no longer exist, new modules not documented, renamed/moved files, changed public APIs, added/removed commands, changed feature flags or build targets.
+   - Behavior changes: different data flows, new invariants/constraints, updated error handling, WASM vs native surface changes.
+   - Integration points: new or removed dependencies, changed entry points, updated environment variables.
+
+5) Update the document
+   - Keep the existing voice and section ordering when they still make sense. Update only what’s necessary to make the document true and useful.
+   - If the doc is severely out of date, rewrite it using the Template below. Otherwise, surgically edit inaccurate parts.
+   - When introducing new sections, mirror styles used by other `ARCHITECTURE.md` files in this repo (short headings, bullets, concise prose, code fences where helpful).
+   - Prefer accuracy over exhaustiveness; link to code paths where appropriate rather than duplicating implementation details.
+
+6) Validate and summarize
+   - Ensure headings, lists, and code fences render cleanly.
+   - At the end of the file, append a short “Last Updated: YYYY-MM-DD — Summary of changes” line.
+   - In your output back to the user, include a brief summary of changes and any notable gaps or TODOs discovered.
+
+Template (use when creating or fully rewriting the doc)
+```
+# <name> — Architecture
+
+Summary
+- Purpose: what this directory/crate/package does in the workspace.
+- Scope: key responsibilities and boundaries; platforms/targets (native, WASM, browser, tauri).
+
+Directory Layout
+- Brief list of important files/folders and their roles.
+
+Build & Test
+- Commands relevant to this directory (use Nix):
+  - Build: `nix develop -c <cmd>`
+  - Test: `nix develop -c <cmd>`
+  - Lint/format: `nix develop -c <cmd>`
+
+Modules & Public Surface
+- Rust/TS/Solidity modules with a concise description of responsibilities.
+- Public API highlights (types, functions, classes, wasm exports, CLI commands).
+
+Key Data Flows & Behavior
+- Primary flows and how components interact. Note important invariants and error surfaces.
+
+External & Internal Dependencies
+- Workspace crates/packages it depends on and any notable third-party libs.
+
+How It Fits The Workspace
+- How this directory integrates with the rest of the project.
+
+Limitations & TODOs
+- Known gaps, future work, or caveats.
+
+Last Updated: YYYY-MM-DD — Summary of changes
+```
+
+Practical ast-grep patterns (examples)
+- Rust public items: `sg --lang rust -p 'pub (struct|enum|trait|fn) $NAME'`
+- Rust clap CLI: `sg --lang rust -p '#[derive(Parser)] struct $S'`
+- Rust wasm exports: `sg --lang rust -p '#[wasm_bindgen] fn $F(...)'`
+- TS exports: `sg --lang ts -p 'export (function|class|interface|type) $NAME'`
+
+Acceptance Criteria
+- The updated `ARCHITECTURE.md` exists in the target directory and describes the current code accurately.
+- Discrepancies between the previous document and the code have been resolved or explicitly noted.
+- The tone and structure match other architecture docs in this repo (concise headings, bullets, minimal verbosity).
+- The doc includes a “Last Updated” line with today’s date and a one-line summary.
+
+What to return
+- A short summary of what changed and why, plus the path to the updated file.

--- a/ai_commands/sdk-documentation-update.md
+++ b/ai_commands/sdk-documentation-update.md
@@ -1,0 +1,110 @@
+Title: Sync SDK Documentation with Current JS API and Package
+
+You are an engineering assistant. Your task is to verify and update the SDK documentation so it matches the current codebase. The primary source of truth is the Rust JS API in `crates/js_api` (inline docs on items exported via the `wasm_export` macro). You must also validate and update the additional package-level docs in `packages/orderbook` (e.g., README and any in‑package docs) to stay consistent with the built TypeScript surface.
+
+Goal
+- Ensure every JS-facing API exported from `crates/js_api` is documented accurately: names, parameters, parameter descriptions, return types, return descriptions, error semantics, and examples.
+- Ensure package documentation in `packages/orderbook` (e.g., README) reflects the current API surface and real usage patterns.
+- Avoid changing behavior or public API; this task is documentation-only. If you find code/doc conflicts that cannot be resolved with doc edits alone, open/leave a clear TODO note in your summary.
+
+Scope
+- Rust JS API: `crates/js_api/**` — functions, classes, and types reachable from JS via `#[wasm_export]`, `#[wasm_bindgen]`, and `Tsify`.
+- Package docs: `packages/orderbook/README.md` and any additional docs in that package. Validate against built declarations `packages/orderbook/{cjs.d.ts,esm.d.ts}` when helpful.
+- Cross-check TS usage in `packages/orderbook/test/**/*` to keep examples canonical.
+
+Constraints and Repo Conventions
+- Always use a Nix shell for build/test commands: prefix commands with `nix develop -c` (or use appropriate shell attributes).
+- Do not fetch network resources. Keep changes scoped to docs and docstrings.
+- Prefer syntax-aware search with ast-grep for structured matching:
+  - Rust: `sg --lang rust -p '<pattern>'`
+  - TypeScript: `sg --lang ts -p '<pattern>'`
+  - Use plain file reads only when structural matching is unnecessary (e.g., opening a README).
+- Follow AGENTS.md for tone and style. Keep edits concise and consistent with existing documentation voice.
+
+High-Level Process
+1) Build and list the JS-facing API.
+2) Compare inline Rust docs and export metadata to the built TypeScript surface.
+3) Audit package README and examples against canonical usage from tests.
+4) Apply focused documentation edits in Rust doc comments and package docs.
+5) Validate with workspace builds and TS checks. Summarize changes and any gaps.
+
+Procedure
+1) Prep and build
+   - Run the relevant builds and tests to ensure the code is in a good state:
+     - `nix develop -c cargo build --workspace`
+     - `nix develop -c cargo test`
+     - `cd packages/orderbook && nix develop -c npm run build && nix develop -c npm run test`
+
+2) Enumerate exported JS API (Rust)
+   - Find all wasm-exported items and their metadata:
+     - `sg --lang rust -p '#[wasm_export]' crates/js_api`
+     - Also consider `#[wasm_bindgen]` classes/impls and `Tsify` types when relevant:
+       - `sg --lang rust -p '#[wasm_bindgen]' crates/js_api`
+       - `sg --lang rust -p 'derive(Tsify)' crates/js_api`
+   - For each exported function/class/method, record:
+     - JS name (`js_name` in the attribute, or inferred from Rust name if not set)
+     - Parameter list and ordering; whether any `unchecked_param_type` is specified
+     - Return type (`unchecked_return_type` if present), and whether `preserve_js_class` is set
+     - Associated doc comments (`///`), `param_description`, and `return_description`
+
+3) Compare Rust docs to the effective TS surface
+   - Build the package and inspect generated declarations as a quick proxy for the public TS surface:
+     - `cd packages/orderbook && nix develop -c npm run build`
+     - Open `packages/orderbook/cjs.d.ts` and `packages/orderbook/esm.d.ts`.
+   - Verify that each exported item’s JS name, parameter types/order, and return type match the Rust `wasm_export` metadata.
+   - If you find a mismatch between Rust doc comments/metadata and the generated `.d.ts`, prefer fixing the Rust docs/metadata (not changing code semantics) so docs match actual exports.
+
+4) Reconcile README and examples with canonical usage
+   - Locate examples and usage references in the package README:
+     - `packages/orderbook/README.md`
+   - Cross-check against real usage in tests to keep documentation examples canonical:
+     - `sg --lang ts -p 'import { $X } from \"@rainlanguage/orderbook\"' packages/orderbook/test`
+     - Skim `packages/orderbook/test/js_api/*.test.ts` for calls and parameter shapes.
+   - Ensure examples use correct names, parameter order and types, and demonstrate error handling with `WasmEncodedResult<T>` where relevant.
+
+5) Apply focused edits
+   - In Rust (`crates/js_api/**`):
+     - Update `///` doc comments to describe current behavior precisely.
+     - Ensure each exported function has accurate `param_description` and `return_description` attributes.
+     - Make examples minimal and correct, using the JS-facing `js_name` and showing realistic inputs.
+     - Keep tone consistent with existing docs in this crate.
+   - In package docs (`packages/orderbook/README.md` and peers):
+     - Fix any outdated names, parameters, or return shapes.
+     - Align examples with patterns used in tests (preferred canonical usage).
+     - Keep imports correct: `import { ... } from '@rainlanguage/orderbook'`.
+
+6) Validate
+   - Rust checks: `nix develop -c cargo fmt --all && nix develop -c cargo clippy --all-targets -- -D warnings`
+   - Build artifacts needed for TS surface checks: `cd packages/orderbook && nix develop -c npm run build`
+   - TS type-check the built output: `cd packages/orderbook && nix develop -c npm run check`
+   - Run tests to confirm examples mirror real usage: `cd packages/orderbook && nix develop -c npm run test`
+
+Practical ast-grep patterns
+- List wasm exports: `sg --lang rust -p '#[wasm_export]' crates/js_api`
+- Find JS name assignments: `sg --lang rust -p 'js_name = $NAME' crates/js_api`
+- Param descriptions: `sg --lang rust -p 'param_description = $DESC' crates/js_api`
+- Return descriptions: `sg --lang rust -p 'return_description = $DESC' crates/js_api`
+- Tsify types: `sg --lang rust -p 'derive(Tsify)' crates/js_api`
+- TS API imports in tests: `sg --lang ts -p 'import { $API } from "@rainlanguage/orderbook"' packages/orderbook/test`
+
+Editing Guidelines
+- Do not change any function signatures or runtime logic for this task.
+- Prefer clarifying Rust doc comments and `wasm_export` attributes so the generated TypeScript aligns with docs.
+- Use the `js_name` in all JS examples; avoid Rust identifiers in examples.
+- Keep examples realistic but short; include basic error handling with `WasmEncodedResult<T>` where applicable.
+- If multiple names or behaviors are plausible, defer to the generated `.d.ts` and existing tests.
+- Preserve the existing voice and formatting used across current docs.
+
+Acceptance Criteria
+- All `#[wasm_export]` items in `crates/js_api` have accurate, up-to-date docs: names, params (with descriptions), return types/descriptions, and examples.
+- `packages/orderbook/README.md` contains examples that compile conceptually against the current `.d.ts` and mirror test usage.
+- TypeScript declarations (`cjs.d.ts`/`esm.d.ts`) match the documentation claims for names/types.
+- Builds, tests, and type checks pass locally using Nix shell commands listed above.
+- Your summary lists what changed and calls out any unresolved mismatches that require follow-up.
+
+What to return
+- A concise summary of updates made, the files touched, and any notable mismatches discovered that couldn’t be resolved via doc changes.
+
+Notes
+- This repo uses a macro named `wasm_export` in `crates/js_api` to define JS-visible APIs and attach TypeScript-specific metadata (`js_name`, `unchecked_return_type`, `param_description`, `return_description`, `preserve_js_class`). Treat those attributes as the contract for the generated TypeScript surface.
+- Some examples in README demonstrate end-to-end flows (e.g., GUI setup via `DotrainOrderGui`, order hash/calldata helpers). Prefer aligning those with current tests under `packages/orderbook/test/js_api` to avoid drift.

--- a/crates/bindings/ARCHITECTURE.md
+++ b/crates/bindings/ARCHITECTURE.md
@@ -1,0 +1,136 @@
+Rain Orderbook Bindings — Architecture
+
+Summary
+- Purpose: Provide strongly typed Rust bindings to the Rain Orderbook Solidity contracts and small utilities for calling them from Rust (native and WASM). The crate centralizes ABI-derived types and call helpers so the rest of the workspace can construct calldata, perform reads, and expose safe JS-facing types.
+- Scope: ABI-based type generation via Alloy, a read‑only provider builder with multi‑RPC fallback, and WASM interop shims (TypeScript typings + conversions).
+
+File Layout
+- Cargo.toml: Declares the crate `rain_orderbook_bindings`. Key deps: `alloy` (codegen + types + RPC), `serde` (Serialize/Deserialize), `tower` (layers), `url`, `thiserror`. For WASM builds it uses `wasm-bindgen-utils` and `wasm-bindgen-test` for tests.
+- src/lib.rs: Declares contract bindings using Alloy’s `sol!` macro and re‑exports internal modules. Conditionally includes WASM modules.
+- src/provider.rs: Builds a read‑only provider with multi‑RPC fallback and sensible default request fillers.
+- src/js_api.rs (wasm only): JS/WASM interop. Implements wasm conversion traits and custom TypeScript interfaces for selected ABI types used in the GUI.
+- src/wasm_traits.rs (wasm only): Utility trait to convert JS `BigInt` to `U256` with negative/overflow handling plus tests.
+
+Generated Solidity Bindings (Alloy `sol!`)
+- The crate uses `alloy::sol!` to generate Rust modules, types, and (optionally) RPC call helpers from contract ABIs produced by Foundry. ABIs are read from the repository’s `out/` directory.
+
+- Bindings defined in `src/lib.rs`:
+  - `IOrderBookV5, "../../out/IOrderBookV5.sol/IOrderBookV5.json"`
+    - Attributes: `#![sol(all_derives = true, rpc)]`, `#![sol(extra_derives(serde::Serialize, serde::Deserialize))]`.
+    - Effect: Generates Rust types for all ABI structs/enums/events and RPC instance helpers for calling the contract. Adds `Serialize/Deserialize` derives for ergonomic (de)serialization.
+  - `OrderBook, "../../out/OrderBook.sol/OrderBook.json"`
+    - Attributes: `#![sol(all_derives = true)]`, `#![sol(extra_derives(serde::Serialize, serde::Deserialize))]`.
+    - Effect: Same as above but without the `rpc` helpers. This is sufficient for constructing/calculating calldata (e.g., `multicallCall`) without needing a bound instance type.
+  - `IERC20, "../../out/IERC20.sol/IERC20.json"`
+    - Attributes: `#![sol(all_derives = true, rpc)]`.
+    - Effect: ERC‑20 call helpers and Rust types (e.g., `approveCall`, `allowanceCall`) with RPC instance support.
+  - `ERC20, "../../out/ERC20.sol/ERC20.json"`
+    - Attributes: `#![sol(all_derives = true)]`.
+    - Effect: Full types for concrete ERC‑20; used for calldata construction and decoding when instance helpers aren’t required.
+
+- Practical result of the `sol!(… rpc)` attribute:
+  - For `IOrderBookV5` and `IERC20`, you can construct an instance bound to a provider and call methods with strong typing, for example: `let ob = IOrderBookV5Instance::new(address, provider.clone()); ob.quote2(config).await?`.
+  - For all bindings, you can still directly use generated call structs, e.g., `IOrderBookV5::removeOrder3Call { ... }.abi_encode()` or `OrderBook::multicallCall { ... }`.
+
+- Derives and defaults:
+  - `all_derives = true` enables useful traits on generated types, including `Clone`, `Debug`, `Default`, `Eq`, `PartialEq`, and more, which the codebase relies on (e.g., `OrderV4::default()`).
+  - `extra_derives(serde::Serialize, serde::Deserialize)` ensures all ABI types can be serialized to/from JSON, which is critical for CLI/GUI I/O and WASM interop.
+
+ABI Source of Truth
+- The referenced JSON files under `out/` are produced by Foundry (`forge build`). If ABIs change, re‑build the contracts so `out/.../*.json` stays in sync. The `sol!` macro reads these on compile.
+
+Provider Utilities (`src/provider.rs`)
+- Type alias
+  - `pub type ReadProvider = FillProvider<JoinedRecommendedFillers, RootProvider<AnyNetwork>, AnyNetwork>;`
+  - Meaning: a provider stack consisting of an `RpcClient` → `RootProvider` for `AnyNetwork`, with the “recommended” fillers layered in (gas/nonce/chain-id/etc.) to auto‑complete missing call fields.
+
+- `mk_read_provider(rpcs: &[Url]) -> Result<ReadProvider, ReadProviderError>`
+  - Accepts one or more RPC URLs for the same chain.
+  - Builds an HTTP transport stack wrapped with `FallbackLayer` so requests survive individual RPC outages by trying the next available transport.
+  - `with_active_transport_count(NonZeroUsize::new(size)?)` activates as many transports as provided URLs, enabling concurrent/fallback behavior.
+  - Connects an `RpcClient` to an `AnyNetwork` provider via `ProviderBuilder::new_with_network::<AnyNetwork>().connect_client(client)`.
+  - Errors:
+    - `UrlParse`: invalid URL parsing failed (bubbled from `url` crate when constructing inputs elsewhere).
+    - `NoRpcs`: the input slice was empty (no transports to build).
+
+- When to use
+  - Use this provider for read‑only flows (e.g., quoting, allowances, balances) needing resilience across multiple public/provider endpoints. Signing/submitting transactions is performed elsewhere in the workspace; this crate doesn’t include wallet/signing.
+
+WASM and JS Interop
+- Conditional compilation: `src/js_api.rs` and `src/wasm_traits.rs` are compiled only for `target_family = "wasm"`.
+
+- `src/js_api.rs` bridges key ABI types to predictable TypeScript shapes for the GUI, using the workspace’s `wasm-bindgen-utils` macros:
+  - `impl_wasm_traits!(T)` implements glue code to convert between Rust and JS values (e.g., Serde + wasm-bindgen interop) for the given type.
+  - `impl_custom_tsify!(T, "…TS interface…")` pins the exact TypeScript surface for WASM consumers. This avoids relying on auto‑generated typings that may drift with upstream changes.
+
+- Exposed interfaces (hand‑written TS definitions):
+  - `IOV2`: `{ token: string; vaultId: string; }`
+  - `QuoteV2`: `{ order: OrderV4; inputIOIndex: string; outputIOIndex: string; signedContext: SignedContextV1[]; }`
+  - `OrderV4`: `{ owner: string; evaluable: EvaluableV4; validInputs: IOV2[]; validOutputs: IOV2[]; nonce: string; }`
+  - `EvaluableV4`: `{ interpreter: string; store: string; bytecode: string; }`
+  - `SignedContextV1`: `{ signer: string; context: string[]; signature: string; }`
+  - `TakeOrderConfigV4`: `{ order: OrderV4; inputIOIndex: string; outputIOIndex: string; signedContext: SignedContextV1[]; }`
+  - `TakeOrdersConfigV4`: `{ minimumInput: string; maximumInput: string; maximumIORatio: string; orders: TakeOrderConfigV4[]; data: string; }`
+
+- Why many fields are `string` in TS
+  - Large numeric values (e.g., `U256`) are represented as strings to avoid precision issues and to keep interop predictable across JS runtimes. Hex strings are used for byte data. This matches how the rest of the workspace serializes on the boundary.
+
+- WASM tests (in `src/js_api.rs`)
+  - Use `wasm-bindgen-test` to validate that the serialized JS values expose exactly the properties declared by the TS interfaces (e.g., `'owner' in obj`). The tests create default Rust values, convert with `to_js_value`, and assert property presence.
+
+WASM Numeric Conversion (`src/wasm_traits.rs`)
+- Trait: `TryIntoU256` for JS `BigInt` → `U256` conversion.
+  - Implementation parses the stringified `BigInt` into `U256` using Alloy’s `ruint` parser.
+  - Error handling covers:
+    - Negative values → `ParseError::InvalidDigit('-')`.
+    - Overflow beyond `U256::MAX` → `ParseError::BaseConvertError(Overflow)`.
+  - Tests cover `0`, a small positive, `U256::MAX`, overflow (`2^256`), and negatives.
+
+How This Crate Is Used Elsewhere
+- Quote engine (`crates/quote`):
+  - Imports `IOrderBookV5::IOrderBookV5Instance` and `mk_read_provider`.
+  - Binds the instance to a provider and calls `quote2` for many orders via Alloy’s multicall helper.
+- Common utilities (`crates/common`):
+  - Uses ABI‑generated call structs (e.g., `deposit3Call`, `withdraw3Call`, `removeOrder3Call`, `IERC20::approveCall`) to build calldata for transactions.
+- JS API (`crates/js_api`):
+  - Builds GUI calldata for approvals/deposits/add‑order and uses call structs like `OrderBook::multicallCall` without needing on‑chain RPC instance helpers.
+- CLI (`crates/cli`):
+  - Consumes ABI struct types such as `OrderV4` and `IOV2` to construct orders from user inputs.
+
+Design Choices and Rationale
+- Keep bindings centralized: All ABI structs and call helpers live in one place so downstream crates share a single, consistent type system.
+- Split `rpc` vs. non‑`rpc` bindings:
+  - `IOrderBookV5`/`IERC20` include RPC instance helpers for ergonomic reads.
+  - `OrderBook`/`ERC20` are included without `rpc` when only calldata construction/decoding is required.
+- Provider is read‑only by design: This crate does not handle signing or nonce management beyond auto‑fillers. Submission/signature flows live in other crates.
+- WASM boundary is explicit: Hand‑authored TS interfaces lock the surface area for the webapp, preventing accidental breaking changes from codegen drift.
+
+Error Handling
+- `ReadProviderError` enumerates provider construction failures:
+  - `UrlParse(url::ParseError)` and `NoRpcs`.
+- ABI call errors, revert decoding, and multicall aggregation are handled in consumer crates (e.g., `quote`), leveraging these bindings for encoding/decoding.
+
+Build and Test
+- Build (workspace): `nix develop -c cargo build -p rain_orderbook_bindings`.
+- Tests (native and wasm; wasm executed via runner in the flake):
+  - Native: `nix develop -c cargo test -p rain_orderbook_bindings`.
+  - WASM: the workspace’s Nix config sets `CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER='wasm-bindgen-test-runner'` and runs `cargo test --target wasm32-unknown-unknown -p rain_orderbook_bindings`.
+
+Examples
+- Constructing a read provider and querying via an instance (native):
+  - Parse URLs to `url::Url` and build: `let provider = mk_read_provider(&rpcs)?;`
+  - Bind to an orderbook: `let ob = IOrderBookV5Instance::new(orderbook_addr, provider.clone());`
+  - Call a view: `let quote = ob.quote2(config).await?;`
+
+- Building calldata without an instance:
+  - `use rain_orderbook_bindings::IOrderBookV5::removeOrder3Call;`
+  - Construct the struct and encode: `let bytes = removeOrder3Call { order, tasks }.abi_encode();`
+
+Limitations and Notes
+- Not a signer: The provider is for reads; transaction signing/broadcast is out of scope.
+- Assumes ABIs are current: If Foundry output changes, re‑build before compiling Rust.
+- `AnyNetwork` provider: Consumers are responsible for ensuring the supplied RPCs point to the intended chain.
+
+Updating Bindings
+- Modify the Solidity contracts as needed, run `nix develop -c forge build`, then rebuild Rust. If new structs/functions are added to the ABIs, they will appear under the corresponding Rust modules after recompilation. Add/update WASM TS interfaces in `src/js_api.rs` as needed for GUI usage.
+

--- a/crates/common/ARCHITECTURE.md
+++ b/crates/common/ARCHITECTURE.md
@@ -1,0 +1,269 @@
+# rain_orderbook_common — Architecture & Reference
+
+This crate provides the shared core for the Rain Orderbook toolchain across native (CLI, services) and WebAssembly (browser/tauri) targets. It bundles higher‑level orchestration around:
+
+- Parsing and composing Rain language (Rainlang) and DOTRAIN YAML frontmatter.
+- Building and executing Orderbook contract calls (add/remove orders, deposit, withdraw), including Ledger support on native.
+- Querying orderbook state via the subgraph and flattening results for display/CSV export.
+- A WASM‑friendly API surface for UI apps (via `wasm_bindgen_utils` and `tsify`).
+- Developer ergonomics: LSP helpers, fuzz/unit‑test runners, and EVM fork utilities to parse/evaluate Rainlang and replay transactions.
+
+The library is built as `rlib` and `cdylib`. A Git commit identifier is embedded as `GH_COMMIT_SHA` for traceability.
+
+
+## Module Overview
+
+- `add_order` — Compose Rainlang from DOTRAIN, parse to bytecode via on‑chain Parser, generate `addOrder3` call parameters, execute or simulate on a fork.
+- `remove_order` — Convert subgraph `SgOrder` to `removeOrder3` call, execute or return calldata.
+- `deposit` — ERC20 allowance check/approve and `deposit3` call builder/executor.
+- `withdraw` — `withdraw3` call builder/executor and calldata generator.
+- `transaction` — Shared tx args (RPCs, chain ID, fees), Ledger provider creation (native), and `WriteContractParameters` helpers.
+- `erc20` — Typed ERC20 reads (decimals/name/symbol/allowance/balance), multicall token info, and robust revert decoding.
+- `subgraph` — Thin wrapper to instantiate an orderbook subgraph client from a URL.
+- `raindex_client/*` — High‑level client over orderbook YAML config: find networks/orderbooks, fetch orders, vaults, trades, transactions; quote orders; prepare batch withdraw calldata; expose WASM‑friendly structs.
+- `dotrain_order` — Parse and validate a DOTRAIN config; compose scenarios/deployments to Rainlang; fetch authoring metadata and pragma words; merge additional settings.
+- `rainlang` — Compose Rainlang from a DOTRAIN string + bindings; optional fork‑based parser that returns encoded bytecode.
+- `dotrain_add_order_lsp` — Language‑services integration for Rainlang/DOTRAIN (hover, completion, diagnostics, and fork‑parse problems).
+- `types/*` — Flattened view models for CSV/export: orders, order takes, vault balance changes, token vaults, plus shared errors and constants.
+- `csv` — Generic `TryIntoCsv` trait for serializing vectors of typed rows.
+- `utils/*` — Formatting helpers for amounts (`U256` → string) and timestamps (seconds → UTC string).
+- `fuzz` — Fuzzing/evaluation harness over Rainlang entrypoints and charts (native), with WASM‑serializable result shapes.
+- `replays` — EVM fork utilities to replay an on‑chain transaction and convert raw traces to `RainEvalResult`.
+- `unit_tests` — Programmatic runner that executes DOTRAIN pre/calculate‑io/handle‑io/post entrypoints on a fork for deterministic tests.
+- `test_helpers` — Sample DOTRAIN used in tests.
+- `lib` — Public module wiring, re‑exports, and `GH_COMMIT_SHA` env binding.
+
+Target gating is used extensively:
+- Native only: Ledger, EVM forking/eval, transaction execution, some tests.
+- WASM: `tsify` types and `wasm_export` bindings, alternate `tokio` features, and JS‑oriented getters.
+
+
+## Key Data Flow & Responsibilities
+
+### 1) DOTRAIN → Rainlang → Bytecode (add_order)
+- Inputs: DOTRAIN (YAML frontmatter + Rainlang sections), selected scenario/deployment (from `rain_orderbook_app_settings`), and bindings.
+- `AddOrderArgs::compose_to_rainlang` uses `rainlang::compose_to_rainlang` to produce the Rainlang snippet for order entrypoints (`calculate-io`, `handle-io`).
+- Parser address is discovered via `DISPair::from_deployer`; the Rainlang text is parsed by `ParserV2::parse_text` over provided RPCs to produce bytecode.
+- Metadata is generated as a Rain Meta V1 document containing `RainlangSourceV1` and CBOR‑encoded with `rain-metadata`.
+- The `addOrder3` call is assembled with Evaluable (interpreter/store/bytecode), inputs/outputs vaults, random nonce/secret, and a post task (`handle-add-order`) compiled similarly.
+- Execution paths:
+  - Native: Build `WriteContractParameters` and execute with `WriteTransaction` via a Ledger provider, or simulate on a fork (`Forker`) per RPC.
+  - Any target: Return ABI‑encoded calldata for external submission.
+
+### 2) Remove Order
+- `RemoveOrderArgs` converts `SgOrder` to `removeOrder3Call` via subgraph traits.
+- Native execution mirrors `add_order` (Ledger provider + `WriteTransaction`), or return calldata only.
+
+### 3) Deposit / Approve
+- `DepositArgs` holds token, vaultId, `Float` amount, and decimals.
+- `read_allowance` uses a readable provider to query ERC20 allowance.
+- If allowance is insufficient, `execute_approve` submits an ERC20 `approve` for the deficit.
+- `execute_deposit` builds and submits `deposit3` with the exact `Float` amount converted to fixed decimal units.
+- Both execution functions accept a status callback for progress.
+
+### 4) Withdraw
+- `WithdrawArgs` maps directly to `withdraw3` call. Provides execution and calldata helpers.
+
+### 5) Transaction Plumbing
+- `TransactionArgs` encapsulates RPCs, chain ID, optional Ledger derivation index, and EIP‑1559 fee caps.
+- `try_fill_chain_id` reads chain ID via the readable client when absent.
+- Native: `try_into_ledger_client` picks the first working RPC, connects a Ledger signer/provider, and returns the signer address.
+- `try_into_write_contract_parameters` packages any typed `SolCall` into the `WriteContractParameters` used by `WriteTransaction`.
+
+### 6) ERC20 Reads & Error Decoding
+- `ERC20` wraps an `IERC20Instance` over a read provider (`mk_read_provider`). Methods: `decimals`, `name`, `symbol`, `allowance`, `balanceOf`, and `token_info` (multicall over all three metadata calls).
+- Revert data is decoded via `rain_error_decoding` to produce human‑readable errors. For multicall `CallFailed`, the revert is decoded and mapped.
+
+### 7) Subgraph Client Creation
+- `SubgraphArgs::to_subgraph_client` parses the URL and returns an `OrderbookSubgraphClient` bound to that endpoint.
+
+### 8) Raindex Client (orderbook YAML–driven API)
+- `RaindexClient::new` parses one or more orderbook YAML strings using `OrderbookYaml`, optionally with full validation.
+- Derives a map of networks and orderbooks to build `MultiSubgraphArgs` groupings for cross‑network queries.
+- Exposed operations (with WASM bindings):
+  - YAML accessors: get unique chain IDs, networks, orderbooks by address, accounts, and RPC URLs.
+  - Orders: list with filters/pagination across networks, fetch by hash, fetch orders created in a transaction.
+  - Quotes: compute per‑pair quotes for an order (`get_order_quotes` under the hood), with formatted ratios and inverses.
+  - Vaults: list/query vaults for an order or orderbook, fetch balance changes, prepare withdraw multicall calldata, format balances.
+  - Trades and transactions: list trades (with optional time bounds), fetch trade detail, transaction detail.
+- Conversion helpers map subgraph types (`Sg*`) to WASM/JS‑friendly shapes (`Raindex*`) and back when needed.
+- Error surface `RaindexError` normalizes failures from YAML parsing, hex parsing, subgraph network errors, ERC20 reads, float/parse errors, etc., and provides user‑facing messages via `to_readable_msg`.
+
+### 9) DOTRAIN Order Utilities
+- `DotrainOrder::create` extracts frontmatter from a DOTRAIN text, validates spec version, hydrates remote networks/tokens if configured, and builds both `DotrainYaml` and `OrderbookYaml` caches.
+- Compose helpers:
+  - `compose_scenario_to_rainlang` and `compose_deployment_to_rainlang` create Rainlang with scenario/deployment bindings applied.
+  - `compose_scenario_to_post_task_rainlang` produces post‑task (`handle-add-order`) Rainlang.
+- Queries:
+  - `get_pragmas_for_scenario` and `get_contract_authoring_meta_v2_for_scenario` read pragma addresses and authoring metadata (supports metaboard subgraph).
+- Errors map to readable messages for UI consumption.
+
+### 10) Rainlang Composition & Fork Parse
+- `rainlang::compose_to_rainlang` uses language services’ meta store and `RainDocument::create` with optional rebinding to render specified entrypoints.
+- Native: `fork_parse::parse_rainlang_on_fork` lazily initializes a global `FORKER`, selects/creates an EVM fork per RPC, and returns ABI‑encoded expression config. Reverts are decoded to typed errors.
+
+### 11) LSP Integration for Add Order
+- `DotrainAddOrderLsp` stores a `TextDocumentItem` plus optional bindings. Methods:
+  - `hover`, `completion` via `RainLanguageServices`.
+  - `problems` composes entrypoints; if composition fails, reports structured errors; else optionally fork‑parses Rainlang against a selected deployment to provide diagnostics.
+
+### 12) Fuzzing, Unit Tests, and Replays
+- `fuzz::FuzzRunner` composes entrypoints for scenarios (replacing elided bindings with random data), creates a fork at configured block(s), and runs multiple iterations. Results flatten to tables for charting.
+- `unit_tests::TestRunner` orchestrates a four‑phase evaluation (pre → calculate‑io → handle‑io → post) with controlled context injection; designed for deterministic contract‑level testing of Rainlang logic.
+- `replays::TradeReplayer` builds a fork and replays a given transaction hash, returning converted `RainEvalResult` traces.
+
+### 13) Flattened Types and CSV
+- `types/order_detail_extended.rs` — Wraps `SgOrder` and optionally decoded Rainlang source from meta.
+- `types/orders_list_flattened.rs` — `OrderFlattened` for list views: timestamps, owner, interpreters/stores, valid vault IDs and token symbols, and first add‑event transaction, with `TryFrom<SgOrder>`.
+- `types/order_takes_list_flattened.rs` — `OrderTakeFlattened` summarizing a trade (input/output amounts, tokens, and formatted values).
+- `types/vault_balance_change_flattened.rs` — Normalized view of vault balance changes across deposits/withdrawals/trades with signed formatted amounts and type labels.
+- `types/token_vault_flattened.rs` — Vault + token metadata and formatted balance.
+- All implement `TryIntoCsv<T>` on `Vec<T>` to produce headers + rows via `serde::Serialize` and `csv::Writer`.
+
+### 14) Utilities
+- `utils/amount_formatter.rs` — `format_amount_u256` using `alloy::primitives::utils::format_units` and `remove_trailing_zeros` to clean fixed‑decimal strings. Error type wraps unit and parse errors.
+- `utils/timestamp.rs` — Formatting helpers: `format_bigint_timestamp_display` (string seconds → UTC) and `format_timestamp_display_utc` with strict bounds and parse errors.
+
+
+## Public API Highlights
+
+- Call builders and calldata
+  - `AddOrderArgs::{try_into_call, get_add_order_call_parameters, execute, get_add_order_calldata, simulate_execute}`
+  - `RemoveOrderArgs::{execute, get_rm_order_calldata}`
+  - `DepositArgs::{read_allowance, execute_approve, execute_deposit}` and `WithdrawArgs::{execute, get_withdraw_calldata}`
+  - `RaindexVaultsList::get_withdraw_calldata` for multicall batch withdraws
+
+- DOTRAIN/Rainlang
+  - `DotrainOrder::create`, `compose_*_to_rainlang`, YAML accessors, pragma/meta queries
+  - `rainlang::compose_to_rainlang` and native `fork_parse::parse_rainlang_on_fork`
+
+- Raindex client (selected)
+  - YAML: `get_unique_chain_ids`, `get_all_networks`, `get_network_by_chain_id`, `get_orderbook_by_address`, `get_all_accounts`
+  - Orders: `get_orders`, `get_order_by_hash`, `get_add_orders_for_transaction`
+  - Quotes: `RaindexOrder::get_quotes`
+  - Vaults: `get_vaults_list`, `get_orderbook_vaults_list`, `RaindexVault::{get_balance_changes, get_deposit_calldata, get_withdraw_calldata}`, `RaindexVault::get_account_balance`
+  - Trades/Tx: `RaindexOrder::{get_trades_list, get_trades_count}`, `RaindexOrder::get_trade_detail`, `RaindexClient::get_transaction`
+
+- CSV & types
+  - `TryIntoCsv` implemented on vectors of flattened types for export.
+
+- Constants
+  - `ORDERBOOK_ORDER_ENTRYPOINTS` = [`calculate-io`, `handle-io`]
+  - `ORDERBOOK_ADDORDER_POST_TASK_ENTRYPOINTS` = [`handle-add-order`]
+  - `types::vault::NO_SYMBOL` — fallback when token symbol is absent
+  - `GH_COMMIT_SHA` — compile‑time commit id
+
+
+## Error Handling
+
+Each domain defines focused error enums with `thiserror::Error`:
+- `AddOrderArgsError`, `RemoveOrderArgsError`, `DepositError`, `WritableTransactionExecuteError`, `TransactionArgsError` — transactional and parsing failures.
+- `erc20::Error` — revert decoding, provider/multicall errors, and typed ABI decode errors.
+- `RaindexError` — umbrella for YAML/subgraph/hex/float/amount formatting/ERC20/tx errors; exposes `to_readable_msg` for UI.
+- `types::FlattenError` — conversion/formatting failures when building flattened view models.
+- `TryDecodeRainlangSourceError` — meta decoding and content validation of Rainlang source.
+- Fuzz/unit‑test/replay errors normalize fork issues, abi‑decoded reverts, and YAML/spec mismatches.
+
+Errors typically bubble with `#[from]` to preserve sources and are turned into WASM‑friendly structures via `From<...> for WasmEncodedError` where applicable.
+
+
+## WASM vs Native Surface
+
+- WASM builds derive `Tsify` for public structs and expose getters with JS‑friendly types (`Hex`, `Address`, `number[]`, `Map<..>`) using `wasm_bindgen_utils` annotations.
+- Native builds enable:
+  - `tokio` full features.
+  - Ledger transport and provider setup for transaction execution.
+  - EVM forking (`rain_interpreter_eval`) to parse/eval Rainlang, simulate calls, and replay txs.
+
+Where functionality cannot run in WASM, equivalent calldata generation methods are provided so frontends can submit via their own providers.
+
+
+## Subgraph, YAML, and Quoting
+
+- Subgraph clients are constructed from orderbook YAML to ensure per‑network routing and naming.
+- The client supports multi‑network fan‑out via `MultiOrderbookSubgraphClient` and paginated queries.
+- Quotes use on‑chain multicall under the hood; results are converted to `Float` and pre‑formatted strings, including inverse ratios and empty/infinite cases.
+
+
+## Testing & Quality Notes
+
+- The crate has extensive unit tests across modules (including mocked RPC/subgraph) validating:
+  - Error surfaces and message mapping.
+  - ABI encoding/decoding of calls and calldata consistency.
+  - CSV/flattening correctness and edge cases (missing symbols, invalid timestamps, invalid hex/ABI).
+  - DOTRAIN spec version gating and settings merging.
+  - ERC20 revert handling and multicall decoding.
+  - EVM‑fork‑based parsing/evaluation and replay correctness (native).
+- Fuzz and unit‑test runners demonstrate example patterns for evaluating Rainlang over controlled contexts.
+
+
+## Notable Dependencies (workspace crates)
+
+- `rain_orderbook_bindings` — Strongly‑typed ABI for Orderbook and ERC20 contracts (`addOrder3`, `removeOrder3`, `deposit3`, `withdraw3`, multicall).
+- `rain_orderbook_subgraph_client` — GraphQL types and clients for orderbook data; provides `Sg*` models and helpers.
+- `rain_orderbook_app_settings` — DOTRAIN/orderbook YAML structures, validation, and spec versioning.
+- `rain_orderbook_quote` — Batch quote engine for orders.
+- `rain_interpreter_*` — Parser, eval, DISP pair, bindings used to compile/evaluate Rainlang.
+- `rain_metadata` — CBOR‑encoded metadata with magic prefixes; used to embed Rainlang source.
+- `rain_error_decoding` — ABI error decoding to readable types/names.
+- `rain_math_float` — Arbitrary‑precision floats with hex encoding for on‑chain compatibility and pretty formatting.
+- `alloy` & `alloy_ethers_typecast` — EVM primitives, providers, signers (Ledger), and Read/Write contract helpers.
+- `wasm_bindgen_utils`, `tsify` — WASM/JS interop helpers and type generation.
+
+
+## Typical End‑to‑End Flows
+
+- Add an order (native or UI):
+  1) Build `DotrainOrder` from DOTRAIN text; pick a deployment; build `AddOrderArgs` via `new_from_deployment`.
+  2) Compose Rainlang and parse to bytecode via parser address (from `DISPair`).
+  3) Generate metadata bytes and `addOrder3Call` with post task.
+  4) Execute with `WriteTransaction` (native) or obtain `abi_encode()` and submit via external provider (WASM).
+
+- Remove an order:
+  1) Fetch `SgOrder` from subgraph; convert to `removeOrder3Call` and execute or export calldata.
+
+- Deposit/Withdraw:
+  1) For deposit, check allowance and approve if needed; call `deposit3`.
+  2) For withdraw, construct `withdraw3` calldata or execute; batch multiple via `RaindexVaultsList::get_withdraw_calldata`.
+
+- Explore orderbook data in a UI:
+  1) Instantiate `RaindexClient` from YAML configs.
+  2) List orders across networks; fetch vaults, trades, and quotes for selected orders.
+  3) Render CSV exports using `TryIntoCsv` on flattened types.
+
+
+## Constants & Build Flags
+
+- `GH_COMMIT_SHA` is set at compile time via the `COMMIT_SHA` env var and can be displayed for “About/Version” screens.
+- `crate-type = ["rlib", "cdylib"]` enables consumption as a Rust lib and a WASM/FFI‑ready dynamic library.
+- Conditional `tokio` features are selected for WASM vs native targets in Cargo.toml.
+
+
+## Notes & Caveats
+
+- Many error types intentionally capture inner variants to preserve exact failure causes (RPC transport vs. ABI decode vs. parse errors). UIs should prefer `to_readable_msg` for end users.
+- Fork‑based helpers rely on at least one working RPC; functions return descriptive errors if all providers fail.
+- Non‑WASM execution paths interact with hardware Ledger devices and therefore are compiled out for browser targets.
+- Some performance‑related queries are stubbed/disabled (see TODOs referencing issue 1989) and kept for future reinstatement.
+
+
+## File Map (quick reference)
+
+- API layers
+  - `src/add_order.rs`, `src/remove_order.rs`, `src/deposit.rs`, `src/withdraw.rs`, `src/transaction.rs`, `src/erc20.rs`
+- DOTRAIN/Rainlang
+  - `src/dotrain_order.rs`, `src/rainlang.rs`, `src/dotrain_add_order_lsp.rs`
+- Client & data access
+  - `src/raindex_client/` (orders, quotes, vaults, trades, transactions, YAML)
+  - `src/subgraph.rs`
+- Data views & export
+  - `src/types/` (flattened rows + errors), `src/csv.rs`, `src/utils/*`
+- Eval/fork tooling
+  - `src/fuzz/*`, `src/replays.rs`, `src/unit_tests.rs`
+- Surfacing
+  - `src/lib.rs` (pub mod graph, wasm re‑exports), `GH_COMMIT_SHA`
+
+This document covers all publicly exposed modules and their roles so new contributors and integrators can navigate the crate quickly and correctly wire native/WASM consumers.
+
+
+Last Updated: 2025-09-14 — Verified against current code; doc remains accurate. Added last-updated footer.

--- a/crates/js_api/ARCHITECTURE.md
+++ b/crates/js_api/ARCHITECTURE.md
@@ -1,0 +1,193 @@
+**Overview**
+- Purpose: `rain_orderbook_js_api` exposes a single, browser-friendly WebAssembly surface for the Rain Orderbook application. It bridges YAML-based “dotrain” order configuration, on-chain ERC‑20/token metadata, and contract call generation into a typed JavaScript/TypeScript API.
+- Target: Compiles as a `cdylib` for wasm and is designed to be consumed from JS environments (webapps, Tauri). All public APIs are exported via `wasm_bindgen_utils` macros and return ergonomic results with rich, user‑readable errors.
+- Scope: Includes high-level GUI helpers for interactive order building, a fetchable registry of orders, and low-level helpers for hashing and ABI calldata generation. It re-exports certain sibling crates so their wasm bindings are reachable from a single import.
+
+**Build & Targets**
+- Crate type: `cdylib` (WASM output). Most modules are `#[cfg(target_family = "wasm")]` as they are JS/GUI facing.
+- Key dependencies: `wasm-bindgen-utils`, `alloy` (ABI/primitives), `rain_orderbook_*` crates for app models + on-chain helpers, `tokio` (async), `reqwest` (HTTP, registry), `flate2`/`base64`/`bincode`/`sha2` (state serialization), `strict-yaml-rust` (YAML AST).
+- TypeScript support: Adds TS definitions for `Address` and `Hex` template literal types and uses `tsify` to describe return/param types of exported structs.
+
+**Top-Level Layout**
+- `src/lib.rs`
+  - Exposes modules only when targeting wasm: `bindings`, `gui`, `registry`, `yaml`.
+  - Re-exports crates so their wasm bindings are available from this single module: `rain_orderbook_app_settings`, `rain_orderbook_common`, `rain_orderbook_subgraph_client`.
+  - Appends a small TS section defining `Address` and `Hex` template literal types for better typing on the JS side.
+
+**FFI & Error Conventions**
+- Functions and impl blocks use `#[wasm_export]` (from `wasm_bindgen_utils`), which:
+  - Exports JS-callable functions and classes with Promise-based async where needed.
+  - Bridges `Result<T, E>` into JS objects with `.value` on success or an `.error` containing a serialized `WasmEncodedError` with both `msg` and `readable_msg`.
+  - Uses hints like `unchecked_return_type` and `preserve_js_class` to fine-tune TS output.
+- Data structs use `#[derive(Tsify)]` to generate accurate TS types (e.g., `Hex`, `Map<…>`, arrays), and many address-like types are annotated as TS `string` for interop.
+
+**Modules**
+
+- `bindings` (src/bindings/mod.rs)
+  - Purpose: Low-level helpers exposed to JS for hashing and ABI encoding independent of the GUI flow.
+  - Key types and exports:
+    - `TakeOrdersCalldata(Bytes)` as an opaque JS type for encoded calldata.
+    - `getOrderHash(order: OrderV4) -> string`: ABI-encodes `OrderV4` and returns `keccak256` with `0x` prefix.
+    - `getTakeOrders3Calldata(config: TakeOrdersConfigV4) -> TakeOrdersCalldata`: ABI-encodes a `takeOrders3` call for the on-chain OrderBook.
+    - `keccak256(bytes: Uint8Array) -> string` and `keccak256HexString(hex: string) -> string`.
+  - Errors: `Error::FromHexError` mapped to JS with human-readable message.
+
+- `gui` (src/gui/…)
+  - Purpose: High-level, stateful orchestrator for interactive order creation from a dotrain (YAML + Rainlang) configuration. Encapsulates reading config, managing user inputs, querying token metadata, validating fields, and generating contract call data for deployment.
+  - Core type: `DotrainOrderGui`
+    - Fields: `dotrain_order` (parsed configuration), `selected_deployment`, `field_values` and `deposits` (with preset tracking), and an optional `state_update_callback` JS function.
+    - Construction:
+      - `DotrainOrderGui.getDeploymentKeys(dotrain: string) -> string[]` parses `gui.deployments`.
+      - `DotrainOrderGui.newWithDeployment(dotrain, selectedDeployment, stateUpdateCallback?) -> DotrainOrderGui` validates the deployment and bootstraps a GUI instance.
+    - Config accessors:
+      - `getGuiConfig() -> GuiCfg`, `getCurrentDeployment() -> GuiDeploymentCfg` (filtered for the active deployment).
+      - `getOrderDetails(dotrain) -> NameAndDescriptionCfg` (static), `getDeploymentDetails(dotrain) -> Map<string, NameAndDescriptionCfg>`, `getDeploymentDetail(dotrain, key) -> NameAndDescriptionCfg`.
+      - `getCurrentDeploymentDetails() -> NameAndDescriptionCfg`.
+    - Token metadata:
+      - `getTokenInfo(key) -> TokenInfo`: returns address/decimals/name/symbol. Falls back to on-chain queries if YAML is incomplete.
+      - `getAllTokenInfos() -> TokenInfo[]`: collects token keys from `select-tokens` or order IO, then fetches details as needed.
+    - Dotrain/Rainlang exports:
+      - `generateDotrainText() -> string`: emits full dotrain text (YAML frontmatter + `---` + Rainlang body), preserving the current config.
+      - `getComposedRainlang() -> string`: updates scenario bindings from saved field values and composes Rainlang ready for preview.
+
+  - Submodules
+    - `field_values.rs`
+      - User-controlled inputs declared under `gui.deployments[*].fields`.
+      - Setters and getters:
+        - `setFieldValue(binding, value)`: validates (if rules exist), detects preset matches, stores as either preset index or custom value, and triggers the state callback.
+        - `setFieldValues([{field, value}, …])`: batch equivalent.
+        - `unsetFieldValue(binding)`.
+        - `getFieldValue(binding) -> { field, value, isPreset }` expands presets to actual values for display.
+        - `getAllFieldValues() -> FieldValue[]`.
+        - `getFieldDefinition(binding) -> GuiFieldDefinitionCfg` and `getAllFieldDefinitions(filterDefaults?)` (filter by has default/no default), `getMissingFieldValues()`.
+      - Validation: delegated to `validation.rs` using YAML-provided rules (Number min/max/exclusive bounds, String min/max length, Boolean exact `"true"|"false"`). Uses `rain_math_float::Float` for precise numeric comparisons.
+
+    - `deposits.rs`
+      - User deposit amounts declared under `gui.deployments[*].deposits`.
+      - Helpers:
+        - `getDeposits() -> TokenDeposit[]` expanding presets to actual values and pairing with token addresses.
+        - `setDeposit(tokenKey, amount)` validates per-token rules (min/max/exclusive), detects presets, stores, and triggers state callback.
+        - `unsetDeposit(tokenKey)`, `getDepositPresets(tokenKey) -> string[]`, `getMissingDeposits() -> string[]`, `hasAnyDeposit() -> boolean`.
+        - `check_deposits()` (internal) enforces that all required deposits are set for the current deployment.
+
+    - `select_tokens.rs`
+      - For deployments that declare `select-tokens`, users supply token contracts at runtime.
+      - Features:
+        - `getSelectTokens() -> GuiSelectTokensCfg[]` and `checkSelectTokens()`.
+        - `isSelectTokenSet(key) -> boolean`.
+        - `setSelectToken(key, address)` fetches ERC‑20 metadata via RPC (derived from the deployment’s network) and writes token records back into the dotrain YAML; triggers state callback.
+        - `unsetSelectToken(key)` removes previously selected token records.
+        - `areAllTokensSelected() -> boolean`.
+        - Token discovery: `getAllTokens(search?) -> TokenInfo[]` returns all tokens for the active network. If metadata is missing in YAML, it fetches on-chain, dedupes by address, and optionally filters by name/symbol/address substring. Concurrency is limited by `MAX_CONCURRENT_FETCHES`.
+        - `getAccountBalance(tokenAddress, owner) -> AccountBalance` reads ERC‑20 decimals and balance and returns both raw and formatted balance.
+
+    - `order_operations.rs`
+      - Generates all calldata required to deploy orders and related flows.
+      - Internal preparation:
+        - `prepare_calldata_generation` validates select-tokens, ensures field values exist as needed, populates vault IDs, and updates scenario bindings before generating any calldata.
+        - `get_orderbook()` and `get_transaction_args()` collect the orderbook address and RPCs for downstream calls.
+        - `get_deposits_as_map()` and `get_vaults_and_deposits()` resolve deposit amounts by token/address and match them to order outputs + vaults.
+      - Allowance/approvals:
+        - `checkAllowances(owner) -> AllowancesResult`: queries current allowances for each deposit token against the orderbook.
+        - `generateApprovalCalldatas(owner) -> ApprovalCalldataResult`: compares allowances to required deposit amounts; emits ERC‑20 `approve` calldatas only when needed.
+      - Deposits:
+        - `generateDepositCalldatas() -> DepositCalldataResult`: builds `deposit3` calldatas for non-zero deposits using vault IDs (fetches decimals on-chain if missing in YAML).
+      - Add order:
+        - `generateAddOrderCalldata() -> AddOrderCalldataResult`: composes Rainlang, builds an `AddOrderArgs` from the deployment, and returns the ABI-encoded call.
+      - Combined deployment:
+        - `generateDepositAndAddOrderCalldatas() -> DepositAndAddOrderCalldataResult`: constructs a `multicall` that first performs `addOrder`, then all deposits.
+        - `getDeploymentTransactionArgs(owner) -> DeploymentTransactionArgs`: packages approval calldatas (with token symbol for UX), multicall calldata, orderbook address, and chain ID for a one-shot deployment flow.
+      - Vault IDs:
+        - `setVaultId(type: 'input'|'output', tokenKey, vaultId?: string)`, `getVaultIds() -> IOVaultIds`, and `hasAnyVaultId() -> boolean`.
+      - Types exposed for JS: `AllowancesResult`, `ApprovalCalldataResult|DepositCalldataResult|AddOrderCalldataResult|DepositAndAddOrderCalldataResult`, `ExtendedApprovalCalldata`, `DeploymentTransactionArgs`, `IOVaultIds`. A `WithdrawCalldataResult` type exists but no public generator yet.
+
+    - `state_management.rs`
+      - End-to-end state persistence and restoration:
+        - `serializeState() -> string`: bincode-serializes a compact state (field values and deposit presets, selected tokens, vault IDs, selected deployment) then gzips and base64-encodes. Also embeds a SHA‑256 of the full dotrain to prevent mismatched restores.
+        - `DotrainOrderGui.newFromState(dotrain, serialized, callback?) -> DotrainOrderGui`: validates the hash against the provided dotrain, rebuilds internal maps, replays selected tokens and vault IDs back into the YAML/documents, and returns a fully restored instance.
+        - `executeStateUpdateCallback()`: manually triggers the callback by passing the latest `serializeState()` string. Most mutating methods call this automatically.
+        - `getAllGuiConfig() -> AllGuiConfig`: returns all front-end relevant config slices grouped for progressive UI building (fields by required/optional, deposits, order inputs/outputs).
+
+    - `validation.rs`
+      - Uniform validation library used by `field_values` and `deposits`:
+        - Numbers: `minimum`, `exclusive-minimum`, `maximum`, `exclusive-maximum`; rejects negatives; precise decimal support via `Float`.
+        - Strings: `min-length`, `max-length` (length measured on trimmed strings).
+        - Booleans: accepts only `"true"` or `"false"`.
+      - Errors (`GuiValidationError`) carry contextual, user-readable messages; surfaced to JS via `GuiError::ValidationError`.
+
+  - Error type for the GUI: `GuiError`
+    - Captures configuration, selection, validation, I/O, chain, and serialization errors.
+    - Provides `to_readable_msg()` with end-user friendly explanations.
+    - Implements conversions to `JsValue` and `WasmEncodedError` for FFI.
+
+- `registry` (src/registry.rs)
+  - Purpose: Fetches a remote registry file that lists one shared settings YAML followed by one or more `.rain` order files. Produces merged dotrain content per order and can directly construct a `DotrainOrderGui` instance.
+  - Registry format:
+    - First non-empty line: settings YAML URL (no key)
+    - Subsequent lines: `"<orderKey> <url-to-order.rain>"`
+  - Flow:
+    - `DotrainRegistry.new(registryUrl)` → fetch registry text → parse → fetch settings → fetch all orders (concurrently) → store in-memory.
+    - `getAllOrderDetails()` → parse order-level metadata for every merged dotrain.
+    - `getOrderKeys()` → keys from `order_urls`.
+    - `getDeploymentDetails(orderKey)` → deployment name/description map for a specific order.
+    - `getGui(orderKey, deploymentKey, stateCallback?)` → merge `settings + order` and produce a `DotrainOrderGui` instance.
+  - Errors: `DotrainRegistryError` covers fetch/parse/HTTP/URL issues and wraps `GuiError`. Also returns human-readable messages.
+
+- `yaml` (src/yaml/mod.rs)
+  - Purpose: Wasm-friendly wrapper around orderbook YAML parsing to retrieve an `OrderbookCfg` by contract address.
+  - Exports:
+    - `OrderbookYaml.new([yamlSources], validate?) -> OrderbookYaml`: parse/merge/optionally validate sources.
+    - `OrderbookYaml.getOrderbookByAddress(address) -> OrderbookCfg`.
+  - Errors: `OrderbookYamlError` with readable messaging, converted to JS.
+
+**External Crates & Interactions**
+- `rain_orderbook_app_settings`: typed config model + YAML parsing helpers for GUI sections, deployments, networks, orders, select-tokens, and validation rules.
+- `rain_orderbook_common`: higher-level order manipulation (compose Rainlang, add order args), ERC‑20 RPC client, transaction helpers, and formatting utilities.
+- `rain_orderbook_bindings`: generated Solidity bindings for `IOrderBookV5` (e.g., `deposit3`, `multicall`, `takeOrders3`).
+- `alloy`: ABI encoding/decoding, primitives (`Address`, `Bytes`, `U256`, keccak256), and Solidity type utilities.
+- `wasm-bindgen-utils`: export macro, JS bridging, `WasmEncodedError` packaging.
+
+**Data Flow & Typical Lifecycle**
+- From dotrain → GUI → calldata:
+  - Parse dotrain (frontmatter YAML + Rainlang body) with `DotrainOrder::create`.
+  - Initialize GUI with a deployment key.
+  - Optional: select tokens via on-chain metadata, set field values (with validation), set deposit amounts (with validation), and set vault IDs.
+  - Generate approvals if needed, deposits, add order calldata, or a combined multicall. Transaction args include orderbook address and chain ID.
+- State persistence:
+  - Any setter triggers `executeStateUpdateCallback()` with a gzipped/base64 state snapshot that includes a dotrain content hash. `newFromState` restores and protects against mismatched content.
+- Token metadata:
+  - Prefer YAML cache when available; otherwise, query chain via current network’s RPC(s). Concurrency for token info lookups is capped.
+
+**TypeScript Surface**
+- Most exported structs are `Tsify`’d, and methods use `unchecked_return_type` for readable TS types:
+  - Example: `getVaultIds()` returns a `Map<string, Map<string, string | undefined>>` keyed by `"input"`/`"output"` and token keys.
+  - Calldata types are exposed as `Hex` or `Hex[]`, addresses as `string` with TS template literal types appended by `lib.rs`.
+
+**Testing Notes**
+- Uses `wasm-bindgen-test` to exercise behavior within wasm targets.
+- Many tests validate:
+  - Validation errors and their readable messages.
+  - Deposit/field setters, preset detection, and getters.
+  - Select-token flows and token discovery, including search and dedupe.
+  - Vault ID setting and query helpers.
+  - State serialization and restoration roundtrips (including hash mismatch protection).
+  - Registry parsing/fetching logic; non-wasm tests use `httpmock` to simulate HTTP servers.
+
+**Edge Cases & Notes**
+- If YAML is missing token metadata, the crate queries the chain; callers should expect async RPC usage and potential network failures in those code paths.
+- `WithdrawCalldataResult` exists as a type placeholder; no public generator currently uses it.
+- Many GUI methods error if `select-tokens` is configured but tokens are not yet selected, or if required field values/deposits are missing. These error cases surface clear `readable_msg`s.
+- When decimals are absent in YAML, they are fetched on demand before encoding deposits.
+
+**How To Use (High-Level)**
+- Single order flow:
+  - `const gui = await DotrainOrderGui.newWithDeployment(dotrain, deploymentKey, onStateChanged?)`
+  - Fill inputs: `setFieldValue`, `setDeposit`, optionally `setSelectToken`, `setVaultId`.
+  - Generate data: `generateAddOrderCalldata` or `generateDepositAndAddOrderCalldatas`; or get the full package from `getDeploymentTransactionArgs(owner)`.
+  - Persist UI state: read `serializeState()`; restore later with `DotrainOrderGui.newFromState(dotrain, serialized, callback?)`.
+- Multiple orders via registry:
+  - `const registry = await DotrainRegistry.new(registryUrl)` → inspect orders/deployments → `await registry.getGui(orderKey, deploymentKey, onStateChanged?)`.
+
+**Summary**
+- `rain_orderbook_js_api` is the JS/WASM gateway for building, validating, and deploying Rain Orderbook orders from YAML+Rainlang definitions. It centralizes: YAML parsing and validation, user input state, token selection and metadata, field and deposit validation, vault ID management, transaction calldata generation (approvals, deposits, add order, multicall), registry-driven content fetching, and robust error handling—exposed as a typed, ergonomic TypeScript surface.
+

--- a/crates/math/ARCHITECTURE.md
+++ b/crates/math/ARCHITECTURE.md
@@ -1,0 +1,197 @@
+# rain_orderbook_math — Architecture & Design Notes
+
+This crate provides small, focused, and overflow‑safe helpers for 256‑bit integer math used across the Rain Orderbook codebase. It standardizes two things:
+
+- Fixed‑point arithmetic in 18‑decimals (a.k.a. “wad” math).
+- Safe scaling between token native decimals and 18‑decimals.
+
+The implementation wraps `alloy::primitives` big‑ints and exposes a trait implemented for `U256` so call sites can remain expressive and chainable.
+
+## Crate Surface
+
+- Constants
+  - `ONE18: U256` — 10^18, represented as a 256‑bit integer.
+  - `FIXED_POINT_DECIMALS: u8` — 18, the standard fixed‑point scale.
+- Error type
+  - `MathError` — unified error for math/units/width conversions.
+- Trait implemented for `U256`
+  - `BigUintMath`
+    - `scale_up(self, by: u8) -> Result<U256, MathError>`
+    - `scale_down(self, by: u8) -> Result<U256, MathError>`
+    - `scale_18(self, decimals: u8) -> Result<U256, MathError>`
+    - `mul_div(self, mul: U256, div: U256) -> Result<U256, MathError>`
+    - `mul_18(self, other: U256) -> Result<U256, MathError>`
+    - `div_18(self, other: U256) -> Result<U256, MathError>`
+
+There are no module subtrees; everything is in `src/lib.rs` with unit tests under `#[cfg(test)]`.
+
+## Dependencies and Types
+
+- `alloy::primitives::{U256, U512}` — 256/512‑bit unsigned integers.
+- `alloy::primitives::ruint::{FromUintError, UintTryTo}` — fallible, width‑aware conversions and helpers.
+- `alloy::primitives::utils::UnitsError` — error type for unit/decimal utilities (not currently emitted by this crate’s functions, but accounted for in `MathError`).
+- `thiserror::Error` — error derivation.
+
+Note: `once_cell` is a workspace dependency but is not used inside this crate as of this revision.
+
+## Constants
+
+- `ONE18`
+  - Defined via limbs: `U256::from_limbs([1_000_000_000_000_000_000, 0, 0, 0])`.
+  - Used as the scaling factor for 18‑decimal fixed‑point ops.
+- `FIXED_POINT_DECIMALS`
+  - Fixed at 18 and used by `scale_18` to decide direction of scaling.
+
+## Error Model — `MathError`
+
+- `Overflow` — returned when checked arithmetic fails (e.g., `checked_mul`/`checked_div` or intermediate width conversions cannot fit).
+- `UnitsError(UnitsError)` — passthrough for unit/decimal parsing and conversion errors (present for ergonomic composition; not produced by functions in this file at the moment).
+- `FromUintErrorU256(FromUintError<U256>)` — converting into `U256` failed (e.g., narrowing from a `U512` result that won’t fit).
+- `FromUintErrorU512(FromUintError<U512>)` — converting into `U512` failed (kept for completeness when using `UintTryTo::<U512>` paths).
+
+All public functions return `Result<U256, MathError>`. Division by zero surfaces as `Overflow` (via `checked_div` returning `None`).
+
+## BigUintMath — Semantics and Rationale
+
+All methods are implemented for `U256` and return a `U256` (or error). The guiding principles are:
+
+- Deterministic integer arithmetic (no floats), suitable for on‑chain semantics and reproducible off‑chain analytics.
+- Use 512‑bit intermediates when multiplying to avoid overflow before dividing.
+- Keep API composable and minimal; callers can build richer flows on top.
+
+### `scale_up(self, by: u8)`
+
+- Computes `self * 10^by` with `checked_mul` to detect overflow.
+- Intended to increase a value’s decimal precision. Example: USDC `6 → 18` uses `by = 12`.
+- Errors
+  - `Overflow` if `10^by` overflows `U256` or the product doesn’t fit in `U256`.
+
+### `scale_down(self, by: u8)`
+
+- Computes `self / 10^by` with `checked_div`.
+- Truncates toward zero (integer division). No rounding.
+- Errors
+  - `Overflow` if divisor is zero due to an invalid exponent (practically unreachable for reasonable `by` but captured for safety).
+
+### `scale_18(self, decimals: u8)`
+
+- Converts `self` from `decimals` to 18 decimals.
+- Logic
+  - If `decimals > 18`: `scale_down(decimals - 18)`.
+  - If `decimals < 18`: `scale_up(18 - decimals)`.
+  - If `decimals == 18`: returns `self`.
+- Behavior
+  - Scaling down truncates fractional remainders; callers must account for this if rounding is required.
+
+### `mul_div(self, mul: U256, div: U256)`
+
+- Computes floor((`self * mul`) / `div`) using a 512‑bit widening multiply to avoid overflow during the product.
+- Steps
+  1. `self.widening_mul(mul)` → `U512` product.
+  2. `checked_div(U512(div))` — detect divide‑by‑zero; keep the integer quotient.
+  3. Attempt to `try_to::<U256>()` the result; fail if it doesn’t fit.
+- Errors
+  - `Overflow` on divide‑by‑zero or if intermediate doesn’t fit when narrowing.
+  - `FromUintErrorU512`/`FromUintErrorU256` for width conversion failures.
+
+### `mul_18(self, other: U256)`
+
+- 18‑dec fixed‑point multiplication: `floor(self * other / 1e18)`.
+- Implemented as `mul_div(other, ONE18)`.
+
+### `div_18(self, other: U256)`
+
+- 18‑dec fixed‑point division: `floor(self * 1e18 / other)`.
+- Implemented as `mul_div(ONE18, other)`.
+
+## Rounding and Truncation
+
+- All divisions truncate toward zero (integer floor for non‑negative inputs).
+- There is no built‑in rounding mode. If callers require “round half up”, they should bias the numerator before division, e.g. `mul_div(x + div/2, mul, div)` for appropriate domains.
+
+## Limits and Edge Cases
+
+- Exponent bounds: `10^by` must fit in `U256` to be meaningful. Practical ERC‑20 token decimals are typically ≤ 36; values well beyond ~77 will overflow `U256`.
+- Division by zero: guarded and returned as `Overflow`.
+- Sign: all values are unsigned (`U256`). If negative semantics are needed, the sign must be tracked out‑of‑band by the caller (as seen in other crates that pair magnitudes with boolean flags).
+
+## Interactions in the Workspace
+
+Downstream crates treat these helpers as the canonical way to:
+
+- Normalize per‑token magnitudes to 18 decimals with `scale_18` for comparability.
+- Perform fixed‑point rates and APY math using `mul_18`/`div_18` without risking 256‑bit overflow (thanks to widening intermediates).
+
+Examples of usage (from `crates/subgraph`):
+
+- Compute per‑vault APY over time windows:
+  - Convert vault balances to 18‑dec with `scale_18`.
+  - Compute annualization and ratios with `mul_18`/`div_18`.
+- Convert between token denominations by applying a pair ratio via `mul_18` to capitals and net volumes.
+
+## Tests — Intent and Coverage
+
+`src/lib.rs` includes unit tests asserting the core behaviors:
+
+- `test_big_uint_math_scale_18`
+  - Scales up when `decimals < 18` and down when `decimals > 18`.
+  - No‑op when already 18 decimals.
+  - Shows that scaling down truncates remainders.
+- `test_big_uint_math_mul_div`
+  - Checks simple products and divisions.
+  - Includes a case where a 256‑bit product would overflow, verifying `widening_mul` correctness and final narrowing.
+- `test_big_uint_math_mul_18`
+  - Exercises fixed‑point multiply, including a large value where a 256‑bit product would overflow without widening.
+- `test_big_uint_math_div_18`
+  - Exercises fixed‑point division under large inputs.
+
+These tests collectively validate scaling correctness, overflow resistance, and fixed‑point semantics.
+
+## Design Notes & Rationale
+
+- Chosen representation: integers avoid floating‑point rounding and platform variance, matching on‑chain arithmetic.
+- Widening strategy: `U512` intermediates for multiply‑then‑divide patterns are the standard approach to preserve precision without overflow before division.
+- API locality: A single trait on `U256` keeps call sites terse and testable without introducing new wrapper types.
+- Error aggregation: `MathError` centralizes math‑related failures for ergonomic propagation into higher‑level error types.
+
+## Usage Patterns (Examples)
+
+Assume `amount` is a token balance in its native decimals.
+
+- Normalize to 18 decimals:
+  ```rust
+  use alloy::primitives::U256;
+  use rain_orderbook_math::BigUintMath;
+
+  let usdc_amount = U256::from(1_500_000u64); // 1.5 USDC with 6 decimals
+  let wad = usdc_amount.scale_18(6)?;          // 1.5 * 1e18 as U256
+  ```
+
+- Apply a fixed‑point price (18‑decimals) to a quantity:
+  ```rust
+  let qty_18 = U256::from_dec_str("2000000000000000000")?; // 2.0
+  let price_18 = U256::from_dec_str("333333333333333333")?; // 0.333333333333333333
+  let value_18 = qty_18.mul_18(price_18)?;                   // floor(2.0 * 0.333..)
+  ```
+
+- Compute a ratio safely without overflow:
+  ```rust
+  let numerator = U256::from_dec_str("10_000_000_000_000_000_000")?;
+  let denominator = U256::from_dec_str("2_000_000_000_000_000_000")?;
+  let x = U256::from(10_000u64).mul_div(numerator, denominator)?; // 40_000
+  ```
+
+## Known Limitations / Considerations
+
+- No rounding modes are provided; all divisions truncate. Callers must implement their own rounding if required.
+- `UnitsError` is part of `MathError` for convenience but is not currently produced by functions in this file.
+- Extremely large exponents in scaling (e.g., `by > ~77`) will overflow `U256` powers of ten.
+
+## File Map
+
+- `src/lib.rs` — All implementations and tests.
+- `Cargo.toml` — Declares crate as `rain_orderbook_math`; depends on `alloy`, `thiserror` (and `once_cell` via workspace, unused here).
+
+## Summary
+
+`rain_orderbook_math` supplies the minimal, safe building blocks needed for consistent 18‑dec fixed‑point math on `U256`, with careful overflow handling and 512‑bit intermediates for the common mul‑then‑div pattern. Other Rain Orderbook crates rely on these helpers to normalize magnitudes and compute rates without duplicating math or risking undefined overflow behavior.

--- a/crates/quote/ARCHITECTURE.md
+++ b/crates/quote/ARCHITECTURE.md
@@ -1,0 +1,248 @@
+# rain_orderbook_quote — Architecture & Design
+
+This crate provides all functionality to quote Rain Orderbook orders from Rust, expose the API to WASM/TypeScript, and ship a small CLI for ad‑hoc quoting and debugging. It stitches together three external systems:
+
+- On‑chain Orderbook V5 contracts (`IOrderBookV5`) via JSON‑RPC
+- The Orderbook subgraph for fetching order details by id
+- Rain error decoding to turn revert data into human readable errors
+
+It also includes a debugger that can fork an EVM and trace a `quote2` call for step‑by‑step analysis of interpreter execution.
+
+
+## Targets and Build Modes
+
+- Library: `rain_orderbook_quote` (default). Always built.
+- Binary: uses `src/main.rs` which calls the crate CLI entry `cli::main()`.
+- WASM: many types derive `Tsify` and use `wasm-bindgen-utils` helpers. The `cli` and `quote_debug` modules are disabled for wasm via `#[cfg(not(target_family = "wasm"))]`.
+
+Key gating:
+- `src/lib.rs` re‑exports modules and conditionally exposes `cli` and `quote_debug` when not targeting wasm.
+- `Cargo.toml` has extra `tokio` features for wasm (no full runtime) and enables `rain-interpreter-eval` only for native targets.
+
+
+## High‑Level Responsibilities
+
+- Build quoting requests for one or many orders (direct or via subgraph lookups).
+- Perform efficient batched on‑chain calls using Multicall3 `aggregate3`.
+- Represent quote results in a consistent, serializable format (`OrderQuoteValue`).
+- Decode revert data (including Rain errors) into structured failures (`FailedQuote`).
+- Provide a CLI to drive the above with ergonomic input formats and JSON output.
+- Provide a quote debugger that forks an EVM and returns interpreter traces for `quote2` calls.
+
+
+## Core Data Model
+
+- `OrderQuoteValue`
+  - Fields: `max_output: Float`, `ratio: Float`
+  - Converts from the ABI type `quote2Return { exists, outputMax, ioRatio }`.
+  - Used by both native and wasm; serializes to camelCase.
+
+- `QuoteTarget`
+  - A fully specified quote request with the exact `QuoteV2` (includes the `OrderV4` bytes, input/output indices, and optional signed context) and the `orderbook` address.
+  - Helpers:
+    - `get_order_hash()`: `keccak256(order.abi_encode())`
+    - `get_id()`: subgraph order id = `keccak256(orderbook || order_hash)`
+    - `validate()`: verifies the input/output indices are in bounds for the given order.
+    - `do_quote(rpcs, block_number, gas, multicall_address)`: calls `rpc::batch_quote` with just this target and returns its `QuoteResult`.
+
+- `BatchQuoteTarget(Vec<QuoteTarget>)`
+  - Adds `do_quote(...) -> Result<Vec<QuoteResult>, Error>` and is the standard input to RPC batch quoting.
+
+- `QuoteSpec`
+  - A quote specification that references an order by `order_hash` and `orderbook` without embedding the order bytes. Includes `input_io_index`, `output_io_index`, and optional `signed_context`.
+  - `get_id()`: same subgraph id as above using `orderbook || order_hash`.
+  - `get_quote_target_from_subgraph(subgraph_url)`: queries the subgraph to fetch `orderBytes` and builds a `QuoteTarget`.
+  - `do_quote(subgraph_url, rpcs, block_number, gas, multicall_address)`: fetches order bytes first, then quotes once.
+
+- `BatchQuoteSpec(Vec<QuoteSpec>)`
+  - `get_batch_quote_target_from_subgraph(subgraph_url) -> Vec<Option<QuoteTarget>>`: batch fetches order bytes; returns `None` for missing orders.
+  - `do_quote(...) -> Vec<QuoteResult>`: fetches all targets that exist, quotes them in batch, and returns the results aligned to the original spec order; missing specs yield `Err(FailedQuote::NonExistent)`.
+
+- `QuoteResult`
+  - Type alias: `Result<OrderQuoteValue, FailedQuote>`.
+  - For wasm consumers a matching TS type alias is emitted: `export type QuoteResult = OrderQuoteValue | string`.
+
+- `Pair` and `BatchOrderQuotesResponse` (in `order_quotes.rs`)
+  - `Pair` describes a human‑readable input/output pair on an order (`pair_name`, `input_index`, `output_index`).
+  - `BatchOrderQuotesResponse` bundles the pair, `block_number`, success flag, optional `data` (`OrderQuoteValue`), and optional string `error`.
+
+
+## Error Types and Semantics
+
+- `FailedQuote` represents a per‑call failure returned as an element within `Vec<QuoteResult>`:
+  - `NonExistent` — the target `quote2` call returned `exists=false`.
+  - `RevertError(AbiDecodedErrorType)` — decoder recognized the revert (often a Rain error like `TokenSelfTrade`).
+  - `RevertErrorDecodeFailed(AbiDecodeFailedErrors)` — revert present but not decodable by the registry.
+  - `CorruptReturnData(String)` — malformed data when a multicall reports failure without decodable payload.
+
+- `Error` represents top‑level failures of building or executing a batch:
+  - URL parse errors, subgraph client errors, ABI decode errors when building targets, provider creation failures, and `MulticallError` when the overall transport fails.
+
+- wasm conversions are implemented so both `FailedQuote` and `Error` convert to `JsValue` messages.
+
+
+## RPC Layer: `rpc::batch_quote`
+
+Purpose: execute `quote2` for many `QuoteTarget`s in one multicall.
+
+Flow:
+1. Parse RPC URLs into `Url` and build a `ReadProvider` via `mk_read_provider(&rpcs)` from `rain_orderbook_bindings`.
+2. Create a dynamic `multicall` builder; override its address if `multicall_address` is provided.
+3. Optionally pin to `block_number` via `BlockId::Number(block)`.
+4. For each target, push `IOrderBookV5::quote2(QuoteV2)` into the multicall.
+5. Await `aggregate3()`:
+   - If the entire multicall returns `Err(MulticallError::CallFailed(bytes))`, decode the bytes via the Rain error selector registry and return a vector with the same per‑target error for each element (so callers still receive a `Vec<QuoteResult>` of the right length).
+   - If other transport‑level errors occur, bubble them up as `Error::MulticallError` and do not return per‑target results.
+6. For every `aggregate3` element:
+   - `Ok(ret)` and `ret.exists == true` → `Ok(OrderQuoteValue::from(ret))`.
+   - `Ok(ret)` and `ret.exists == false` → `Err(FailedQuote::NonExistent)`.
+   - `Err(failure)` → decode `failure.return_data` via the registry into `FailedQuote::RevertError` or `FailedQuote::RevertErrorDecodeFailed`.
+
+Notes:
+- `gas` is currently accepted but unused (placeholder for future control).
+- `block_number` lets callers obtain deterministic historical quotes.
+
+
+## Subgraph Integration
+
+- `OrderbookSubgraphClient` is used to fetch `orderBytes` either single (`order_detail`) or batch (`batch_order_detail`).
+- `QuoteSpec` and `BatchQuoteSpec` use the helper `make_order_id(orderbook, order_hash)` to query the subgraph.
+- ABI decoding of `orderBytes` constructs `OrderV4`, which is then embedded into `QuoteV2`.
+
+
+## Order Pair Sweep: `order_quotes::get_order_quotes`
+
+Purpose: given full `SgOrder` records (including token metadata), compute quotes for every valid input/output pair of the order and package human‑readable results.
+
+Flow:
+- Resolve `req_block_number`: use the provided `block_number` or fetch the current one via `ReadableClient::new_from_http_urls(rpcs.clone())?.get_block_number().await`.
+- For each `SgOrder`:
+  - Convert `order.order_bytes` into `OrderV4`.
+  - For each combination of `validInputs × validOutputs` where `input.token != output.token`:
+    - Build `pair_name` using token symbols from the subgraph record.
+    - Build a `QuoteTarget` with `QuoteV2 { order, inputIOIndex, outputIOIndex, signedContext: [] }`.
+  - Batch quote all constructed targets at `req_block_number`.
+  - For each pair, push a `BatchOrderQuotesResponse` with either `data: Some(OrderQuoteValue)` and `success: true`, or `error: Some(<string>)` and `success: false`.
+
+Result: a flat `Vec<BatchOrderQuotesResponse>` that UIs can render per pair.
+
+
+## CLI: `cli` module and `src/main.rs`
+
+Entrypoint:
+- `src/main.rs` calls `rain_orderbook_quote::cli::main()` which initializes tracing, parses args, and delegates to `Quoter::run()`.
+
+Arguments (selected):
+- `--rpc <URL>` (required): JSON‑RPC endpoint.
+- `--sg|--subgraph <URL>` (optional): subgraph endpoint; required when using specs.
+- `--block-number <INTEGER>`: quote at a specific block.
+- `--multicall-address <ADDRESS>`: override Multicall3 address.
+- `--output <PATH>`: write JSON result to a file.
+- `--no-stdout`: suppress stdout; useful with `--output`.
+- `--pretty`: pretty‑print JSON.
+
+Input formats (mutually exclusive via `Input` group):
+- `-i|--input <HEX_STRING>`: Packed bytes representing one or more `QuoteSpec`s. Each spec is exactly 54 bytes: `[20 bytes orderbook][1 byte inputIO][1 byte outputIO][32 bytes order_hash]`. Length must be a non‑zero multiple of 54.
+- `--target <ORDERBOOK_ADDRESS> <INPUT_IO_INDEX> <OUTPUT_IO_INDEX> <ORDER_BYTES>`: One or more fully specified targets (can repeat `--target`).
+- `--spec <ORDERBOOK_ADDRESS> <INPUT_IO_INDEX> <OUTPUT_IO_INDEX> <ORDER_HASH>`: One or more specs (requires `--subgraph`).
+
+Output format:
+- Always JSON array (`QuoterResult`). For each element:
+  - Success → `{ "maxOutput": "0x…", "ratio": "0x…" }`.
+  - Failure → `{ "status": "error", "message": "…" }`.
+- File output mirrors stdout; `--pretty` controls formatting.
+
+Behavior:
+- `--target …` → `BatchQuoteTarget.do_quote()` directly against RPC.
+- `--spec … --subgraph …` → fetch order bytes, then batch quote.
+- `--input … --subgraph …` → decode into specs, then same as above.
+
+
+## Quote Debugger: `quote_debug` (native only)
+
+Purpose: Help users debug a `quote2` call by forking a chain, executing the call, collecting interpreter traces, and decoding any revert reason.
+
+- Types:
+  - `NewQuoteDebugger { fork_url: Url, fork_block_number: Option<u64> }`.
+  - `QuoteDebugger { forker: Forker }`.
+
+- `QuoteDebugger::new(args)` constructs a forked EVM via `rain_interpreter_eval::Forker::new_with_fork`.
+- `QuoteDebugger::debug(quote_target)`:
+  - Validates IO indices with `QuoteTarget::validate()`.
+  - Encodes `quote2` call and executes it against the forked EVM.
+  - If reverted, optionally decode revert data using the Rain selector registry.
+  - Returns `(RainEvalResult, Option<Result<AbiDecodedErrorType, AbiDecodeFailedErrors>>)` where the first element contains execution traces (stacks, etc.).
+
+
+## Module Map
+
+- `src/lib.rs`: module wiring and public re‑exports.
+- `src/main.rs`: CLI binary entry.
+- `src/error.rs`: `Error` and `FailedQuote` enums; wasm conversions.
+- `src/rpc.rs`: batched multicall quoting and revert decoding.
+- `src/quote.rs`: core quoting types (`OrderQuoteValue`, `QuoteTarget`, `BatchQuoteTarget`, `QuoteSpec`, `BatchQuoteSpec`) and subgraph integration.
+- `src/order_quotes.rs`: utilities to compute quotes across all IO pairs for `SgOrder`s.
+- `src/cli/input.rs`: input parsing for CLI; conversions from CLI args/hex to batch types.
+- `src/cli/mod.rs`: CLI struct (`Quoter`), output wrapper types, `run()` logic, and `main()`.
+- `src/quote_debug.rs`: fork‑based debugger returning traces and optional decoded revert information.
+
+
+## External Dependencies of Note
+
+- `alloy` primitives and `sol_types`: ABI encode/decode, EVM types, and contract call modeling.
+- `rain_orderbook_bindings`: contract bindings (`IOrderBookV5`, provider helpers like `mk_read_provider`).
+- `rain_orderbook_subgraph_client`: GraphQL client and types; provides `order_detail` and `batch_order_detail`.
+- `rain-error-decoding`: decodes revert selectors (known/unknown) into structured errors.
+- `alloy-ethers-typecast::ReadableClient`: convenience for fetching block number across multiple HTTP RPCs.
+- `rain_math_float::Float`: canonical numeric type used in quotes; serializes to hex strings and provides safe equality/formatting.
+- `wasm-bindgen-utils`: `Tsify` derives and helper macros (`impl_wasm_traits!`, `add_ts_content!`).
+
+
+## Testing Overview
+
+The crate has extensive unit tests across modules, including:
+- CLI parsing and end‑to‑end runs with mocked RPC and subgraph servers.
+- `rpc::batch_quote` success, transport errors, and both encoded and undecodable revert paths.
+- `quote` module helpers (`get_id`, `validate`, subgraph fetches, batch alignment preserving optionals).
+- `order_quotes::get_order_quotes` happy path and error propagation for malformed input or RPC URLs.
+- Debugger tests that stand up a local anvil‑based EVM, deploy orders, and assert interpreter traces.
+
+Tests use:
+- `httpmock` for simulating JSON‑RPC and subgraph HTTP responses.
+- `rain_orderbook_test_fixtures::LocalEvm` to spawn a local chain with tokens and an orderbook.
+
+
+## Invariants and Edge Cases
+
+- IO indices must be within bounds of the `OrderV4`’s `validInputs`/`validOutputs` (enforced by `QuoteTarget::validate()` and in debugger; RPC path assumes caller provides valid indices).
+- Packed hex input for `-i|--input` must be a non‑zero multiple of 54 bytes; otherwise parsing fails.
+- Multicall behavior:
+  - Aggregate transport errors → top‑level `Error::MulticallError`.
+  - Aggregate “call failed with bytes” → returns a per‑target `Err(FailedQuote::…)` vector to preserve shape.
+- Missing subgraph orders:
+  - Batch path returns `Err(FailedQuote::NonExistent)` in the corresponding positions.
+- `gas` parameter currently reserved; intentionally unused.
+
+
+## Typical Usage Patterns
+
+- Library (native):
+  - Build `QuoteTarget`s and call `BatchQuoteTarget::do_quote(rpcs, block, None, None)`.
+  - Or build `QuoteSpec`s and call `BatchQuoteSpec::do_quote(subgraph_url, rpcs, block, None, None)`.
+
+- CLI:
+  - Direct targets: `cargo run -p rain_orderbook_quote -- --rpc <RPC> --target <ORDERBOOK> <IN_IO> <OUT_IO> <ORDER_BYTES>`
+  - Specs via subgraph: `--spec <ORDERBOOK> <IN_IO> <OUT_IO> <ORDER_HASH> --sg <SUBGRAPH>`
+  - Packed bytes: `-i <HEX> --sg <SUBGRAPH>` where `<HEX>` is repeated 54‑byte chunks.
+
+- Debugging (native only):
+  - Instantiate `QuoteDebugger` with a fork URL (e.g. local anvil or public RPC) and optional block.
+  - Call `.debug(quote_target)` and inspect `RainEvalResult` traces and decoded revert, if any.
+
+
+## Limitations and Future Work
+
+- `gas` is not used yet; future revisions may allow customizing execution gas per call in multicall contexts.
+- Subgraph fetch assumes ABI correctness in `orderBytes`; corrupted bytes cause `OrderDetailError`.
+- RPC URL health is caller’s responsibility; the library supports multiple URLs and will error on unparseable inputs.
+

--- a/crates/settings/ARCHITECTURE.md
+++ b/crates/settings/ARCHITECTURE.md
@@ -1,0 +1,350 @@
+# Settings Crate – Architecture and Responsibilities
+
+This crate defines the configuration model, parsing, validation and update utilities for the Rain Orderbook stack. It turns one or more YAML “settings” documents into strongly‑typed Rust structures that the rest of the system can consume (CLI, services, GUI/Tauri, and WASM/JS bindings). It also supports fetching and merging remote configuration (networks, tokens), contextual variable interpolation, and in‑place updates back to the underlying YAML.
+
+At a glance:
+
+- Input format: one or more YAML documents (via `StrictYaml` from `strict_yaml_rust`).
+- Output types: `NetworkCfg`, `TokenCfg`, `OrderbookCfg`, `SubgraphCfg`, `DeployerCfg`, `OrderCfg`, `ScenarioCfg`, `DeploymentCfg`, `GuiCfg`, `ChartCfg`, `MetaboardCfg`, `AccountCfg`, plus helpers.
+- Cross‑document merge: parse operations accept a vector of YAML documents and merge sections across them, rejecting duplicate keys deterministically.
+- Remote sources: optional “using‑*” sections enable fetching networks/tokens from external endpoints and merging them into the local model.
+- Context: a runtime context carries selected deployment/order, token selection for GUI flows, remote caches, and supports string interpolation from order paths.
+- WASM/TypeScript: many types derive `Tsify` and implement WASM trait helpers for interop with the webapp/Tauri.
+
+
+## Parsing Framework (yaml/*)
+
+Core traits and helpers live under `src/yaml` and are used by all config types:
+
+- Traits
+  - `ValidationConfig`: strategy for which sections to validate (networks, tokens, orders, etc.).
+  - `YamlParsable`: for top‑level parsers that accept multiple YAML documents (e.g. `OrderbookYaml`, `DotrainYaml`). Provides constructors from strings/documents and helper to stringify a document.
+  - `YamlParsableHash`: for map‑shaped sections (e.g. `networks`, `tokens`, `orders`). Provides `parse_all_from_yaml` and `parse_from_yaml(key)`.
+  - `YamlParsableVector`: for vector‑shaped items if needed.
+  - `YamlParsableString`: for single string fields with optionality (e.g. `SpecVersion`, `Sentry`).
+  - `YamlParseableValue`: for single logical objects that are not a map (e.g. `GuiCfg`, `RemoteTokensCfg`).
+
+- Context and caching
+  - `Context` holds:
+    - `order: Option<Arc<OrderCfg>>` – the current order for interpolation.
+    - `select_tokens: Option<Vec<String>>` – allow GUI to reference tokens by key without YAML definitions.
+    - `gui_context`: current deployment/order selection.
+    - `yaml_cache`: remote networks/tokens cache injected by providers.
+  - Interpolation: `Context::interpolate("... ${order.inputs.0.token.symbol} ...")` resolves values from the current order (inputs/outputs, token address/symbol/label/decimals, vault IDs).
+  - Path resolution helpers and errors: `ContextError::{NoOrder, InvalidPath, InvalidIndex, PropertyNotFound}` with human‑readable messages.
+
+- Cache
+  - `yaml/cache.rs::Cache` stores remote networks/tokens fetched previously. The providers (`OrderbookYaml`, `DotrainYaml`) expose them to `Context` when parsing.
+  - Update/get helpers return clones to keep the cache immutable from the caller’s perspective.
+
+- YAML helpers and errors
+  - Required/optional accessors: `require_string`, `optional_string`, `require_hash`, `optional_hash`, `require_vec`, `optional_vec`, `get_hash_value`, `get_hash_value_as_option`.
+  - `YamlError` and `FieldErrorKind` model validation issues precisely and implement `to_readable_msg()` for end‑user feedback. Additional variants wrap module‑specific parse errors (e.g. network/token/order errors).
+
+
+## Document Providers
+
+Two top‑level providers wrap one or more YAML documents and expose a convenient API to parse sections, fetch remote data, and produce contexts.
+
+- OrderbookYaml (`yaml/orderbook.rs`)
+  - Holds `documents: Vec<Arc<RwLock<StrictYaml>>>` and a `Cache`.
+  - `new(sources, validation)` loads YAML strings, applies validation gates via `ValidationConfig`, and returns a provider.
+  - Context initialization: `initialize_context_and_expand_remote_data()` injects remote networks/tokens from the cache into a fresh `Context`.
+  - Accessors (all parse across all documents, merging maps and checking duplicates):
+    - Networks: `get_network_keys`, `get_networks`, `get_network(key)`, `get_network_by_chain_id(u32)`.
+    - Remote networks: `get_remote_networks` (parse `using-networks-from`).
+    - Tokens: `get_token_keys`, `get_tokens`, `get_token(key)`.
+    - Remote tokens: `get_remote_tokens` (parse optional `using-tokens-from`).
+    - Subgraphs: `get_subgraph_keys`, `get_subgraphs`, `get_subgraph(key)`.
+    - Orderbooks: `get_orderbook_keys`, `get_orderbooks`, `get_orderbook(key)`, `get_orderbook_by_address(Address)`, `get_orderbooks_by_network_key(&str)`.
+    - Metaboards: `get_metaboard_keys`, `get_metaboards`, `get_metaboard(key)`, `add_metaboard(key, url)`.
+    - Deployers: `get_deployer_keys`, `get_deployers`, `get_deployer(key)`.
+    - Sentry: `get_sentry()` → Option<bool> from `sentry` scalar.
+    - Spec version: `get_spec_version()` → string from `version` scalar.
+    - Accounts: `get_account_keys`, `get_accounts`, `get_account(key)`.
+  - Serde: serializes/deserializes as a sequence of YAML documents represented as strings.
+
+- DotrainYaml (`yaml/dotrain.rs`)
+  - Also wraps `documents` and a `Cache`.
+  - `new(sources, validation)` selectively validates orders, scenarios, deployments.
+  - Accessors:
+    - Orders: `get_order_keys`, `get_orders`, `get_order(key)`, `get_order_for_gui_deployment(order_key, deployment_key)`.
+    - Scenarios: `get_scenario_keys`, `get_scenarios`, `get_scenario(key)`.
+    - Deployments: `get_deployment_keys`, `get_deployments`, `get_deployment(key)`.
+    - GUI: `get_gui(current_deployment)` parses optional GUI section with deployment‑scoped overrides and select‑tokens.
+    - Charts: `get_chart_keys`, `get_charts`, `get_chart(key)`.
+  - Serde mirrors `OrderbookYaml`.
+
+
+## Core Config Objects
+
+All core configs implement `YamlParsableHash` unless noted, and each instance carries a reference to the originating YAML document via `document: Arc<RwLock<StrictYaml>>`. This enables in‑place updates that preserve the source document. Equality (`PartialEq`) ignores the `document` field and compares logical data only.
+
+### Networks (`network.rs`)
+
+- `NetworkCfg { key, rpcs: Vec<Url>, chain_id, label?, network_id?, currency? }`
+  - `dummy()` and `Default` for tests.
+  - Validators: `validate_rpc(&str) -> Url`, `validate_chain_id(&str) -> u64`, `validate_network_id(&str) -> u32`.
+  - Parse all: looks for `networks` map with entries shaped like:
+    ```yaml
+    networks:
+      mainnet:
+        rpcs: [https://mainnet.infura.io]
+        chain-id: 1
+        label: Ethereum Mainnet
+        network-id: 1
+        currency: ETH
+    ```
+  - `parse_rpcs(documents, network_key)` reads just the `rpcs` vector for a named network.
+  - `update_rpcs(&mut self, Vec<String>)` updates both the YAML document and the in‑memory struct.
+  - Integrates remote networks from context cache; duplicate keys cause `KeyShadowing`.
+  - Specific error enum: `ParseNetworkConfigSourceError` with readable messages.
+
+### Tokens (`token.rs`)
+
+- `TokenCfg { key, network: Arc<NetworkCfg>, address, decimals?, label?, symbol? }`
+  - Validators: `validate_address(value) -> Address`, `validate_decimals(value) -> u8`.
+  - Parsing requires `tokens` map entries with `network` and `address`, optional `decimals`/`label`/`symbol`.
+  - Mutations:
+    - `update_address(&mut self, &str)` updates YAML and struct.
+    - `add_record_to_yaml(docs, key, network_key, address, decimals?, label?, symbol?)` inserts a new token record into the first document, checking that the key doesn’t already exist and that the referenced network exists.
+    - `remove_record_from_yaml(docs, key)` removes a token from whichever document contains it.
+    - `parse_network_key(docs, token_key)` returns the network key for an existing token definition.
+  - Merges remote tokens from context cache; conflicts produce `RemoteTokenKeyShadowing`.
+  - Specific error enum: `ParseTokenConfigSourceError` with readable messages.
+
+### Subgraphs (`subgraph.rs`)
+
+- `SubgraphCfg { key, url }` as a simple `subgraphs:` map.
+- `add_record_to_yaml(document, key, url)` helper with URL validation.
+
+### Orderbooks (`orderbook.rs`)
+
+- `OrderbookCfg { key, address, network: Arc<NetworkCfg>, subgraph: Arc<SubgraphCfg>, label?, deployment_block }`.
+- Validators: `validate_address(&str) -> Address`, `validate_deployment_block(&str) -> u64`.
+- Lookup helpers: `parse_network_key(docs, orderbook_key)` returns the referenced network key or defaults to the orderbook key.
+- Parses with references to previously parsed networks and subgraphs; duplicates are rejected.
+- Error enum: `ParseOrderbookConfigSourceError` (invalid address, missing network/subgraph, block parse error) with readable messages.
+
+### Deployers (`deployer.rs`)
+
+- `DeployerCfg { key, address, network }`.
+- Validators and `parse_network_key` similar to orderbooks (defaults to key if `network` is omitted).
+- Error enum: `ParseDeployerConfigSourceError`.
+
+### Accounts (`accounts.rs`)
+
+- `AccountCfg { key, address }` from a simple `accounts:` map where values are addresses.
+- Error enum: `ParseAccountCfgError`.
+
+### Metaboards (`metaboard.rs`)
+
+- `MetaboardCfg { key, url }` from `metaboards:` map of key → URL.
+- `add_record_to_yaml(document, key, url)` to append entries.
+
+### Spec Version and Sentry
+
+- `SpecVersion` reads required root scalar `version`. Const `CURRENT_SPEC_VERSION = "3"` and helpers `current()` / `is_current()`.
+- `Sentry` parses optional root scalar `sentry`. `OrderbookYaml::get_sentry()` normalizes to `Option<bool>` accepting `true/false/1/0`.
+
+
+## Orders, Scenarios, Deployments
+
+These three model how orders are defined, how they are executed (bindings, blocks, runs), and how a deployment pairs an order with a scenario under a specific deployer.
+
+### Orders (`order.rs`)
+
+- `OrderCfg { key, inputs: Vec<OrderIOCfg>, outputs: Vec<OrderIOCfg>, network: Arc<NetworkCfg>, deployer?: Arc<DeployerCfg>, orderbook?: Arc<OrderbookCfg> }`.
+- `OrderIOCfg { token?: Arc<TokenCfg>, vault_id?: U256 }` – tokens are optional to support GUI‑driven select‑tokens; vault IDs are arbitrary U256 strings.
+- Validation and network unification
+  - Inputs/outputs must each contain `token` (unless permitted by GUI select‑tokens through context) and optional `vault-id`.
+  - The order’s effective `network` is inferred from first matching component (deployer/orderbook/token), and all references must match. Mismatch yields detailed errors (`DeployerNetworkDoesNotMatch`, `OrderbookNetworkDoesNotMatch`, `InputTokenNetworkDoesNotMatch`, `OutputTokenNetworkDoesNotMatch`). If no network can be determined, `NetworkNotFoundError` is raised.
+  - Vault IDs are validated via `U256::from_str`.
+- Mutations
+  - `update_vault_id(vault_type, token_key, vault_id_opt)` updates a vault ID for a specific input/output token inside the YAML.
+  - `populate_vault_ids()` fills missing input/output `vault-id`s in the YAML with a freshly generated random U256, and updates the in‑memory struct accordingly.
+- Helpers
+  - `parse_network_key(docs, order_key)` – resolves the expected network key by reconciling deployer/orderbook and all IO token networks; errors if any disagree.
+- Error enum: `ParseOrderConfigSourceError` implements `to_readable_msg()` for user‑oriented descriptions.
+
+### Scenarios (`scenario.rs`)
+
+- `ScenarioCfg { key, bindings: HashMap<String,String>, runs?: u64, blocks?: BlocksCfg, deployer: Arc<DeployerCfg> }`.
+- Nested structure: scenarios can contain sub‑scenarios under `scenarios:`; keys compose as `parent.child` in the parsed map.
+- Bindings
+  - Parent bindings are inherited; children cannot change an existing binding’s value (shadowing causes `ParentBindingShadowedError`).
+  - Values support interpolation through `Context`.
+- Blocks and runs
+  - `runs` is optional `u64`.
+  - `blocks` can be the compact range form (`[a..b]`, `[..b]`, `[a..]`) or an object with `{ range: [...], interval: u32 }` (see Blocks below). Parser accepts either string or structured map formats.
+- Deployer
+  - A scenario can pick a deployer explicitly (`deployer: <key>`) or implicitly by name (scenario key matches a deployer key). A child scenario must not change the deployer chosen by its parent (`ParentDeployerShadowedError`).
+- Mutations
+  - `update_bindings(Map<String,String>)` updates only existing binding keys across the scenario path; new keys are appended at the lowest level of the current scenario path. Changes are persisted into YAML, then the scenario is re‑parsed and returned.
+
+### Blocks (`blocks.rs`)
+
+- `BlockCfg`: `Number(BlockNumber) | Genesis | Latest` with helper `to_block_number(latest)`.
+- `BlockRangeCfg { start: BlockCfg, end: BlockCfg }` with `validate(latest)`.
+- `BlocksCfg`: `SimpleRange(BlockRangeCfg)` or `RangeWithInterval { range, interval }`.
+- Expansion: `expand_to_block_numbers(latest)` produces a concrete vector of block numbers after validating the range.
+
+### Deployments (`deployment.rs`)
+
+- `DeploymentCfg { key, scenario: Arc<ScenarioCfg>, order: Arc<OrderCfg> }`.
+- Parsing
+  - Respects optional GUI context for “current deployment” to allow per‑deployment scoping when documents contain many deployments.
+  - Ensures the selected order and scenario share the same deployer; otherwise returns `ParseDeploymentConfigSourceError::NoMatch`.
+  - Helper `parse_order_key(docs, deployment_key)` extracts the order name for a deployment.
+
+
+## GUI Configuration (`gui.rs`)
+
+The GUI DSL configures per‑deployment user inputs (fields), deposit presets/validation, and “select tokens” behavior for orders rendered in the UI.
+
+- Source types (pure data) to transform into runtime types:
+  - `GuiConfigSourceCfg { name, description, deployments: Map<deployment_name, GuiDeploymentSourceCfg> }`.
+  - `GuiDeploymentSourceCfg { name, description, deposits: [GuiDepositSourceCfg], fields: [GuiFieldDefinitionSourceCfg], select_tokens?: [GuiSelectTokensCfg] }`.
+  - `GuiDepositSourceCfg { token: String, presets?: [String], validation?: DepositValidationCfg }`.
+  - `GuiFieldDefinitionSourceCfg { binding, name, description?, presets?: [GuiPresetSourceCfg], default?, show_custom_field?, validation? }`.
+  - `GuiPresetSourceCfg { name?, value }`.
+  - Validation enums:
+    - `FieldValueValidationCfg::Number { minimum?, exclusive_minimum?, maximum?, exclusive_maximum? }`.
+    - `FieldValueValidationCfg::String { min_length?, max_length? }`.
+    - `FieldValueValidationCfg::Boolean`.
+    - `DepositValidationCfg { minimum?, exclusive_minimum?, maximum?, exclusive_maximum? }`.
+
+- Runtime types (used by app/wasm):
+  - `GuiCfg { name, description, deployments: Map<deployment_name, GuiDeploymentCfg> }`.
+  - `GuiDeploymentCfg { key, deployment: Arc<DeploymentCfg>, name, description, deposits: [GuiDepositCfg], fields: [GuiFieldDefinitionCfg], select_tokens? }`.
+  - `GuiDepositCfg { token?: Arc<TokenCfg>, presets?, validation? }`.
+  - `GuiFieldDefinitionCfg { binding, name, description?, presets?: [GuiPresetCfg], default?, show_custom_field?, validation? }`.
+  - `GuiPresetCfg { id, name?, value }`.
+
+- Parsing
+  - `GuiCfg::parse_from_yaml_optional(documents, context)` traverses a `gui:` map, applying deployment scoping from GUI context and order/deployment context, and builds a `GuiCfg` if present.
+  - Helper queries: `check_gui_key_exists`, `parse_deployment_keys`, `parse_order_details`, `parse_deployment_details`, `parse_field_presets`, `parse_select_tokens`.
+  - Integrates tokens (if present) to resolve deposit token references to `Arc<TokenCfg>`. With “select‑tokens”, the context is seeded with allowed token keys so orders may omit YAML token entries.
+
+
+## Charts and Plot DSL
+
+Charts let scenarios expose visualizations for analysis.
+
+- `ChartCfg { key, scenario: Arc<ScenarioCfg>, plots?: [PlotCfg], metrics?: [MetricCfg] }`.
+  - `MetricCfg { label, description?, unit_prefix?, unit_suffix?, value, precision? }`.
+  - Parses `charts:` map; each chart may reference a scenario by key (defaults to the chart key) and include `plots:` and `metrics:`.
+
+- Plot source DSL (`plot_source.rs`)
+  - `PlotCfg { title?, subtitle?, marks: [MarkCfg], x?: AxisOptionsCfg, y?: AxisOptionsCfg, margin/…? }`.
+  - `MarkCfg` variants: `Dot(DotOptionsCfg)`, `Line(LineOptionsCfg)`, `RectY(RectYOptionsCfg)`.
+  - Mark options may carry an optional transform.
+  - Transforms: `TransformCfg::HexBin(HexBinTransformCfg)` and `TransformCfg::BinX(BinXTransformCfg)` each with `TransformOutputsCfg` and `options` specific to the transform (e.g. `bin-width` for hexbin, `thresholds` for binx).
+  - `AxisOptionsCfg` configures labels/anchors for axes.
+
+- The chart parser (`chart.rs`) wires the YAML layout into these types and performs validation (e.g., presence and types of transform `content`, numeric fields, required `marks` vectors). Numeric strings are validated via `ChartCfg::validate_u32` where appropriate.
+
+
+## Remote Data
+
+Remote sections allow enriching local YAML with data fetched at runtime and merged into the model.
+
+- Remote Networks (`remote_networks.rs` + `remote/chains.rs`)
+  - YAML shape:
+    ```yaml
+    using-networks-from:
+      source-name:
+        url: https://…
+        format: chainid
+    ```
+  - `RemoteNetworksCfg` parses the above. `fetch_networks(map)` issues HTTP GET requests and parses JSON into `ChainId` structures.
+  - `ChainId::try_into_network_cfg` converts a chain into a `NetworkCfg` by selecting the first acceptable RPC URL (non‑WS and without `API_KEY` placeholders). Key is the chain’s `shortName`.
+  - Conflicts in produced network keys across sources yield `ConflictingNetworks`.
+
+- Remote Tokens (`remote_tokens.rs` + `remote/tokens.rs`)
+  - YAML shape:
+    ```yaml
+    using-tokens-from:
+      - https://…/tokenlist.json
+      - https://…/another-list.json
+    ```
+  - `RemoteTokensCfg::parse_from_yaml_optional` collects/validates URLs (deduplicating across documents). `fetch_tokens(networks, cfg)` GETs each URL, merges token lists while de‑duplicating by `(chainId, addressLowercase)`, and then converts known chain IDs into `TokenCfg` by matching against provided `networks`.
+  - Key format: `"<network-key>-<TokenName-with-dashes>-<addressLowercase>"`.
+  - Conflicting keys across URLs produce `ConflictingTokens`.
+
+Both remote features are surfaced to parsing via the `Context`/`Cache`. `OrderbookYaml` and `DotrainYaml` expose helper methods to fetch/update cache and then merge these into subsequent parses.
+
+
+## Miscellaneous Modules
+
+- `accounts.rs`: named EVM addresses in `accounts:`. Simple map with validation and duplicate checks.
+- `sentry.rs`: optional root scalar `sentry` read as string and normalized to `Option<bool>` by `OrderbookYaml`.
+- `spec_version.rs`: required root scalar `version` and helpers to compare to the current spec version (constant "3").
+- `test.rs`: test helpers to construct mock networks/tokens/deployers/orderbooks.
+- `unit_test.rs`: auxiliary types (`UnitTestConfigSource`, `TestConfigSource`, `ScenarioConfigSource`) used by the test harness in other crates. `TestConfigSource::into_test_config()` converts the simplified source into a `TestConfig` with an embedded `ScenarioCfg`.
+
+
+## Concurrency and Update Semantics
+
+Every config item carries `document: Arc<RwLock<StrictYaml>>` pointing to the YAML document where it originated. “Update” methods (`TokenCfg::update_address`, `NetworkCfg::update_rpcs`, `OrderCfg::update_vault_id`, `OrderCfg::populate_vault_ids`, `MetaboardCfg::add_record_to_yaml`, `SubgraphCfg::add_record_to_yaml`, `TokenCfg::add_record_to_yaml`/`remove_record_from_yaml`) acquire a write lock, mutate the tree in place, and update the in‑memory struct for consistency. All read operations acquire read locks.
+
+
+## Duplicate Keys and Merging
+
+For map‑shaped sections parsed across multiple documents, the crate enforces unique keys within the merged result. If a key appears twice across any documents, parsing fails with `YamlError::KeyShadowing(key, section)`. This guarantees deterministic provenance and avoids silent overrides.
+
+
+## Error Reporting Philosophy
+
+All parser and validator errors convert to `YamlError` or module‑specific `*Parse*Error` enums with a `to_readable_msg()` that is safe to show to end users. `FieldErrorKind::{Missing, InvalidType, InvalidValue}` always include a precise human‑readable location (e.g., "order 'MyOrder'", "output index '0' in order 'MyOrder'", "gui deployment 'MyDeployment'").
+
+
+## WASM/TypeScript Interop
+
+When building for `wasm32`, many types derive `Tsify` and implement WASM trait helpers via `wasm_bindgen_utils::impl_wasm_traits!`. This allows the web UI/Tauri app to import the same configuration model with strong typing (including union types and optional fields) and to consume results produced by this crate.
+
+
+## Typical Workflows
+
+- Validate orderbook YAML for networks/tokens/etc. and query objects:
+  1. Load strings into `OrderbookYaml::new([...], OrderbookYamlValidation::full())`.
+  2. Optionally fetch remote networks/tokens, store in cache, and then call `get_*` methods to retrieve `NetworkCfg`, `TokenCfg`, `OrderbookCfg`, etc.
+  3. Use update helpers to persist changes back to YAML documents.
+
+- Validate dotrain YAML and build a deployment plan:
+  1. Load strings into `DotrainYaml::new([...], DotrainYamlValidation::full())`.
+  2. Resolve `OrderCfg`, `ScenarioCfg`, and `DeploymentCfg`; ensure network/deployer invariants hold.
+  3. Optional GUI: parse `GuiCfg` scoped to a specific deployment and seed context with `select-tokens`.
+  4. Optional Charts: parse `ChartCfg` for visualization.
+
+
+## YAML Shape Reference (informative)
+
+- Root keys seen across modules (some optional depending on usage):
+  - `version: "3"`
+  - `using-networks-from: { name: { url, format: chainid } }`
+  - `using-tokens-from: [ url, ... ]`
+  - `networks: { key: { rpcs: [url,...], chain-id, label?, network-id?, currency? } }`
+  - `tokens: { key: { network, address, decimals?, label?, symbol? } }`
+  - `subgraphs: { key: url }`
+  - `orderbooks: { key: { address, network?, subgraph?, label?, deployment-block } }`
+  - `metaboards: { key: url }`
+  - `deployers: { key: { address, network? } }`
+  - `accounts: { key: address }`
+  - `orders: { key: { inputs: [{ token, vault-id? }, ...], outputs: [...], deployer?, orderbook? } }`
+  - `scenarios: { key: { bindings: {k:v}, runs?, blocks?, deployer?, scenarios?: {...} } }`
+  - `deployments: { key: { scenario, order } }`
+  - `gui: { name, description, deployments: { key: { name, description, deposits: [...], fields: [...], select-tokens?: [...] } } }`
+  - `charts: { key: { scenario?, plots?: {...}, metrics?: [...] } }`
+  - `sentry: true|false|1|0`
+
+
+## Testing
+
+The crate ships extensive unit tests for every parser and update path, including error paths with precise messages. Test helpers in `src/test.rs` construct mock networks/deployers/tokens/orderbooks; parser modules provide happy‑path and negative test cases (duplicate keys, missing/invalid fields, range validation for blocks, GUI validation, remote fetch flows with http mocks, etc.).
+
+
+## Summary
+
+The settings crate provides a single, well‑typed interface over YAML configuration for the Rain Orderbook ecosystem: robust parsing across multiple files, strict validation with user‑friendly errors, safe in‑place updates, optional remote augmentation, contextual interpolation, GUI and chart DSLs, and WASM interop. Other crates consume these types to build CLIs, runtimes, and UIs without re‑implementing YAML logic.
+

--- a/packages/orderbook/ARCHITECTURE.md
+++ b/packages/orderbook/ARCHITECTURE.md
@@ -1,0 +1,124 @@
+# @rainlanguage/orderbook — Architecture
+
+This package is the JavaScript/TypeScript SDK that exposes Rain Orderbook functionality to web and Node.js consumers. It packages the Rust WASM crate surface (primarily `rain_orderbook_js_api`, plus re‑exports from sibling crates) into a single, installable NPM module with CJS and ESM entry points.
+
+The SDK is designed to work in browsers, Node.js, and hybrid runtimes (e.g., Tauri). It embeds the compiled `.wasm` bytes directly in the published bundle so consumers do not need network fetches or filesystem access at runtime.
+
+
+## Overview
+
+- Purpose
+  - Provide a WASM‑backed API for: YAML parsing/validation, orderbook queries (subgraph), quoting, vault management, transaction calldata generation (add/remove, deposit/withdraw), GUI helpers to deploy orders from dotrain, and low‑level hashing/ABI helpers.
+- Targets
+  - ESM (browser) and CJS (Node.js) builds are both published.
+  - The WASM is base64‑embedded to avoid runtime `fetch`/`fs` requirements.
+- Upstream crates
+  - Backed by `rain_orderbook_js_api` (WASM cdylib) which re‑exports `rain_orderbook_app_settings`, `rain_orderbook_common`, and `rain_orderbook_subgraph_client` for a unified JS surface.
+
+Typical import
+
+```ts
+import { RaindexClient, DotrainOrderGui, parseYaml, getOrderHash } from "@rainlanguage/orderbook";
+```
+
+
+## Build & Packaging
+
+All builds should be run inside a Nix shell to ensure toolchain parity (`nix develop -c <cmd>`).
+
+- Entry generation (`scripts/build.js`)
+  - Writes thin top‑level entry files: `cjs.js` (CommonJS re‑export), `esm.js` (ESM re‑export), plus `.d.ts` stubs.
+  - Creates `dist/cjs` and `dist/esm` directories.
+  - Invokes `npm run build-wasm` to compile the Rust workspace to `wasm32-unknown-unknown` in release mode (excludes CLI and integration tests).
+  - For each package (currently just `js_api`), calls `scripts/buildPackage.js` to produce JS bindings and package artifacts.
+- WASM binding & embedding (`scripts/buildPackage.js`)
+  - Runs `wasm-bindgen` twice to generate Node (CJS) and Web (ESM) wrappers from the compiled `.wasm`. The `wasm-bindgen` binary comes from the Nix environment.
+  - Reads the generated `.wasm` files and writes `dist/cjs/orderbook_wbg.json` and `dist/esm/orderbook_wbg.json` containing base64‑encoded bytes.
+  - Rewrites the generated JS to:
+    - CJS: read bytes from the embedded JSON via `Buffer.from(base64)` and initialize the module without touching the filesystem.
+    - ESM: import the embedded JSON and use top‑level `await __wbg_init(bytes)` to initialize the WASM before exporting symbols.
+  - Copies type declarations to `dist/*/index.d.ts` and prefixes generated files with a note that they are auto‑generated.
+- Prepublish bootstrap (`scripts/setup.js`)
+  - If `./dist` exists, exits early (supporting installs from already‑built tarballs).
+  - Otherwise, cleans temp/outputs and runs the full build inside Nix: `nix develop -c node scripts/build`.
+- Type checking & tests
+  - `npm run check` runs `tsc` over the built JS to validate the emitted types.
+  - `npm run test` executes Vitest suites under `test/` against the built artifacts.
+
+Key commands
+
+- Build: `nix develop -c npm run build`
+- Test: `nix develop -c npm run test`
+- Docs: `nix develop -c npm run docs`
+
+
+## Directory Layout
+
+- `cjs.js`, `esm.js` — Top‑level re‑exports pointing at `dist/` (published files).
+- `cjs.d.ts`, `esm.d.ts` — Type re‑export stubs for consumers.
+- `dist/` — Build output (published)
+  - `cjs/`
+    - `index.js` — Auto‑generated CommonJS glue that initializes WASM from `orderbook_wbg.json`.
+    - `index.d.ts` — Type declarations.
+    - `orderbook_wbg.json` — Base64‑encoded WASM bytes.
+  - `esm/`
+    - `index.js` — Auto‑generated ESM glue with top‑level `await` for WASM init.
+    - `index.d.ts` — Type declarations.
+    - `orderbook_wbg.json` — Base64‑encoded WASM bytes.
+- `scripts/`
+  - `build.js` — Orchestrates the full build.
+  - `buildPackage.js` — Runs `wasm-bindgen`, embeds WASM, writes JS/TS outputs.
+  - `setup.js` — Prepublish bootstrap inside Nix.
+- `test/` — Vitest suites exercising bindings (bindings/common/js_api).
+- `typedoc.json`, `tsconfig.json` — Documentation and TS settings for the published surface.
+- `README.md` — End‑user SDK guide with examples.
+
+
+## Exports & API Surface
+
+The package re‑exports the WASM‑bound API from the Rust crates. Representative items:
+
+- Functions
+  - `parseYaml`, `getOrderHash`, `getTakeOrders3Calldata`, `keccak256`, `keccak256HexString`.
+- High‑level classes (selected)
+  - `RaindexClient` — orderbook queries (orders, trades, vaults, quotes, transactions) across configured networks/subgraphs.
+  - `RaindexOrder`, `RaindexVault`, `RaindexTrade`, `RaindexTransaction`, `RaindexVaultsList`, etc.
+  - `DotrainOrder`, `DotrainOrderGui`, `DotrainRegistry` — dotrain parsing, GUI orchestration, registry fetching, and deployment calldata.
+  - `OrderbookYaml` — typed access to networks, tokens, orderbooks, subgraphs, deployers, accounts, metaboards.
+  - `Float` — arbitrary‑precision float utilities used across the API.
+- Errors & results
+  - Most methods return `WasmEncodedResult<T>` with either `{ value }` or `{ error: { msg, readableMsg } }` for ergonomic, user‑readable error handling in JS.
+
+Notes on runtime behavior
+
+- ESM builds use top‑level `await` to initialize the WASM module before exports are used. Ensure your bundler/runtime supports top‑level await.
+- No network fetches are performed to load the WASM bytes; they are embedded via JSON.
+
+
+## How It Fits The Workspace
+
+- Rust crates under `crates/*` implement the core logic. `rain_orderbook_js_api` compiles to WASM and re‑exports pieces of `common`, `settings`, `subgraph`, and others for a cohesive JS surface.
+- This package is the NPM wrapper that compiles those crates for WASM, generates JS glue, and publishes the resulting SDK.
+- Consumers use only `@rainlanguage/orderbook`; no direct interaction with the Rust build is required.
+
+
+## Testing & Documentation
+
+- Tests: Vitest suites under `test/` validate representative flows: orders/vaults/trades queries, quoting, calldata generation, GUI flows, and error surfaces.
+- Docs: `npm run docs` builds TypeDoc from the emitted `.d.ts` for hosted API documentation.
+
+
+## Publishing & Versioning
+
+- The `prepublish` script ensures the package is fully rebuilt within a Nix shell and includes the embedded WASM. Tarballs contain `dist/` and thin top‑level entry points.
+- Node.js >= 22 is required (see `package.json#engines`). A small `buffer` dependency is bundled for ESM environments that lack a native `Buffer`.
+
+
+## Caveats & Tips
+
+- Always run build/test inside `nix develop` so `wasm-bindgen`, Rust toolchains, and targets are available.
+- If you add new WASM crates/exports in the workspace, extend the `packages` array in `scripts/build.js` and mirror any binding tweaks in `scripts/buildPackage.js`.
+- If you see initialization issues in the browser, confirm your bundler supports top‑level await and that `orderbook_wbg.json` is included in the bundle.
+
+This document explains what the `packages/orderbook` directory is for, how the WASM artifacts are produced and embedded, what gets exported to consumers, and how it connects to the rest of the Rain Orderbook workspace.
+

--- a/packages/ui-components/ARCHITECTURE.md
+++ b/packages/ui-components/ARCHITECTURE.md
@@ -1,0 +1,167 @@
+# @rainlanguage/ui-components — Architecture
+
+This package is the reusable Svelte component library for building Rain Orderbook UIs. It composes the WASM‑backed SDK `@rainlanguage/orderbook` with UI primitives, domain components, providers, hooks, and utilities to implement common flows: listing and inspecting orders and vaults, showing charts, handling wallet connection and transactions, and guiding users through deploying algorithmic orders from a dotrain registry.
+
+
+## Overview
+
+- Purpose
+  - Provide a cohesive, app‑ready set of Svelte components and helpers for Orderbook features: tables, detail views, charts, deployment GUI, toasts, and transaction UX.
+  - Ship provider and hook contexts so apps can wire wallet, client, registry, toasts, and transaction state consistently.
+- Targets
+  - Svelte 4 components, packaged with `svelte-package` for consumption in SvelteKit/Vite apps.
+  - Single `dist/index.js` entry (ESM) with `svelte` and `types` fields; no SSR‑specific code required.
+- Upstream libraries
+  - SDK: `@rainlanguage/orderbook` (WASM)
+  - State/query: `@tanstack/svelte-query`
+  - Wallet: `wagmi`, `viem`, `@reown/appkit` + `@reown/appkit-adapter-wagmi`
+  - UI: `flowbite-svelte` (+ icons), `tailwindcss`, `lightweight-charts`, `svelte-markdown`, `svelte-codemirror-editor`, `codemirror-rainlang`
+
+Typical development
+
+```bash
+cd packages/ui-components
+nix develop -c npm run dev
+```
+
+
+## Providers & State
+
+The library exposes lightweight provider components that set Svelte contexts, plus hooks to access them:
+
+- Raindex client
+  - `RaindexClientProvider` — sets a `RaindexClient` from `@rainlanguage/orderbook` in context.
+  - `useRaindexClient()` — retrieves the client and reports a user‑facing error if missing.
+- Wallet
+  - `WalletProvider` — injects a Svelte `Readable<Hex | null>` account store into context.
+  - `useAccount()` — returns the account store from context.
+- Transactions
+  - `TransactionProvider` — constructs a `TransactionManager` using TanStack Query’s `QueryClient` (via `useQueryClient()`), a `wagmi` `Config`, and an `addToast` function.
+  - `useTransactions()` — returns `{ manager, transactions }`, where `transactions` is a store of in‑flight `TransactionStore` instances.
+  - UI components: `TransactionList`, `FixedBottomTransaction` to surface status, errors, and explorer links.
+- Registry
+  - `RegistryProvider` + `RegistryManager` — manage dotrain registry URL (persisted in `localStorage` and an optional `?registry=` query param). `useRegistry()` returns the manager.
+- Toasts
+  - `ToastProvider` — provides a toasts store and renders `ToastDetail` instances.
+  - `useToasts()` — returns `{ toasts, addToast, removeToast, errToast }`.
+- GUI (deploy flows)
+  - `GuiProvider` — provides a `DotrainOrderGui` instance for deployment flows.
+  - `useGui()` — retrieves the GUI instance; integrates with deployment components.
+
+Notes
+
+- Consumers should wrap their app in a TanStack Query `QueryClientProvider` (from `@tanstack/svelte-query`) so `TransactionProvider` can access the client.
+- `TransactionProvider` requires an `addToast` callback. A small “wrapper” component that calls `useToasts()` is a convenient way to pass this down.
+
+
+## Components & Features
+
+- Tables & lists
+  - `OrdersListTable`, `OrderTradesListTable`, `VaultsListTable`, `VaultBalanceChangesTable`, `OrderVaultsVolTable` driven by TanStack Query, with `TanstackAppTable` wrapper.
+- Detail views & quotes
+  - `OrderDetail`, `VaultDetail`, `TanstackOrderQuote`, `TanstackPageContentDetail`, `Hash`, `OrderOrVaultHash`.
+- Charts
+  - `LightweightChart`, `TanstackLightweightChartLine`, `OrderTradesChart`, `VaultBalanceChart` with time helpers and themes.
+- Deployment GUI
+  - `OrderPage`, `DeploymentsSection`, `DeploymentSteps`, `TokenIOInput`, `FieldDefinitionInput`, `SelectToken`, `DisclaimerModal`, `ValidOrdersSection`, `InvalidOrdersSection`.
+  - Services: dotrain registry fetch/validate/share (`registry.ts`, `loadRegistryUrl.ts`, `handleShareChoices.ts`).
+- Wallet UX & general UI
+  - `WalletConnect`, `ButtonDarkMode`, dropdowns, inputs (`InputTokenAmount`, `InputHex`, `InputOrderHash`, `InputRegistryUrl`), tooltips, badges, icons.
+- Editors
+  - `CodeMirrorRainlang`, `CodeMirrorDotrain` with theme helpers.
+
+
+## Services, Utils, Queries
+
+- Time & indexing
+  - `awaitTransactionIndexing` — generic polling helper to await subgraph indexing with success predicate; used by `TransactionStore`.
+  - `formatTimestampSecondsAsLocal`, `timestampSecondsToUTCTimestamp`, `promiseTimeout`, `dateTimestamp`.
+- Links & formatting
+  - `getExplorerLink` (via `viem/chains`), `bigintStringToHex`, numeric/string utilities.
+- Registry
+  - `fetchParseRegistry`, `fetchRegistryDotrains`, `validateOrders`, `loadRegistryUrl`.
+- Charts
+  - `historicalOrderCharts.ts` for transforming trades to chartable data.
+- Queries
+  - `queries/constants.ts`, `queries/keys.ts`, `queries/queryClient.ts` (includes `invalidateTanstackQueries`).
+
+
+## Exports & API Surface
+
+`src/lib/index.ts` re‑exports by category:
+
+- Components: tables, detail views, charts, editors, inputs, icons, wallet/connectivity, UI primitives.
+- Providers: `GuiProvider`, `RaindexClientProvider`, `WalletProvider`, `RegistryProvider`, `ToastProvider`, `TransactionProvider`.
+- Hooks: `useGui`, `useRaindexClient`, `useAccount`, `useRegistry`, `useToasts`, `useTransactions`.
+- Types: app stores, modal/transaction/toast/order typings.
+- Functions: time helpers, explorer link, TanStack invalidation helpers, mocks for tests.
+- Constants: query keys, default page sizes/intervals, chart/code editor themes.
+- Stores: cached writable store helpers.
+- Assets: light/dark logos.
+- Classes: `RegistryManager`, `TransactionStore`, `TransactionManager`.
+
+
+## Directory Layout
+
+- `src/lib/components/` — Svelte components grouped by domain (`tables`, `detail`, `charts`, `deployment`, `transactions`, `wallet`, `input`, etc.).
+- `src/lib/providers/` — Context providers for GUI, client, wallet, registry, toasts, transactions.
+- `src/lib/hooks/` — Accessors for provider contexts.
+- `src/lib/models/` — State models such as `TransactionStore`.
+- `src/lib/types/` — Type helpers and enums.
+- `src/lib/services/` — Registry, indexing, sharing, time utilities.
+- `src/lib/queries/` — Query keys, constants, query client helpers.
+- `src/lib/utils/` — Formatting and misc utilities.
+- `src/lib/assets/` — SVGs, logos.
+- `src/lib/__mocks__/` — Test helpers and resolvable queries/stores.
+
+
+## Build, Test, and Dev
+
+Run inside a Nix shell for tool parity (`nix develop -c <cmd>`):
+
+- Dev preview: `nix develop -c npm run dev`
+- Build: `nix develop -c npm run build` (Vite) and `npm run package` (svelte‑package + publint)
+- Package only: `nix develop -c npm run package`
+- Lint/format/check: `npm run format`, `npm run lint`, `npm run check`
+- Tests: `nix develop -c npm run test` (Vitest, jsdom)
+
+
+## Usage Notes
+
+- Provider wiring
+  - Wrap your app in `QueryClientProvider`, then add `ToastProvider`, `WalletProvider`, `RaindexClientProvider`, `RegistryProvider`, and a small wrapper for `TransactionProvider` that supplies `addToast` from `useToasts()` and a `wagmi` `Config`.
+  - See `packages/webapp` for a working composition with a fixed‑bottom transaction status bar.
+- Tailwind setup
+  - Ensure Tailwind’s `content` globs include this package and `flowbite-svelte` so styles tree‑shake correctly. Example (from the webapp):
+
+```ts
+// tailwind.config.ts (consumer app)
+export default {
+  content: [
+    './src/**/*.{html,js,svelte,ts}',
+    '../../node_modules/flowbite-svelte/**/*.{html,js,svelte,ts}',
+    '../../node_modules/@rainlanguage/ui-components/**/*.{html,js,svelte,ts}',
+    '../ui-components/**/*.{html,js,svelte,ts}',
+  ],
+  // ...
+}
+```
+
+
+## How It Fits The Workspace
+
+- Rust crates under `crates/*` implement core logic and compile to a WASM surface consumed by `@rainlanguage/orderbook`.
+- `@rainlanguage/ui-components` provides the reusable Svelte UI and provider layer that apps compose.
+- The `packages/webapp` project consumes this library directly to implement the full Orderbook UI.
+
+
+## Caveats & Tips
+
+- Always run inside `nix develop` for consistent Node/tooling.
+- Ensure the Query Client is available in context before mounting `TransactionProvider`.
+- Pass a valid `wagmi` `Config` to `TransactionProvider` and ensure wallet connectors are initialized at the app level.
+- Include this package in Tailwind `content` globs to avoid missing styles.
+- For deployment flows, pass a `DotrainOrderGui` via `GuiProvider` and use the registry helpers to load/validate dotrain entries.
+
+This document explains what `packages/ui-components` is for, how providers and components are organized, how to build and test the package, and how it integrates with the rest of the Rain Orderbook workspace.
+

--- a/packages/webapp/ARCHITECTURE.md
+++ b/packages/webapp/ARCHITECTURE.md
@@ -1,0 +1,136 @@
+# @rainlanguage/webapp — Architecture
+
+This package is the SvelteKit web application for exploring and interacting with the Rain Orderbook. It composes the `@rainlanguage/ui-components` library with the WASM‑backed SDK `@rainlanguage/orderbook` to provide a browser UI for:
+
+- Browsing orders, trades and vaults across networks
+- Viewing order detail and performing actions (remove, deposit, withdraw)
+- Deploying “algorithmic orders” from a dotrain registry via a guided GUI
+- Managing wallet connection and transaction flows
+
+
+## Overview
+
+- Purpose
+  - End‑user web UI showcasing Orderbook features and the reusable `@rainlanguage/ui-components` surface.
+  - Loads workspace settings from YAML, initializes a `RaindexClient`, and wires providers for state, wallet and transactions.
+- Targets
+  - Client‑side SvelteKit app (SSR disabled) built with Vite and Tailwind.
+  - Deployed using the Vercel adapter (Node.js 20 runtime).
+- Upstream libraries
+  - UI: `@rainlanguage/ui-components`, `flowbite-svelte`, `@tanstack/svelte-query`.
+  - SDK: `@rainlanguage/orderbook` (WASM), `@rainlanguage/float`.
+  - Wallet: `viem`, `@wagmi/core`, `@reown/appkit` + `@reown/appkit-adapter-wagmi`.
+
+Typical development
+
+```bash
+cd packages/webapp
+nix develop -c npm run dev
+```
+
+
+## Runtime & State
+
+- App bootstrap (`src/routes/+layout.ts`)
+  - Fetches a remote settings YAML (`REMOTE_SETTINGS_URL`) and constructs a `RaindexClient` from `@rainlanguage/orderbook`.
+  - Exposes a set of Svelte stores (selected chains, active accounts, filters, etc.) to child routes.
+  - `export const ssr = false;` — the app renders client‑side only.
+- Layout shell (`src/routes/+layout.svelte`)
+  - Wraps the app with providers:
+    - `ToastProvider` for notifications
+    - `WalletProvider` for account context
+    - `QueryClientProvider` (TanStack Query) for data caching
+    - `TransactionProviderWrapper` and `FixedBottomTransaction` for tx UX
+    - `RaindexClientProvider` to pass the initialized client to UI components
+  - Initializes wallet on mount and surfaces any initialization error to the user.
+- Wallet integration (`src/lib/stores/wagmi.ts`, `src/lib/services/handleWalletInitialization.ts`)
+  - Configures Wagmi + AppKit with injected and WalletConnect connectors.
+  - Requires `PUBLIC_WALLETCONNECT_PROJECT_ID` (see Configuration below).
+  - Tracks connection, chain, and signer via Svelte stores and reacts to account changes.
+- Modal orchestration (`src/lib/services/modal.ts`)
+  - Creates Svelte modals for deposit/withdraw/confirmation and a custom “withdraw all” flow by instantiating components onto `document.body`.
+
+
+## Routes & Features
+
+- `/` — Home. Static copy and getting‑started content via `Homepage.svelte`.
+- `/orders`
+  - Lists orders via `OrdersListTable` from `@rainlanguage/ui-components`.
+  - Detail route: `/orders/[chainId]-[orderbook]-[orderHash]` displays `OrderDetail` and wires actions:
+    - Remove order
+    - Deposit / Withdraw / Withdraw All to/from vaults
+- `/vaults`
+  - Lists vaults using `VaultsListTable`; supports filtering, active accounts, and bulk withdraw.
+  - Detail route: `/vaults/[chainId]-[orderbook]-[id]` (components handle the heavy lifting inside `ui-components`).
+- `/deploy`
+  - Loads a dotrain registry (`?registry=` query param or default `REGISTRY_URL`), validates orders, and shows valid/invalid sections.
+  - Nested routes:
+    - `/deploy/[orderName]` — loads the dotrain and order details
+    - `/deploy/[orderName]/[deploymentKey]` — fetches deployment detail with `DotrainOrderGui.getDeploymentDetail`, then renders a GUI for composing calldata
+- `/license` — Static license information.
+
+
+## Directory Layout
+
+- `src/routes/`
+  - `+layout.ts` — Fetch settings, build `RaindexClient`, define app‑wide stores, disable SSR.
+  - `+layout.svelte` — Provider composition and app shell (sidebar + content area).
+  - `orders/` — Orders list and dynamic order detail.
+  - `vaults/` — Vaults list and dynamic vault detail.
+  - `deploy/` — Registry load/validation, order selection, and deployment GUI routes.
+- `src/lib/`
+  - `components/` — App‑specific wrappers (Sidebar, modals, loaders, error page, etc.).
+  - `services/` — Side‑effectful helpers (wallet init, transactions, modal helpers, deposit/withdraw flows).
+  - `stores/` — Svelte stores for settings, wagmi state, loading flags, and toasts.
+  - `types/` — Small app‑local type helpers.
+- `src/app.*` — SvelteKit app template, global CSS, and global TS types.
+- `static/` — Static assets.
+- `tailwind.config.ts` — Tailwind setup (includes `ui-components` and Flowbite paths).
+- `svelte.config.js` — Vercel adapter (Node.js 20 runtime) and preprocessing.
+- `vite.config.ts` — Build and Vitest configuration (JS DOM, inline deps, env passthrough).
+
+
+## Build, Test, and Dev
+
+Run inside a Nix shell for tool parity (`nix develop -c <cmd>`):
+
+- Dev server: `nix develop -c npm run dev`
+- Build: `nix develop -c npm run build`
+- Preview: `nix develop -c npm run preview`
+- Lint/format/check: `npm run format`, `npm run lint`, `npm run check`
+- Tests: `nix develop -c npm run test` (Vitest, jsdom)
+
+
+## Configuration
+
+- Copy `.env.example` to `.env` and set:
+
+```bash
+PUBLIC_WALLETCONNECT_PROJECT_ID=<your_walletconnect_project_id>
+```
+
+- Notes
+  - Use the `PUBLIC_` prefix (SvelteKit convention) for variables that must be available in the browser.
+  - Never commit secrets. Use Vercel/hosted environment variables for deploys.
+  - Settings source: `REMOTE_SETTINGS_URL` in `src/routes/+layout.ts` controls where the app fetches YAML configuration.
+  - Deploy registry: `REGISTRY_URL` in `src/lib/constants.ts` can be overridden via the `?registry=` query parameter.
+
+
+## How It Fits The Workspace
+
+- Rust crates under `crates/*` implement the core logic; `@rainlanguage/orderbook` packages a WASM surface to consume from JS.
+- `@rainlanguage/ui-components` provides reusable Svelte components, transaction plumbing, and providers.
+- This webapp stitches both together into a cohesive UI. It lives in the JS workspace and is not part of the Cargo workspace.
+
+
+## Caveats & Tips
+
+- SSR is disabled; avoid Node‑only APIs or server‑only assumptions in route/load code.
+- Always run inside `nix develop` so the correct Node and build tools are available.
+- If you modify or add routes, ensure Tailwind’s `content` globs include your files for proper styling.
+- Wallet init issues usually stem from a missing/invalid `PUBLIC_WALLETCONNECT_PROJECT_ID` or blocked popups.
+- When adding new flows that touch the blockchain, prefer composing `@rainlanguage/ui-components` helpers and passing the `RaindexClient` from the layout provider.
+
+
+This document explains the purpose and structure of `packages/webapp`, how the app boots and wires providers, where key features live, and how it integrates with the rest of the Rain Orderbook workspace.
+

--- a/tauri-app/ARCHITECTURE.md
+++ b/tauri-app/ARCHITECTURE.md
@@ -1,0 +1,162 @@
+# Tauri App — Architecture
+
+This directory contains the Raindex desktop application built with Tauri (Rust + Svelte). It pairs a Svelte front end (Vite/SvelteKit client-only) with a Rust “backend” running in the same process that exposes native capabilities (filesystem, dialogs, Ledger, RPC) via Tauri `invoke` commands and emits UI events for toasts and transaction status.
+
+
+## Overview
+
+- Purpose
+  - Native desktop app to compose, deploy, debug, and manage Rain Orderbook “algorithmic orders”.
+  - Bridges UI workflows (Svelte) to workspace Rust crates for quoting, subgraph reads, calldata generation, and transaction execution.
+- Targets
+  - Cross‑platform Tauri bundle (macOS `.app/.dmg`, Windows `.msi/.nsis`, Linux `.deb`), using WebKit/Wry for the UI.
+  - Runs fully offline for most flows; relies on configured RPCs/subgraphs for chain data.
+- Upstream crates and libs (Rust)
+  - `rain_orderbook_common`, `rain_orderbook_quote`, `rain_orderbook_subgraph_client`, `rain_orderbook_app_settings`, `rain_orderbook_bindings`, `rain-erc`, `rain-math-float`, Alloy, `alloy-ethers-typecast`.
+- Upstream packages (TS)
+  - `@rainlanguage/orderbook` (WASM SDK), `@rainlanguage/ui-components` (UI), WalletConnect, Ethers v5, CodeMirror (Rainlang), Sentry.
+
+Typical development
+
+```
+# from repo root, inside a Nix shell
+nix develop .#tauri-shell --command cargo tauri dev
+```
+
+
+## Runtime & State
+
+- Front end (Svelte, client‑only)
+  - `src/routes/+layout.ts` sets `export const ssr = false` and wires stores/providers in `+layout.svelte`.
+  - Feature routes under `src/routes/*`: orders, vaults, settings, license and modals for quote/trade debug.
+  - Sentry is initialized in `src/hooks.client.ts`/`src/lib/services/sentry.ts` (disabled by default via env; runtime‑toggleable).
+- Native side (Rust/Tauri)
+  - `src-tauri/src/main.rs` registers all `#[tauri::command]` handlers and manages shared state.
+  - `SharedState` holds a `FuzzRunner` for charting/debug across invocations.
+  - On Linux, sets `WEBKIT_DISABLE_COMPOSITING_MODE=1` to avoid a blank screen (known WebKitGTK issue).
+
+
+## Commands (Rust side)
+
+All commands are defined in `src-tauri/src/commands/*` and registered in `main.rs`. They are invoked from the UI via `@tauri-apps/api` `invoke()`.
+
+- Chain (`commands/chain.rs`)
+  - `get_chainid(rpcs)` — read chain ID via multi‑RPC client.
+  - `get_block_number(rpcs)` — read latest block.
+- Wallet (`commands/wallet.rs`)
+  - `get_address_from_ledger(derivation_index, chain_id)` — query Ledger for the current address on a chain.
+- Rainlang / DOTRAIN (`commands/dotrain.rs`, `commands/dotrain_add_order_lsp.rs`)
+  - `parse_dotrain(rainlang, rpcs, block_number, deployer)` — fork‑parse Rainlang to bytecode.
+  - Language services: `call_lsp_hover`, `call_lsp_completion`, `call_lsp_problems` for CodeMirror integration, optionally on a fork.
+- Config & YAML (`commands/config.rs`)
+  - `check_settings_errors(text[])`, `check_dotrain_with_settings_errors(dotrain, settings[])` — validate YAML with strict rules.
+  - `get_deployments(dotrain, settings?)`, `get_scenarios(dotrain, settings?)` — parse and return typed maps for UI selection.
+- Orders (`commands/order.rs`)
+  - CSV/export: `orders_list_write_csv(path, subgraphArgs)`.
+  - Mutations: `order_add(dotrain, deployment, transactionArgs)`, `order_remove(chain_id, id, transactionArgs, subgraphArgs)`.
+  - Calldata helpers: `order_add_calldata(...)`, `order_remove_calldata(id, subgraphArgs)`.
+  - Composition & validation: `compose_from_scenario(dotrain, settings?, scenario)`, `validate_spec_version(dotrain, settings[])`.
+- Vaults (`commands/vault.rs`)
+  - CSV/export: `vaults_list_write_csv(path, subgraphArgs)`, `vault_balance_changes_list_write_csv(id, path, subgraphArgs)`.
+  - Mutations: `vault_deposit(depositArgs, transactionArgs)`, `vault_withdraw(withdrawArgs, transactionArgs)`.
+  - Calldata helpers: `vault_deposit_approve_calldata(...)`, `vault_deposit_calldata(...)`, `vault_withdraw_calldata(...)`.
+- Debug & Analysis
+  - Quotes (`commands/order_quote.rs`): `debug_order_quote(...)` to simulate quotes for an order.
+  - Trades (`commands/trade_debug.rs`): `debug_trade(tx_hash, rpcs)` to replay a transaction and return evaluation results.
+  - Charts (`commands/charts.rs`): `make_charts(dotrain, settings?)` and `make_deployment_debug(dotrain, settings, block_numbers?)` via the fuzz runner.
+- App (`commands/app.rs`)
+  - `get_app_commit_sha()` — expose embedded commit SHA for diagnostics.
+
+Errors are unified via `src-tauri/src/error.rs` as `CommandError/CommandResult`, translating many upstream error types to user‑readable strings for the UI.
+
+
+## IPC Events (Rust → UI)
+
+- Toasts (`src-tauri/src/toast.rs`)
+  - Emits `toast` with `{ message_type, text }` for UI notifications. Consumed by `src/lib/stores/toasts.ts`.
+- Transaction status (`src-tauri/src/transaction_status.rs`)
+  - `TransactionStatusNoticeRwLock` tracks a tx’s lifecycle (`Initialized`, `PendingPrepare`, `PendingSign`, `Sending`, `Confirmed`, `Failed`).
+  - Emits `transaction_status_notice` events, consumed by `src/lib/stores/transactionStatusNotice.ts` to display transient banners.
+  - Types are shared to TS via wasm‑generated bindings (see below).
+
+
+## UI & Services (Svelte)
+
+- Services layer (`src/lib/services/*`)
+  - Thin wrappers around `invoke()` for each command: `order.ts`, `vault.ts`, `chain.ts`, `config.ts`, `chart.ts`, `authoringMeta.ts`, `wallet.ts`, `app.ts`.
+  - Execution helpers: `executeLedgerOrder.ts` (native flow), `executeWalletConnectOrder.ts` (WalletConnect + Ethers), `ethersTx.ts`.
+  - Language services bridge: `langServices.ts` wires CodeMirror Rainlang hover/completion/problems to Tauri LSP commands and a fork block number store.
+  - Settings application: `applySettings.ts`, diagnostics mapping in `configCodemirrorProblems.ts`.
+- Stores (`src/lib/stores/*`)
+  - WalletConnect orchestration (`walletconnect.ts`), selected chains/accounts/filters (`settings.ts`), toasts, tx notices, dark mode, etc.
+  - `walletconnect.ts` discovers working RPCs per chain before connecting, and tracks the active chain/account.
+- Components & routes
+  - Orders: list, detail, remove; vaults: list, deposit/withdraw; add‑order screen with CodeMirror + charts; debug modals for quotes/trades.
+  - Many UI pieces come from `@rainlanguage/ui-components`.
+
+
+## Bindings generation (TS types for events)
+
+- The Rust crate exposes a tiny `src-tauri/src/types/*` surface that is compiled for `wasm32-unknown-unknown` to derive TS types (`wasm_bindgen_utils` + `tsify`).
+- Build pipeline
+  - `npm run build-wasm` runs `cargo build --target wasm32-unknown-unknown --lib -r` in `src-tauri/`.
+  - `scripts/build.js` runs `wasm-bindgen` and writes `src/lib/types/tauriBindings.ts` with the event payload typings:
+    - `ToastMessageType`, `ToastPayload`, `TransactionStatus`, `TransactionStatusNotice`.
+  - UI imports these types for strict event payloads.
+
+
+## Build, Dev, Test
+
+- Dev
+  - `nix develop .#tauri-shell --command cargo tauri dev` (from repo root). Tauri runs the Svelte dev server (`vite dev`) per `tauri.conf.json#build.beforeDevCommand`.
+- Build
+  - `nix develop .#tauri-shell --command cargo tauri build` to produce installers/bundles.
+  - Frontend build is configured via `vite.config.ts`; source maps can be uploaded to Sentry in release mode.
+- Frontend scripts (from `tauri-app/`)
+  - `npm run dev`, `npm run build`, `npm run test` (Vitest, jsdom), `npm run build-bindings` to regenerate TS event types.
+
+
+## Configuration
+
+Copy `.env.example` to `.env` in this directory and set as needed:
+
+- `VITE_WALLETCONNECT_PROJECT_ID` — required for WalletConnect.
+- Sentry (optional): `VITE_SENTRY_DSN`, `VITE_SENTRY_RELEASE`, `VITE_SENTRY_ENVIRONMENT`, `VITE_SENTRY_FORCE_DISABLED`.
+- Build‑time source maps upload (optional release flow): `SENTRY_SOURCE_MAPS_ENABLED`, `SENTRY_ORG`, `SENTRY_PROJECT`, `SENTRY_AUTH_TOKEN`.
+
+Tauri allowlist and bundling are configured in `src-tauri/tauri.conf.json`:
+
+- Allowlist: `shell.open`, `dialog.open/save`, `fs.readFile/writeFile`, `window.startDragging`, and `os.*`.
+- Bundle targets: `deb`, `nsis`, `msi`, `app`, `dmg`, `updater`.
+- macOS frameworks include USB libraries required for Ledger.
+
+
+## Directory Layout
+
+- `src/` — Svelte app
+  - `routes/` — pages: home, orders, vaults, settings, license.
+  - `lib/services/` — invoke clients, execution helpers, charts, language services, sentry.
+  - `lib/stores/` — app state (walletconnect, settings, toasts, tx notices, theme).
+  - `lib/components/` — app‑specific wrappers and modals.
+  - `lib/types/tauriBindings.ts` — auto‑generated TS types from Rust.
+- `src-tauri/` — Rust side
+  - `src/commands/` — Tauri commands grouped by domain (`order`, `vault`, `chain`, `config`, `charts`, `wallet`, `dotrain*`, `trade_debug`, `order_quote`).
+  - `src/{error,toast,transaction_status,shared_state}.rs` — error unification, UI event emitters, tx status tracker, shared FuzzRunner state.
+  - `tauri.conf.json` — allowlist, bundling, window config, pre‑dev/build hooks.
+  - `Cargo.toml` — depends on workspace crates via `path` and Alloy; builds as `cdylib` for bindings.
+- `scripts/build.js` — wasm‑bindgen step to emit TS typings for event payloads.
+
+
+## How It Fits The Workspace
+
+- This app is a consumer of the Rust crates under `crates/*` and the UI kit under `packages/*`.
+- `src-tauri/` is not part of the Cargo workspace but depends on those crates by path.
+- If you add features to core crates (e.g., new order/vault operations or analysis), expose them via a new Tauri command and a matching UI service wrapper.
+
+
+## References
+
+- Crates: `crates/ARCHITECTURE.md`, `crates/common/ARCHITECTURE.md`, `crates/quote/ARCHITECTURE.md`, `crates/settings/ARCHITECTURE.md`.
+- JS packages: `packages/orderbook/ARCHITECTURE.md`, `packages/webapp/ARCHITECTURE.md`, `packages/ui-components/ARCHITECTURE.md`.
+- Dev commands & repo tips: see repository README and the project “Repository Guidelines”.
+


### PR DESCRIPTION


  <!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

  ## Motivation

  We want better AI-assisted workflows and clearer internal documentation. This PR adds:
  - Documents for AI agents to understand our repo structure and conventions.
  - Task-specific “AI commands” to streamline common developer/AI tasks (PR content, architecture refresh, SDK docs sync).
  - Architecture overviews across crates and packages to provide accurate context.

  ## Solution

  - Added root guidance:
    - AGENTS.md with repository structure, build/test commands, and agent-specific instructions.
    - CLAUDE.md to direct agents to AGENTS.md.

  - Added AI task docs under `ai_commands/`:
    - `generate-pr-content.md` for drafting high-quality PR titles/descriptions from diffs.
    - `refresh-architecture.md` for keeping `ARCHITECTURE.md` files current with code.
    - `sdk-documentation-update.md` for syncing SDK docs with the JS/WASM API.

  - Added architecture docs across the workspace:
    - `crates/*/ARCHITECTURE.md` (bindings, common, js_api, math, quote, settings)
    - `packages/*/ARCHITECTURE.md` (orderbook, ui-components, webapp)
    - `tauri-app/ARCHITECTURE.md`
    These describe purpose, layout, build/test commands (Nix), public surfaces, data flows, dependencies, and integration points.

  - No runtime code changes; this is documentation-only to improve contributor onboarding and AI effectiveness. Front-end screenshots are not applicable.

  ## Checks
  <!-- It's important you've done these, or your PR will not be considered for review -->
  By submitting this for review, I'm confirming I've done the following:
  - [ ] made this PR as small as possible
  - [ ] unit-tested any new functionality
  - [ ] linked any relevant issues or PRs
  - [ ] included screenshots (if this involves a front-end change)