### PR TITLE
Add database integrity check to detect and recover from corruption

### DIFF
--- a/crates/common/src/local_db/pipeline/adapters/bootstrap.rs
+++ b/crates/common/src/local_db/pipeline/adapters/bootstrap.rs
@@ -8,6 +8,7 @@ use crate::local_db::query::fetch_tables::{fetch_tables_stmt, TableResponse};
 use crate::local_db::query::fetch_target_watermark::fetch_target_watermark_stmt;
 use crate::local_db::query::fetch_target_watermark::TargetWatermarkRow;
 use crate::local_db::query::insert_db_metadata::insert_db_metadata_stmt;
+use crate::local_db::query::integrity_check::{integrity_check_stmt, IntegrityCheckRow};
 use crate::local_db::query::{LocalDbQueryExecutor, SqlStatementBatch};
 use crate::local_db::LocalDbError;
 use crate::local_db::OrderbookIdentifier;
@@ -115,6 +116,18 @@ pub trait BootstrapPipeline {
         .await?;
         db.execute_batch(&create_views_batch()).await?;
         Ok(())
+    }
+
+    async fn check_integrity<DB>(&self, db: &DB) -> Result<bool, LocalDbError>
+    where
+        DB: LocalDbQueryExecutor + ?Sized,
+    {
+        let rows: Vec<IntegrityCheckRow> = db.query_json(&integrity_check_stmt()).await?;
+        let is_healthy = rows
+            .first()
+            .map(|row| row.quick_check.eq_ignore_ascii_case("ok"))
+            .unwrap_or(false);
+        Ok(is_healthy)
     }
 
     async fn clear_orderbook_data<DB>(
@@ -750,5 +763,88 @@ mod tests {
             .map(|stmt| stmt.sql().to_string())
             .collect();
         assert_eq!(captured, expected);
+    }
+
+    #[tokio::test]
+    async fn check_integrity_returns_true_when_ok() {
+        use crate::local_db::query::integrity_check::IntegrityCheckRow;
+
+        let adapter = TestBootstrapPipeline::new();
+        let row = IntegrityCheckRow {
+            quick_check: "ok".to_string(),
+        };
+        let db = MockDb::default().with_json(&integrity_check_stmt(), json!([row]));
+
+        let is_healthy = adapter.check_integrity(&db).await.unwrap();
+        assert!(is_healthy, "should return true for 'ok' response");
+    }
+
+    #[tokio::test]
+    async fn check_integrity_returns_true_when_ok_uppercase() {
+        use crate::local_db::query::integrity_check::IntegrityCheckRow;
+
+        let adapter = TestBootstrapPipeline::new();
+        let row = IntegrityCheckRow {
+            quick_check: "OK".to_string(),
+        };
+        let db = MockDb::default().with_json(&integrity_check_stmt(), json!([row]));
+
+        let is_healthy = adapter.check_integrity(&db).await.unwrap();
+        assert!(is_healthy, "should return true for 'OK' response");
+    }
+
+    #[tokio::test]
+    async fn check_integrity_returns_false_when_corrupted() {
+        use crate::local_db::query::integrity_check::IntegrityCheckRow;
+
+        let adapter = TestBootstrapPipeline::new();
+        let row = IntegrityCheckRow {
+            quick_check: "database disk image is malformed".to_string(),
+        };
+        let db = MockDb::default().with_json(&integrity_check_stmt(), json!([row]));
+
+        let is_healthy = adapter.check_integrity(&db).await.unwrap();
+        assert!(
+            !is_healthy,
+            "should return false for corruption error message"
+        );
+    }
+
+    #[tokio::test]
+    async fn check_integrity_returns_false_for_any_non_ok_response() {
+        use crate::local_db::query::integrity_check::IntegrityCheckRow;
+
+        let adapter = TestBootstrapPipeline::new();
+        let row = IntegrityCheckRow {
+            quick_check: "some error".to_string(),
+        };
+        let db = MockDb::default().with_json(&integrity_check_stmt(), json!([row]));
+
+        let is_healthy = adapter.check_integrity(&db).await.unwrap();
+        assert!(!is_healthy, "should return false for any non-ok response");
+    }
+
+    #[tokio::test]
+    async fn check_integrity_returns_false_for_empty_response() {
+        let adapter = TestBootstrapPipeline::new();
+        let db = MockDb::default().with_json(
+            &integrity_check_stmt(),
+            json!([]), // empty array
+        );
+
+        let is_healthy = adapter.check_integrity(&db).await.unwrap();
+        assert!(!is_healthy, "should return false for empty response");
+    }
+
+    #[tokio::test]
+    async fn check_integrity_propagates_query_error() {
+        let adapter = TestBootstrapPipeline::new();
+        let db = MockDb::default(); // no response configured -> will error
+
+        let err = adapter.check_integrity(&db).await.unwrap_err();
+        match err {
+            LocalDbError::LocalDbQueryError(..) => {}
+            other => panic!("unexpected error: {other:?}"),
+        }
     }
 }

--- a/crates/common/src/local_db/query/integrity_check.rs
+++ b/crates/common/src/local_db/query/integrity_check.rs
@@ -1,0 +1,45 @@
+use super::SqlStatement;
+use serde::{Deserialize, Serialize};
+
+pub const INTEGRITY_CHECK_SQL: &str = "PRAGMA quick_check";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct IntegrityCheckRow {
+    pub quick_check: String,
+}
+
+pub fn integrity_check_stmt() -> SqlStatement {
+    SqlStatement::new(INTEGRITY_CHECK_SQL)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn integrity_check_stmt_is_static_and_param_free() {
+        let stmt = integrity_check_stmt();
+        assert_eq!(stmt.sql(), INTEGRITY_CHECK_SQL);
+        assert!(stmt.params().is_empty());
+    }
+
+    #[test]
+    fn integrity_check_row_serde_ok() {
+        let row = IntegrityCheckRow {
+            quick_check: "ok".to_string(),
+        };
+        let j = serde_json::to_value(&row).expect("serialize");
+        let rt: IntegrityCheckRow = serde_json::from_value(j).expect("deserialize");
+        assert_eq!(rt, row);
+    }
+
+    #[test]
+    fn integrity_check_row_serde_error() {
+        let row = IntegrityCheckRow {
+            quick_check: "database disk image is malformed".to_string(),
+        };
+        let j = serde_json::to_value(&row).expect("serialize");
+        let rt: IntegrityCheckRow = serde_json::from_value(j).expect("deserialize");
+        assert_eq!(rt, row);
+    }
+}

--- a/crates/common/src/local_db/query/mod.rs
+++ b/crates/common/src/local_db/query/mod.rs
@@ -15,6 +15,7 @@ pub mod fetch_target_watermark;
 pub mod fetch_vault_balance_changes;
 pub mod fetch_vaults;
 pub mod insert_db_metadata;
+pub mod integrity_check;
 pub mod sql_statement;
 pub mod sql_statement_batch;
 pub mod update_last_synced_block;

--- a/crates/common/src/raindex_client/local_db/pipeline/bootstrap.rs
+++ b/crates/common/src/raindex_client/local_db/pipeline/bootstrap.rs
@@ -87,6 +87,12 @@ impl BootstrapPipeline for ClientBootstrapAdapter {
     where
         DB: LocalDbQueryExecutor + ?Sized,
     {
+        let is_healthy = self.check_integrity(db).await.unwrap_or(false);
+        if !is_healthy {
+            self.reset_db(db, db_schema_version).await?;
+            return Ok(());
+        }
+
         let BootstrapState {
             has_required_tables,
             ..
@@ -167,6 +173,16 @@ mod tests {
                 .statements()
                 .iter()
                 .fold(self, |db, stmt| db.with_text(stmt, "ok"))
+        }
+
+        fn with_healthy_integrity(self) -> Self {
+            use crate::local_db::query::integrity_check::{
+                integrity_check_stmt, IntegrityCheckRow,
+            };
+            let row = IntegrityCheckRow {
+                quick_check: "ok".to_string(),
+            };
+            self.with_json(&integrity_check_stmt(), json!([row]))
         }
     }
 
@@ -258,6 +274,7 @@ mod tests {
         };
 
         let db = MockDb::default()
+            .with_healthy_integrity()
             .with_json(&fetch_tables_stmt(), tables_json)
             .with_json(&fetch_db_metadata_stmt(), json!([db_meta_row]))
             .with_text(&clear_tables_stmt(), "ok")
@@ -298,6 +315,7 @@ mod tests {
         .unwrap();
 
         let db = MockDb::default()
+            .with_healthy_integrity()
             .with_json(&fetch_tables_stmt(), tables_json)
             .with_json(&fetch_db_metadata_stmt(), json!([])) // triggers reset
             // inspect_state will look for watermark since table exists
@@ -347,6 +365,7 @@ mod tests {
         };
 
         let db = MockDb::default()
+            .with_healthy_integrity()
             .with_json(&fetch_tables_stmt(), tables_json)
             .with_json(&fetch_target_watermark_stmt(&runner_ob_id()), json!([]))
             .with_json(&fetch_db_metadata_stmt(), json!([mismatched_row]))
@@ -395,6 +414,7 @@ mod tests {
         };
 
         let db = MockDb::default()
+            .with_healthy_integrity()
             .with_json(&fetch_tables_stmt(), tables_json)
             .with_json(&fetch_db_metadata_stmt(), json!([db_row]))
             .with_json(&fetch_target_watermark_stmt(&runner_ob_id()), json!([]));
@@ -404,7 +424,10 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(db.calls().is_empty());
+        assert!(
+            db.calls().is_empty(),
+            "no text queries should be called when schema is ok"
+        );
     }
 
     #[tokio::test]
@@ -412,7 +435,10 @@ mod tests {
         let adapter = ClientBootstrapAdapter::new();
         let tables_json = required_tables_json();
 
-        let db = MockDb::default().with_json(&fetch_tables_stmt(), tables_json);
+        let db = MockDb::default()
+            .with_healthy_integrity()
+            .with_json(&fetch_tables_stmt(), tables_json)
+            .with_json(&fetch_target_watermark_stmt(&runner_ob_id()), json!([]));
 
         let err = adapter
             .runner_run(&db, Some(DB_SCHEMA_VERSION))
@@ -581,5 +607,192 @@ mod tests {
             LocalDbError::LocalDbQueryError(..) => {}
             other => panic!("unexpected error: {other:?}"),
         }
+    }
+
+    struct CorruptedDb {
+        json_map: HashMap<String, String>,
+        text_map: HashMap<String, String>,
+        calls_text: Mutex<Vec<String>>,
+    }
+
+    impl CorruptedDb {
+        fn new() -> Self {
+            use crate::local_db::query::integrity_check::{
+                integrity_check_stmt, IntegrityCheckRow,
+            };
+
+            let mut db = Self {
+                json_map: HashMap::new(),
+                text_map: HashMap::new(),
+                calls_text: Mutex::new(Vec::new()),
+            };
+            let corrupted_row = IntegrityCheckRow {
+                quick_check: "database disk image is malformed".to_string(),
+            };
+            db.json_map.insert(
+                integrity_check_stmt().sql().to_string(),
+                json!([corrupted_row]).to_string(),
+            );
+            db.text_map
+                .insert(clear_tables_stmt().sql().to_string(), "ok".to_string());
+            db.text_map
+                .insert(create_tables_stmt().sql().to_string(), "ok".to_string());
+            db.text_map.insert(
+                insert_db_metadata_stmt(DB_SCHEMA_VERSION).sql().to_string(),
+                "ok".to_string(),
+            );
+            for stmt in create_views_batch().statements() {
+                db.text_map.insert(stmt.sql().to_string(), "ok".to_string());
+            }
+            db
+        }
+
+        fn calls(&self) -> Vec<String> {
+            self.calls_text.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait(?Send)]
+    impl LocalDbQueryExecutor for CorruptedDb {
+        async fn execute_batch(&self, batch: &SqlStatementBatch) -> Result<(), LocalDbQueryError> {
+            for stmt in batch {
+                let _ = self.query_text(stmt).await?;
+            }
+            Ok(())
+        }
+
+        async fn query_json<T>(&self, stmt: &SqlStatement) -> Result<T, LocalDbQueryError>
+        where
+            T: FromDbJson,
+        {
+            let sql = stmt.sql();
+            let Some(body) = self.json_map.get(sql) else {
+                return Err(LocalDbQueryError::database("no json for sql"));
+            };
+            serde_json::from_str::<T>(body)
+                .map_err(|e| LocalDbQueryError::deserialization(e.to_string()))
+        }
+
+        async fn query_text(&self, stmt: &SqlStatement) -> Result<String, LocalDbQueryError> {
+            let sql = stmt.sql();
+            self.calls_text.lock().unwrap().push(sql.to_string());
+            self.text_map
+                .get(sql)
+                .cloned()
+                .ok_or_else(|| LocalDbQueryError::database("no text for sql"))
+        }
+    }
+
+    #[tokio::test]
+    async fn runner_run_resets_on_corrupted_database() {
+        let adapter = ClientBootstrapAdapter::new();
+        let db = CorruptedDb::new();
+
+        adapter
+            .runner_run(&db, Some(DB_SCHEMA_VERSION))
+            .await
+            .expect("runner_run should succeed after resetting corrupted db");
+
+        let calls = db.calls();
+        let expected_views: Vec<String> = create_views_batch()
+            .statements()
+            .iter()
+            .map(|s| s.sql().to_string())
+            .collect();
+        assert!(
+            calls.contains(&clear_tables_stmt().sql().to_string()),
+            "should have cleared tables"
+        );
+        assert!(
+            calls.contains(&create_tables_stmt().sql().to_string()),
+            "should have created tables"
+        );
+        assert!(
+            calls.contains(&insert_db_metadata_stmt(DB_SCHEMA_VERSION).sql().to_string()),
+            "should have inserted db metadata"
+        );
+        assert!(
+            expected_views.iter().all(|stmt| calls.contains(stmt)),
+            "missing view creation statements"
+        );
+    }
+
+    struct IntegrityCheckFailsDb {
+        text_map: HashMap<String, String>,
+        calls_text: Mutex<Vec<String>>,
+    }
+
+    impl IntegrityCheckFailsDb {
+        fn new() -> Self {
+            let mut db = Self {
+                text_map: HashMap::new(),
+                calls_text: Mutex::new(Vec::new()),
+            };
+            db.text_map
+                .insert(clear_tables_stmt().sql().to_string(), "ok".to_string());
+            db.text_map
+                .insert(create_tables_stmt().sql().to_string(), "ok".to_string());
+            db.text_map.insert(
+                insert_db_metadata_stmt(DB_SCHEMA_VERSION).sql().to_string(),
+                "ok".to_string(),
+            );
+            for stmt in create_views_batch().statements() {
+                db.text_map.insert(stmt.sql().to_string(), "ok".to_string());
+            }
+            db
+        }
+
+        fn calls(&self) -> Vec<String> {
+            self.calls_text.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait(?Send)]
+    impl LocalDbQueryExecutor for IntegrityCheckFailsDb {
+        async fn execute_batch(&self, batch: &SqlStatementBatch) -> Result<(), LocalDbQueryError> {
+            for stmt in batch {
+                let _ = self.query_text(stmt).await?;
+            }
+            Ok(())
+        }
+
+        async fn query_json<T>(&self, _stmt: &SqlStatement) -> Result<T, LocalDbQueryError>
+        where
+            T: FromDbJson,
+        {
+            Err(LocalDbQueryError::database(
+                "malformed database schema (db_metadata)",
+            ))
+        }
+
+        async fn query_text(&self, stmt: &SqlStatement) -> Result<String, LocalDbQueryError> {
+            let sql = stmt.sql();
+            self.calls_text.lock().unwrap().push(sql.to_string());
+            self.text_map
+                .get(sql)
+                .cloned()
+                .ok_or_else(|| LocalDbQueryError::database("no text for sql"))
+        }
+    }
+
+    #[tokio::test]
+    async fn runner_run_resets_when_integrity_check_fails_with_error() {
+        let adapter = ClientBootstrapAdapter::new();
+        let db = IntegrityCheckFailsDb::new();
+
+        adapter
+            .runner_run(&db, Some(DB_SCHEMA_VERSION))
+            .await
+            .expect("runner_run should succeed after resetting when integrity check errors");
+
+        let calls = db.calls();
+        assert!(
+            calls.contains(&clear_tables_stmt().sql().to_string()),
+            "should have cleared tables when integrity check errors"
+        );
+        assert!(
+            calls.contains(&create_tables_stmt().sql().to_string()),
+            "should have created tables"
+        );
     }
 }


### PR DESCRIPTION
## Motivation

See issues:
- https://github.com/rainlanguage/rain.orderbook/issues/2385

When a browser tab is closed during a sync operation, the SQLite database can become corrupted with "database disk image is malformed" errors. Previously, this caused sync to fail repeatedly with no recovery mechanism, forcing users to manually clear their browser data.

## Solution

Add a database integrity check at startup using SQLite's `PRAGMA quick_check` command:

- **New query module** (`integrity_check.rs`): Defines the `PRAGMA quick_check` statement and `IntegrityCheckRow` struct to parse the JSON response
- **New `check_integrity()` method**: Added to `BootstrapPipeline` trait to run the integrity check and return whether the database is healthy
- **Updated `runner_run()`**: Now checks integrity at startup before any other operations
  - If `quick_check` returns non-"ok" → database is corrupted → reset and resync from dump
  - If `quick_check` query fails entirely (severe corruption) → treat as corrupted → reset and resync from dump

This ensures automatic recovery from database corruption without user intervention.

## Checks

By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)

fix https://github.com/rainlanguage/rain.orderbook/issues/2385

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic database integrity verification that detects and handles database health issues by resetting corrupted databases before they impact operations.

* **Tests**
  * Expanded test coverage to validate database integrity verification and automatic recovery mechanisms, including comprehensive scenarios for corruption detection, error handling, and reset procedures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->