### PR TITLE
Point webapp Vercel deploys to new v6 project

### DIFF
--- a/.github/workflows/vercel-preview.yaml
+++ b/.github/workflows/vercel-preview.yaml
@@ -87,7 +87,7 @@ jobs:
         shell: bash --noprofile --norc -euo pipefail {0}
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_V6 }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: |
           "$VERCEL_BIN" pull --yes --environment=preview --token="$VERCEL_TOKEN"
@@ -95,7 +95,7 @@ jobs:
         shell: bash --noprofile --norc -euo pipefail {0}
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_V6 }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: |
           "$VERCEL_BIN" deploy --prebuilt --token="$VERCEL_TOKEN" packages/webapp

--- a/.github/workflows/vercel-prod.yaml
+++ b/.github/workflows/vercel-prod.yaml
@@ -1,7 +1,7 @@
 name: GitHub Actions Vercel Production Deployment
 env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_V6 }}
 on:
   push:
     branches:


### PR DESCRIPTION
Update vercel-prod.yaml and vercel-preview.yaml to use VERCEL_PROJECT_ID_V6 so main deploys go to the new v6 Vercel app, while the old VERCEL_PROJECT_ID secret remains for v4/v5 branches.

<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

v5 is currently deployed to production on the existing Vercel app. Our plan only allows one custom environment per app, so v6 needs its own Vercel project. The old VERCEL_PROJECT_ID secret must remain for v4/v5 branches that still deploy to the original app.

## Solution

- Updated vercel-prod.yaml and vercel-preview.yaml to reference VERCEL_PROJECT_ID_V6 instead of VERCEL_PROJECT_ID
- The PR-target preview workflow (vercel-preview-pr-target.yaml) is unchanged — it uses its own isolated VERCEL_PROJECT_ID_PREVIEWS
- Docs workflows are unchanged

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration for production and preview environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->