### PR TITLE
Include spec version in tauri charts settings

### DIFF
--- a/crates/cli/src/commands/words.rs
+++ b/crates/cli/src/commands/words.rs
@@ -315,6 +315,7 @@ metaboards:
         );
         let settings_content = format!(
             "
+version: {spec_version}
 networks:
     some-network:
         rpcs:
@@ -327,7 +328,8 @@ deployers:
     some-deployer:
         network: some-network
         address: 0xF14E09601A47552De6aBd3A0B165607FaFd2B5Ba",
-            server.url("/rpc")
+            server.url("/rpc"),
+            spec_version = SpecVersion::current()
         );
 
         let settings_file = NamedTempFile::new().unwrap();
@@ -437,6 +439,7 @@ metaboards:
         );
         let settings_content = format!(
             "
+version: {spec_version}
 networks:
     some-network:
         rpcs:
@@ -469,6 +472,7 @@ orders:
             - token: token1
 ",
             server.url("/rpc"),
+            spec_version = SpecVersion::current()
         );
 
         let settings_file = NamedTempFile::new().unwrap();

--- a/crates/common/src/dotrain_order.rs
+++ b/crates/common/src/dotrain_order.rs
@@ -811,6 +811,7 @@ _ _: 00;
 
         let settings = format!(
             r#"
+version: {spec_version}
 networks:
     mainnet:
         rpcs:
@@ -819,6 +820,7 @@ networks:
         network-id: 1
         currency: ETH"#,
             rpc_url = server.url("/rpc-mainnet"),
+            spec_version = SpecVersion::current(),
         );
 
         let dotrain_order =

--- a/crates/settings/src/sentry.rs
+++ b/crates/settings/src/sentry.rs
@@ -6,7 +6,7 @@ use strict_yaml_rust::StrictYaml;
 pub struct Sentry;
 
 impl YamlParsableString for Sentry {
-    fn parse_from_yaml(_: Arc<RwLock<StrictYaml>>) -> Result<String, YamlError> {
+    fn parse_from_yaml(_: Vec<Arc<RwLock<StrictYaml>>>) -> Result<String, YamlError> {
         Err(YamlError::InvalidTraitFunction)
     }
 

--- a/crates/settings/src/spec_version.rs
+++ b/crates/settings/src/spec_version.rs
@@ -1,4 +1,4 @@
-use crate::yaml::{require_string, YamlError, YamlParsableString};
+use crate::yaml::{require_string, FieldErrorKind, YamlError, YamlParsableString};
 use std::sync::{Arc, RwLock};
 use strict_yaml_rust::StrictYaml;
 
@@ -18,10 +18,47 @@ impl SpecVersion {
 }
 
 impl YamlParsableString for SpecVersion {
-    fn parse_from_yaml(document: Arc<RwLock<StrictYaml>>) -> Result<String, YamlError> {
-        let document_read = document.read().map_err(|_| YamlError::ReadLockError)?;
-        let value = require_string(&document_read, Some("version"), Some("root".to_string()))?;
-        Ok(value)
+    fn parse_from_yaml(documents: Vec<Arc<RwLock<StrictYaml>>>) -> Result<String, YamlError> {
+        if documents.is_empty() {
+            return Err(YamlError::EmptyFile);
+        }
+
+        let mut parsed_version: Option<String> = None;
+
+        for (index, document) in documents.iter().enumerate() {
+            let location = if index == 0 {
+                "root".to_string()
+            } else {
+                format!("document {}", index + 1)
+            };
+
+            let version = {
+                let document_read = document.read().map_err(|_| YamlError::ReadLockError)?;
+                require_string(&document_read, Some("version"), Some(location.clone()))?
+            };
+
+            if let Some(existing_version) = &parsed_version {
+                if existing_version != &version {
+                    return Err(YamlError::Field {
+                        kind: FieldErrorKind::InvalidValue {
+                            field: "version".to_string(),
+                            reason: format!(
+                                "spec version mismatch: expected '{}', found '{}'",
+                                existing_version, version
+                            ),
+                        },
+                        location,
+                    });
+                }
+            } else {
+                parsed_version = Some(version);
+            }
+        }
+
+        parsed_version.ok_or_else(|| YamlError::Field {
+            kind: FieldErrorKind::Missing("version".to_string()),
+            location: "root".to_string(),
+        })
     }
 
     fn parse_from_yaml_optional(_: Arc<RwLock<StrictYaml>>) -> Result<Option<String>, YamlError> {
@@ -51,7 +88,7 @@ mod tests {
 test: test
 "#;
 
-        let error = SpecVersion::parse_from_yaml(get_document(yaml)).unwrap_err();
+        let error = SpecVersion::parse_from_yaml(vec![get_document(yaml)]).unwrap_err();
         assert_eq!(
             error,
             YamlError::Field {
@@ -68,5 +105,77 @@ test: test
 "#;
         let error = SpecVersion::parse_from_yaml_optional(get_document(yaml)).unwrap_err();
         assert_eq!(error, YamlError::InvalidTraitFunction);
+    }
+
+    #[test]
+    fn test_parse_from_yaml_consistent_versions() {
+        let documents = vec![
+            get_document(
+                r#"
+version: "3"
+"#,
+            ),
+            get_document(
+                r#"
+version: "3"
+"#,
+            ),
+        ];
+
+        let version = SpecVersion::parse_from_yaml(documents).unwrap();
+        assert_eq!(version, "3");
+    }
+
+    #[test]
+    fn test_parse_from_yaml_missing_version() {
+        let documents = vec![
+            get_document(
+                r#"
+version: "3"
+"#,
+            ),
+            get_document(
+                r#"
+name: test
+"#,
+            ),
+        ];
+
+        let error = SpecVersion::parse_from_yaml(documents).unwrap_err();
+        assert_eq!(
+            error,
+            YamlError::Field {
+                kind: FieldErrorKind::Missing("version".to_string()),
+                location: "document 2".to_string()
+            }
+        )
+    }
+
+    #[test]
+    fn test_parse_from_yaml_mismatched_versions() {
+        let documents = vec![
+            get_document(
+                r#"
+version: "3"
+"#,
+            ),
+            get_document(
+                r#"
+version: "2"
+"#,
+            ),
+        ];
+
+        let error = SpecVersion::parse_from_yaml(documents).unwrap_err();
+        assert_eq!(
+            error,
+            YamlError::Field {
+                kind: FieldErrorKind::InvalidValue {
+                    field: "version".to_string(),
+                    reason: "spec version mismatch: expected '3', found '2'".to_string()
+                },
+                location: "document 2".to_string()
+            }
+        )
     }
 }

--- a/crates/settings/src/yaml/mod.rs
+++ b/crates/settings/src/yaml/mod.rs
@@ -83,7 +83,7 @@ pub trait YamlParsableVector: Sized {
 }
 
 pub trait YamlParsableString {
-    fn parse_from_yaml(document: Arc<RwLock<StrictYaml>>) -> Result<String, YamlError>;
+    fn parse_from_yaml(documents: Vec<Arc<RwLock<StrictYaml>>>) -> Result<String, YamlError>;
 
     fn parse_from_yaml_optional(
         document: Arc<RwLock<StrictYaml>>,

--- a/crates/settings/src/yaml/orderbook.rs
+++ b/crates/settings/src/yaml/orderbook.rs
@@ -328,8 +328,7 @@ impl OrderbookYaml {
     }
 
     pub fn get_spec_version(&self) -> Result<String, YamlError> {
-        let value = SpecVersion::parse_from_yaml(self.documents[0].clone())?;
-        Ok(value)
+        SpecVersion::parse_from_yaml(self.documents.clone())
     }
 
     pub fn get_account_keys(&self) -> Result<Vec<String>, YamlError> {

--- a/packages/orderbook/test/common/test.test.ts
+++ b/packages/orderbook/test/common/test.test.ts
@@ -91,6 +91,7 @@ _ _: 0 0;
 
 	it('should compose scenario to rainlang with config', async () => {
 		const config = `
+version: 3
 scenarios:
     config-scenario:
         network: some-network

--- a/tauri-app/src-tauri/src/commands/charts.rs
+++ b/tauri-app/src-tauri/src/commands/charts.rs
@@ -159,6 +159,7 @@ io: fixed-io;
     fn get_settings(rpc: &str, orderbook: &str, deployer: &str) -> String {
         format!(
             r#"
+version: {spec_version}
 networks:
   flare:
     rpcs:
@@ -178,7 +179,8 @@ deployers:
   flare:
     address: {deployer}
     network: "flare"
-"#
+"#,
+            spec_version = SpecVersion::current(),
         )
     }
 


### PR DESCRIPTION
## Summary
- add the current spec version header to the tauri charts command settings helper so supplemental configuration passes multi-document validation

## Testing
- cargo fmt
- cargo test -p tauri-app commands::charts::tests::test_make_charts -- --nocapture *(fails: network 403 fetching git dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68ca61891f988333aadbb97ff221e424

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - YAML outputs (settings, charts, dotrain) now include a top-level spec version.
  - Multi-document YAML is supported for extracting the spec version across configs.
- Bug Fixes
  - Improved validation: detects missing or mismatched versions across documents with clearer errors.
- Tests
  - Updated fixtures to include version fields and added scenarios for multi-document parsing, consistency, and missing/mismatched versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->