### PR TITLE
Vaultless Phase 4: Webapp Order Creation UI

### DIFF
--- a/crates/settings/src/order.rs
+++ b/crates/settings/src/order.rs
@@ -70,6 +70,124 @@ impl OrderCfg {
         Ok(id)
     }
 
+    pub fn update_vaultless(
+        &mut self,
+        vault_type: VaultType,
+        token: String,
+        vaultless: bool,
+    ) -> Result<Self, YamlError> {
+        let mut document = self
+            .document
+            .write()
+            .map_err(|_| YamlError::WriteLockError)?;
+
+        if let StrictYaml::Hash(ref mut document_hash) = *document {
+            if let Some(StrictYaml::Hash(ref mut orders)) =
+                document_hash.get_mut(&StrictYaml::String("orders".to_string()))
+            {
+                if let Some(StrictYaml::Hash(ref mut order)) =
+                    orders.get_mut(&StrictYaml::String(self.key.to_string()))
+                {
+                    let vec_key = match vault_type {
+                        VaultType::Input => "inputs",
+                        VaultType::Output => "outputs",
+                    };
+                    if let Some(StrictYaml::Array(ref mut vec)) =
+                        order.get_mut(&StrictYaml::String(vec_key.to_string()))
+                    {
+                        let item_index = vec.iter().position(|item| {
+                            if let StrictYaml::Hash(ref item_map) = item {
+                                if let Some(StrictYaml::String(item_token)) =
+                                    item_map.get(&StrictYaml::String("token".to_string()))
+                                {
+                                    return item_token == &token;
+                                }
+                            }
+                            false
+                        });
+
+                        if let Some(idx) = item_index {
+                            if let Some(item) = vec.get_mut(idx) {
+                                if let StrictYaml::Hash(ref mut item_map) = item {
+                                    if vaultless {
+                                        item_map.insert(
+                                            StrictYaml::String("vaultless".to_string()),
+                                            StrictYaml::String("true".to_string()),
+                                        );
+                                        item_map
+                                            .remove(&StrictYaml::String("vault-id".to_string()));
+                                        match vault_type {
+                                            VaultType::Input => {
+                                                self.inputs[idx].vaultless = Some(true);
+                                                self.inputs[idx].vault_id = None;
+                                            }
+                                            VaultType::Output => {
+                                                self.outputs[idx].vaultless = Some(true);
+                                                self.outputs[idx].vault_id = None;
+                                            }
+                                        }
+                                    } else {
+                                        item_map
+                                            .remove(&StrictYaml::String("vaultless".to_string()));
+                                        match vault_type {
+                                            VaultType::Input => {
+                                                self.inputs[idx].vaultless = None;
+                                            }
+                                            VaultType::Output => {
+                                                self.outputs[idx].vaultless = None;
+                                            }
+                                        }
+                                    }
+                                } else {
+                                    return Err(YamlError::Field {
+                                        kind: FieldErrorKind::InvalidType {
+                                            field: vec_key.to_string(),
+                                            expected: "a hash".to_string(),
+                                        },
+                                        location: format!("order '{0}'", self.key),
+                                    });
+                                }
+                            }
+                        } else {
+                            return Err(YamlError::Field {
+                                kind: FieldErrorKind::InvalidValue {
+                                    field: vec_key.to_string(),
+                                    reason: format!("token '{}' not found", token),
+                                },
+                                location: format!("order '{0}'", self.key),
+                            });
+                        }
+                    } else {
+                        return Err(YamlError::Field {
+                            kind: FieldErrorKind::Missing(vec_key.to_string()),
+                            location: format!("order '{0}'", self.key),
+                        });
+                    }
+                } else {
+                    return Err(YamlError::Field {
+                        kind: FieldErrorKind::Missing(self.key.clone()),
+                        location: "orders".to_string(),
+                    });
+                }
+            } else {
+                return Err(YamlError::Field {
+                    kind: FieldErrorKind::Missing("orders".to_string()),
+                    location: "root".to_string(),
+                });
+            }
+        } else {
+            return Err(YamlError::Field {
+                kind: FieldErrorKind::InvalidType {
+                    field: "document".to_string(),
+                    expected: "a map".to_string(),
+                },
+                location: "root".to_string(),
+            });
+        }
+
+        Ok(self.clone())
+    }
+
     pub fn update_vault_id(
         &mut self,
         vault_type: VaultType,
@@ -527,6 +645,64 @@ impl OrderCfg {
         }
 
         Ok(vault_ids)
+    }
+
+    pub fn parse_vaultless_flags(
+        documents: Vec<Arc<RwLock<StrictYaml>>>,
+        order_key: &str,
+        r#type: VaultType,
+    ) -> Result<HashMap<String, Option<bool>>, YamlError> {
+        let mut vaultless_flags = HashMap::new();
+
+        for document in documents {
+            let document_read = document.read().map_err(|_| YamlError::ReadLockError)?;
+
+            if let Ok(orders_hash) = require_hash(&document_read, Some("orders"), None) {
+                if let Some(order_yaml) =
+                    orders_hash.get(&StrictYaml::String(order_key.to_string()))
+                {
+                    let location = format!("order '{}'", order_key);
+
+                    let items = match r#type {
+                        VaultType::Input => {
+                            require_vec(order_yaml, "inputs", Some(location.clone()))?
+                        }
+                        VaultType::Output => {
+                            require_vec(order_yaml, "outputs", Some(location.clone()))?
+                        }
+                    };
+
+                    for (idx, item) in items.iter().enumerate() {
+                        let token = require_string(
+                            item,
+                            Some("token"),
+                            Some(format!(
+                                "{} index '{}' in order '{}'",
+                                if r#type == VaultType::Input {
+                                    "input"
+                                } else {
+                                    "output"
+                                },
+                                idx,
+                                order_key
+                            )),
+                        )?;
+                        let vaultless = optional_bool(item, "vaultless");
+                        vaultless_flags.insert(token, vaultless);
+                    }
+                }
+            } else {
+                return Err(YamlError::Field {
+                    kind: FieldErrorKind::InvalidType {
+                        field: "orders".to_string(),
+                        expected: "a map".to_string(),
+                    },
+                    location: "root".to_string(),
+                });
+            }
+        }
+
+        Ok(vaultless_flags)
     }
 
     pub fn parse_io_token_keys(
@@ -1486,5 +1662,161 @@ orders:
         assert_eq!(order.inputs[0].vault_id, None);
         assert!(order.inputs[1].vault_id.is_some());
         assert!(order.outputs[0].vault_id.is_some());
+    }
+
+    #[test]
+    fn test_update_vaultless_enables_vaultless_mode() {
+        let yaml = r#"
+networks:
+    mainnet:
+        rpcs:
+            - "https://mainnet.infura.io"
+        chain-id: "1"
+tokens:
+    eth:
+        network: mainnet
+        address: 0x1234567890123456789012345678901234567890
+orders:
+    order1:
+        inputs:
+            - token: eth
+        outputs:
+            - token: eth
+"#;
+        let orders = OrderCfg::parse_all_from_yaml(vec![get_document(yaml)], None).unwrap();
+        let mut order = orders.get("order1").unwrap().clone();
+        assert_eq!(order.inputs[0].vaultless, None);
+
+        order
+            .update_vaultless(VaultType::Input, "eth".to_string(), true)
+            .unwrap();
+        assert_eq!(order.inputs[0].vaultless, Some(true));
+    }
+
+    #[test]
+    fn test_update_vaultless_disables_vaultless_mode() {
+        let yaml = r#"
+networks:
+    mainnet:
+        rpcs:
+            - "https://mainnet.infura.io"
+        chain-id: "1"
+tokens:
+    eth:
+        network: mainnet
+        address: 0x1234567890123456789012345678901234567890
+orders:
+    order1:
+        inputs:
+            - token: eth
+              vaultless: true
+        outputs:
+            - token: eth
+"#;
+        let orders = OrderCfg::parse_all_from_yaml(vec![get_document(yaml)], None).unwrap();
+        let mut order = orders.get("order1").unwrap().clone();
+        assert_eq!(order.inputs[0].vaultless, Some(true));
+
+        order
+            .update_vaultless(VaultType::Input, "eth".to_string(), false)
+            .unwrap();
+        assert_eq!(order.inputs[0].vaultless, None);
+    }
+
+    #[test]
+    fn test_update_vaultless_clears_existing_vault_id() {
+        let yaml = r#"
+networks:
+    mainnet:
+        rpcs:
+            - "https://mainnet.infura.io"
+        chain-id: "1"
+tokens:
+    eth:
+        network: mainnet
+        address: 0x1234567890123456789012345678901234567890
+orders:
+    order1:
+        inputs:
+            - token: eth
+              vault-id: "123"
+        outputs:
+            - token: eth
+"#;
+        let orders = OrderCfg::parse_all_from_yaml(vec![get_document(yaml)], None).unwrap();
+        let mut order = orders.get("order1").unwrap().clone();
+        assert_eq!(order.inputs[0].vault_id, Some(U256::from(123)));
+
+        order
+            .update_vaultless(VaultType::Input, "eth".to_string(), true)
+            .unwrap();
+        assert_eq!(order.inputs[0].vaultless, Some(true));
+        assert_eq!(order.inputs[0].vault_id, None);
+    }
+
+    #[test]
+    fn test_update_vaultless_on_output() {
+        let yaml = r#"
+networks:
+    mainnet:
+        rpcs:
+            - "https://mainnet.infura.io"
+        chain-id: "1"
+tokens:
+    eth:
+        network: mainnet
+        address: 0x1234567890123456789012345678901234567890
+orders:
+    order1:
+        inputs:
+            - token: eth
+        outputs:
+            - token: eth
+"#;
+        let orders = OrderCfg::parse_all_from_yaml(vec![get_document(yaml)], None).unwrap();
+        let mut order = orders.get("order1").unwrap().clone();
+        assert_eq!(order.outputs[0].vaultless, None);
+
+        order
+            .update_vaultless(VaultType::Output, "eth".to_string(), true)
+            .unwrap();
+        assert_eq!(order.outputs[0].vaultless, Some(true));
+    }
+
+    #[test]
+    fn test_update_vaultless_token_not_found() {
+        let yaml = r#"
+networks:
+    mainnet:
+        rpcs:
+            - "https://mainnet.infura.io"
+        chain-id: "1"
+tokens:
+    eth:
+        network: mainnet
+        address: 0x1234567890123456789012345678901234567890
+orders:
+    order1:
+        inputs:
+            - token: eth
+        outputs:
+            - token: eth
+"#;
+        let orders = OrderCfg::parse_all_from_yaml(vec![get_document(yaml)], None).unwrap();
+        let mut order = orders.get("order1").unwrap().clone();
+
+        let error = order
+            .update_vaultless(VaultType::Input, "nonexistent".to_string(), true)
+            .unwrap_err();
+        assert_eq!(
+            error,
+            YamlError::Field {
+                kind: FieldErrorKind::InvalidValue {
+                    field: "inputs".to_string(),
+                    reason: "token 'nonexistent' not found".to_string(),
+                },
+                location: "order 'order1'".to_string(),
+            }
+        );
     }
 }

--- a/crates/settings/src/order.rs
+++ b/crates/settings/src/order.rs
@@ -1819,4 +1819,45 @@ orders:
             }
         );
     }
+
+    #[test]
+    fn test_parse_vaultless_flags() {
+        let yaml = r#"
+networks:
+    mainnet:
+        rpcs:
+            - "https://mainnet.infura.io"
+        chain-id: "1"
+tokens:
+    eth:
+        network: mainnet
+        address: 0x1234567890123456789012345678901234567890
+    usdc:
+        network: mainnet
+        address: 0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+orders:
+    order1:
+        inputs:
+            - token: eth
+              vaultless: true
+            - token: usdc
+        outputs:
+            - token: eth
+              vaultless: false
+            - token: usdc
+              vaultless: true
+"#;
+        let document = get_document(yaml);
+
+        let input_flags =
+            OrderCfg::parse_vaultless_flags(vec![document.clone()], "order1", VaultType::Input)
+                .unwrap();
+        assert_eq!(input_flags.get("eth"), Some(&Some(true)));
+        assert_eq!(input_flags.get("usdc"), Some(&None));
+
+        let output_flags =
+            OrderCfg::parse_vaultless_flags(vec![document], "order1", VaultType::Output).unwrap();
+        assert_eq!(output_flags.get("eth"), Some(&Some(false)));
+        assert_eq!(output_flags.get("usdc"), Some(&Some(true)));
+    }
 }

--- a/packages/ui-components/src/lib/components/deployment/TokenIOInput.svelte
+++ b/packages/ui-components/src/lib/components/deployment/TokenIOInput.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Input } from 'flowbite-svelte';
+	import { Input, Toggle } from 'flowbite-svelte';
 	import { type OrderIOCfg, type TokenInfo, type VaultType } from '@rainlanguage/orderbook';
 	import { onMount } from 'svelte';
 	import { useGui } from '$lib/hooks/useGui';
@@ -11,24 +11,30 @@
 	export let label: 'Input' | 'Output';
 	export let vault: OrderIOCfg;
 	export let tokenBalances: Map<string, TokenBalance> = new Map();
+	export let onApprovalAmountChange: ((tokenKey: string, amount: string) => void) | undefined =
+		undefined;
 
 	let tokenInfo: TokenInfo | null = null;
 	let inputValue: string = '';
 	let error: string = '';
+	let isVaultless: boolean = vault.vaultless === true;
+	let approvalAmount: string = '';
 
 	onMount(() => {
 		if (!vault.token?.key) return;
 
-		const result = gui.getVaultIds();
-		if (result.error) {
-			error = result.error.msg;
-			return;
-		}
-		const vaultIds = result.value;
-		const vaultMap = vaultIds.get(label.toLowerCase());
-		if (vaultMap) {
-			const vaultId = vaultMap.get(vault.token.key);
-			inputValue = vaultId || '';
+		if (!isVaultless) {
+			const result = gui.getVaultIds();
+			if (result.error) {
+				error = result.error.msg;
+				return;
+			}
+			const vaultIds = result.value;
+			const vaultMap = vaultIds.get(label.toLowerCase());
+			if (vaultMap) {
+				const vaultId = vaultMap.get(vault.token.key);
+				inputValue = vaultId || '';
+			}
 		}
 	});
 
@@ -63,6 +69,25 @@
 		}
 	};
 
+	const handleVaultlessToggle = () => {
+		if (!vault.token?.key) return;
+		error = '';
+		const result = gui.setVaultless(label.toLowerCase() as VaultType, vault.token.key, isVaultless);
+		if (result.error) {
+			error = result.error.msg;
+			return;
+		}
+		if (isVaultless) {
+			inputValue = '';
+		}
+	};
+
+	const handleApprovalAmountInput = () => {
+		if (vault.token?.key && onApprovalAmountChange) {
+			onApprovalAmountChange(vault.token.key, approvalAmount);
+		}
+	};
+
 	$: if (vault.token?.key) {
 		handleGetTokenInfo();
 	}
@@ -78,17 +103,46 @@
 			/>
 		</div>
 	</div>
-	<div class="flex flex-col gap-2">
-		<Input
-			data-testid="vault-id-input"
-			size="lg"
-			type="text"
-			placeholder="Enter vault ID"
-			bind:value={inputValue}
-			on:input={handleInput}
-		/>
-		{#if error}
-			<p class="text-red-500">{error}</p>
+
+	<Toggle bind:checked={isVaultless} on:change={handleVaultlessToggle}
+		>Vaultless mode (direct wallet transfer)</Toggle
+	>
+
+	{#if isVaultless}
+		<div class="rounded-lg bg-blue-900/20 p-3">
+			<p class="text-sm text-blue-300">Token transfers directly without vault storage.</p>
+		</div>
+
+		{#if label === 'Output'}
+			<div class="flex flex-col gap-2">
+				<label for="approval-amount" class="text-sm text-gray-400"
+					>Approval Amount (defaults to unlimited)</label
+				>
+				<Input
+					id="approval-amount"
+					data-testid="approval-amount-input"
+					size="lg"
+					type="text"
+					placeholder="Leave empty for unlimited"
+					bind:value={approvalAmount}
+					on:input={handleApprovalAmountInput}
+				/>
+			</div>
 		{/if}
-	</div>
+	{:else}
+		<div class="flex flex-col gap-2">
+			<Input
+				data-testid="vault-id-input"
+				size="lg"
+				type="text"
+				placeholder="Enter vault ID"
+				bind:value={inputValue}
+				on:input={handleInput}
+			/>
+		</div>
+	{/if}
+
+	{#if error}
+		<p class="text-red-500">{error}</p>
+	{/if}
 </div>

--- a/packages/ui-components/src/lib/components/deployment/TokenIOInput.svelte
+++ b/packages/ui-components/src/lib/components/deployment/TokenIOInput.svelte
@@ -75,6 +75,7 @@
 		const result = gui.setVaultless(label.toLowerCase() as VaultType, vault.token.key, isVaultless);
 		if (result.error) {
 			error = result.error.msg;
+			isVaultless = !isVaultless;
 			return;
 		}
 		if (isVaultless) {

--- a/packages/webapp/src/__tests__/handleAddOrder.test.ts
+++ b/packages/webapp/src/__tests__/handleAddOrder.test.ts
@@ -388,4 +388,38 @@ describe('handleAddOrder', () => {
 		expect(mockCreateApprovalTransaction).not.toHaveBeenCalled();
 		expect(mockCreateAddOrderTransaction).not.toHaveBeenCalled();
 	});
+
+	it('should pass vaultlessApprovalAmounts to getDeploymentTransactionArgs', async () => {
+		const vaultlessApprovalAmounts = new Map<string, string>();
+		vaultlessApprovalAmounts.set('token1', '100');
+		vaultlessApprovalAmounts.set('token2', '200');
+
+		const depsWithApprovalAmounts = {
+			...mockDeps,
+			vaultlessApprovalAmounts
+		};
+
+		mockGetDeploymentTransactionArgs.mockResolvedValue({
+			value: mockDeploymentArgs,
+			error: null
+		});
+
+		await handleAddOrder(depsWithApprovalAmounts);
+
+		expect(mockGetDeploymentTransactionArgs).toHaveBeenCalledWith(
+			MOCKED_ACCOUNT,
+			vaultlessApprovalAmounts
+		);
+	});
+
+	it('should pass undefined for vaultlessApprovalAmounts when not provided', async () => {
+		mockGetDeploymentTransactionArgs.mockResolvedValue({
+			value: mockDeploymentArgs,
+			error: null
+		});
+
+		await handleAddOrder(mockDeps);
+
+		expect(mockGetDeploymentTransactionArgs).toHaveBeenCalledWith(MOCKED_ACCOUNT, undefined);
+	});
 });

--- a/packages/webapp/src/lib/services/handleAddOrder.ts
+++ b/packages/webapp/src/lib/services/handleAddOrder.ts
@@ -3,7 +3,8 @@ import type {
 	DotrainOrderGui,
 	RaindexClient,
 	RaindexVault,
-	RaindexVaultToken
+	RaindexVaultToken,
+	VaultlessApprovalAmounts
 } from '@rainlanguage/orderbook';
 import type {
 	TransactionManager,
@@ -28,6 +29,7 @@ export type HandleAddOrderDependencies = {
 	gui: DotrainOrderGui;
 	raindexClient: RaindexClient;
 	account: Hex | null;
+	vaultlessApprovalAmounts?: VaultlessApprovalAmounts;
 };
 
 export const handleAddOrder = async (deps: HandleAddOrderDependencies) => {
@@ -37,7 +39,7 @@ export const handleAddOrder = async (deps: HandleAddOrderDependencies) => {
 		return errToast('Could not deploy: ' + AddOrderErrors.NO_ACCOUNT_CONNECTED);
 	}
 
-	const result = await gui.getDeploymentTransactionArgs(account);
+	const result = await gui.getDeploymentTransactionArgs(account, deps.vaultlessApprovalAmounts);
 
 	if (result.error) {
 		return errToast('Could not deploy: ' + result.error.msg);

--- a/packages/webapp/src/routes/deploy/[orderName]/[deploymentKey]/+page.svelte
+++ b/packages/webapp/src/routes/deploy/[orderName]/[deploymentKey]/+page.svelte
@@ -10,7 +10,11 @@
 	} from '@rainlanguage/ui-components';
 	import { connected, appKitModal } from '$lib/stores/wagmi';
 	import { handleDisclaimerModal } from '$lib/services/modal';
-	import { DotrainOrderGui, RaindexClient } from '@rainlanguage/orderbook';
+	import {
+		DotrainOrderGui,
+		RaindexClient,
+		type VaultlessApprovalAmounts
+	} from '@rainlanguage/orderbook';
 	import { onMount } from 'svelte';
 	import { handleGuiInitialization } from '$lib/services/handleGuiInitialization';
 	import { handleAddOrder } from '$lib/services/handleAddOrder';
@@ -44,7 +48,11 @@
 		}
 	});
 
-	const onDeploy = (raindexClient: RaindexClient, gui: DotrainOrderGui) => {
+	const onDeploy = (
+		raindexClient: RaindexClient,
+		gui: DotrainOrderGui,
+		vaultlessApprovalAmounts?: VaultlessApprovalAmounts
+	) => {
 		handleDisclaimerModal({
 			open: true,
 			onAccept: () => {
@@ -54,7 +62,8 @@
 					errToast,
 					manager,
 					gui,
-					account: $account
+					account: $account,
+					vaultlessApprovalAmounts
 				});
 			}
 		});


### PR DESCRIPTION
## Chained PRs
- https://github.com/rainlanguage/rain.orderbook/pull/2413

## Motivation

See issues:
- https://github.com/rainlanguage/rain.orderbook/issues/2406
- https://github.com/rainlanguage/rain.orderbook/issues/2402

Phase 4 of the vaultless orders implementation. Add UI elements for vaultless order creation in the webapp deployment flow, allowing users to enable wallet-based trading directly without vault storage.

## Solution

**Rust Backend - Settings (`order.rs`):**
- `update_vaultless()` method to enable/disable vaultless per token (clears vault-id when enabling)
- `parse_vaultless_flags()` for reading vaultless state from YAML documents

**Rust Backend - GUI API (`order_operations.rs`, `state_management.rs`):**
- `setVaultless()` wasm method to set vaultless mode for input/output tokens
- `getVaultlessStatus()` wasm method returning vaultless status map
- Include `vaultless_flags` in GUI state serialization for persistence

**Frontend UI (`TokenIOInput.svelte`, `DeploymentSteps.svelte`):**
- Vaultless toggle switch per token with explanatory text
- Conditional UI: vault ID input vs vaultless mode info
- For vaultless outputs: approval amount input (defaults to unlimited)
- Auto-show advanced options when any token has vaultless mode enabled
- Track `vaultlessApprovalAmounts` and pass through deployment flow

**Webapp Integration (`handleAddOrder.ts`, deploy page):**
- Pass `vaultlessApprovalAmounts` to `getDeploymentTransactionArgs()`

<img width="845" height="569" alt="Screenshot 2026-01-21 at 12 20 41" src="https://github.com/user-attachments/assets/064d28bc-a00c-48e4-b98d-8e1a266651dc" />

<img width="830" height="551" alt="Screenshot 2026-01-21 at 12 20 48" src="https://github.com/user-attachments/assets/66739585-a35f-4519-b880-2db330bfb546" />

## Checks

By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [x] included screenshots (if this involves a front-end change)

fix https://github.com/rainlanguage/rain.orderbook/issues/2406

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Toggle controls to enable and disable vaultless mode for individual input and output tokens
  * Approval amount input field for vaultless outputs (defaults to unlimited)
  * Automatic vault ID clearing when vaultless mode is enabled for a token
  * Vaultless configuration persists reliably across state save and load operations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->