### PR TITLE
Fix orderbook package bug for unused wasm import

### DIFF
--- a/packages/orderbook/scripts/buildPackage.js
+++ b/packages/orderbook/scripts/buildPackage.js
@@ -114,7 +114,10 @@ module.exports.buildEsm = function (pkg) {
     let esm = fs.readFileSync(`./temp/web/${pkg}/${pkg}.js`, {
         encoding: 'utf-8'
     });
+
+    // remove unused wasm import as we import the wasm through json
     esm = esm.replaceAll(`module_or_path = new URL('${pkg}_bg.wasm', import.meta.url);`, "");
+
     esm = esm.replace(`export { initSync };
 export default __wbg_init;`,
         `import { Buffer } from 'buffer';


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation
> [!warning]
> Reported bug:
>
> <img width="552" height="191" alt="Screenshot 2025-11-07 at 2 02 16 AM" src="https://github.com/user-attachments/assets/6a89eb12-c799-4340-abe2-6b4c4f1d4518" />


Reproduction steps:
```txt
# 1. Create Next.js app
npx create-next-app@latest my-test-app --typescript --app --no-tailwind

# 2. Install your SDK
cd my-test-app 
npm install @rainlanguage/orderbook@0.0.1-alpha.188

# 3. Create a simple component
cat > src/app/test/page.tsx << 'EOF''use client'import { useEffect } from 'react'export default function TestPage() {  useEffect(() => {    async function init() {      const { RaindexClient } = await import('@rainlanguage/orderbook')      console.log(RaindexClient)    }    init()  }, [])    return <div>Testing Raindex SDK</div>}EOF

# 4. Run dev server
npm run dev

# 5. Visit http://localhost:3000/test
Error appears immediately during compilation, before the page even loads.
```
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
This is caused by an unused wasm URL import which some bundlers like webpack resolve it internally causing the error to appear, so we need to remove that as its totally unused as we import the wasm through json import.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [ ] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated ESM build so WebAssembly modules are embedded in the bundle rather than loaded via a dynamic external URL—resulting in more reliable module initialization, fewer runtime fetches, and improved consistency across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->