### PR TITLE
Update cli binary workflow to push to releases

### DIFF
--- a/.github/workflows/build-cli-binary.yaml
+++ b/.github/workflows/build-cli-binary.yaml
@@ -44,21 +44,17 @@ jobs:
       - name: Build CLI tarball
         run: nix develop -c rainix-ob-cli-artifact
 
-      - name: Configure Git
-        run: |
-          git config user.name github-actions[bot]
-          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-
-      - name: Commit and push updated tarball
+      - name: Create GitHub release
+        id: create_release
+        uses: ncipollo/release-action@v1
         env:
-          COMMIT_MESSAGE: "refresh orderbook cli"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git add crates/cli/bin/rain-orderbook-cli.tar.gz
-          if git diff --staged --quiet; then
-            echo "No changes to commit"
-            exit 0
-          fi
-
-          git commit -m "$COMMIT_MESSAGE"
-          git push origin HEAD:${{ github.ref_name }}
+        with:
+          tag: cli-${{ github.sha }}
+          name: Rain Orderbook CLI ${{ github.sha }}
+          body: |
+            Rain Orderbook CLI binary built from commit ${{ github.sha }}.
+          prerelease: true
+          generateReleaseNotes: true
+          artifacts: crates/cli/bin/rain-orderbook-cli.tar.gz
+          artifactContentType: application/gzip


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

See issue: https://github.com/rainlanguage/rain.orderbook/issues/2190

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [ ] made this PR as small as possible
- [ ] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Each build now publishes a pre-release on GitHub Releases with a downloadable CLI binary (tar.gz) and autogenerated release notes for easier access and testing.

* **Chores**
  * Streamlined the build pipeline to publish artifacts directly to a GitHub release, improving reliability and reducing manual steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->