### PR TITLE
token dropdown loading issues in Orders/Vaults list pages

### DIFF
--- a/crates/common/src/local_db/query/fetch_all_tokens/mod.rs
+++ b/crates/common/src/local_db/query/fetch_all_tokens/mod.rs
@@ -81,4 +81,13 @@ mod tests {
         assert!(stmt.sql.contains("orderbook_address IN"));
         assert_eq!(stmt.params.len(), 1);
     }
+
+    #[test]
+    fn sql_uses_camel_case_aliases() {
+        let args = FetchAllTokensArgs::default();
+        let stmt = build_fetch_all_tokens_stmt(&args).expect("should build");
+        assert!(stmt.sql.contains("chain_id AS chainId"));
+        assert!(stmt.sql.contains("orderbook_address AS orderbookAddress"));
+        assert!(stmt.sql.contains("token_address AS tokenAddress"));
+    }
 }

--- a/crates/common/src/local_db/query/fetch_all_tokens/query.sql
+++ b/crates/common/src/local_db/query/fetch_all_tokens/query.sql
@@ -1,4 +1,10 @@
-SELECT DISTINCT chain_id, orderbook_address, token_address, name, symbol, decimals
+SELECT DISTINCT
+    chain_id AS chainId,
+    orderbook_address AS orderbookAddress,
+    token_address AS tokenAddress,
+    name,
+    symbol,
+    decimals
 FROM erc20_tokens
 WHERE 1=1
   /*CHAIN_IDS_CLAUSE*/

--- a/crates/common/src/raindex_client/vaults.rs
+++ b/crates/common/src/raindex_client/vaults.rs
@@ -1391,47 +1391,15 @@ impl RaindexClient {
         )]
         chain_ids: Option<ChainIds>,
     ) -> Result<Vec<RaindexVaultToken>, RaindexError> {
-        let subgraph_source = SubgraphVaults::new(self);
-
-        let Some(mut ids) = chain_ids.map(|ChainIds(ids)| ids) else {
-            return subgraph_source.tokens_list(None).await;
-        };
-
-        if ids.is_empty() {
-            return subgraph_source.tokens_list(None).await;
-        }
-
-        let mut local_ids = Vec::new();
-        let mut sg_ids = Vec::new();
-
-        for id in ids.drain(..) {
-            if is_chain_supported_local_db(id) {
-                local_ids.push(id);
-            } else {
-                sg_ids.push(id);
-            }
-        }
-
-        let mut tokens: Vec<RaindexVaultToken> = Vec::new();
-
-        if self.local_db().is_none() {
-            sg_ids.append(&mut local_ids);
-        }
+        let ids = chain_ids.map(|ChainIds(ids)| ids);
 
         if let Some(local_db) = self.local_db() {
-            if !local_ids.is_empty() {
-                let local_source = LocalDbVaults::new(&local_db, Rc::new(self.clone()));
-                let local_tokens = local_source.tokens_list(Some(local_ids)).await?;
-                tokens.extend(local_tokens);
-            }
+            let local_source = LocalDbVaults::new(&local_db, Rc::new(self.clone()));
+            return local_source.tokens_list(ids).await;
         }
 
-        if !sg_ids.is_empty() {
-            let sg_tokens = subgraph_source.tokens_list(Some(sg_ids)).await?;
-            tokens.extend(sg_tokens);
-        }
-
-        Ok(tokens)
+        let subgraph_source = SubgraphVaults::new(self);
+        subgraph_source.tokens_list(ids).await
     }
 }
 impl RaindexClient {


### PR DESCRIPTION
## Motivation

See issues:
- https://github.com/rainlanguage/rain.orderbook/issues/2425

The token selection dropdown in Orders and Vaults list pages had two issues:

1. **Deserialization error when a network was selected**: Selecting a network then opening the token dropdown produced the error: "Cannot load tokens list: There was an error querying the local database: Deserialization failed: missing field `chainId`"

2. **Empty token list when no network selected**: When no network filter was applied, the token dropdown showed no tokens because the code defaulted to querying only the subgraph (which returned nothing) instead of the local database.

## Solution

**SQL Query Fix**: Added camelCase column aliases to the `fetch_all_tokens` SQL query to match the `LocalDbToken` struct's `#[serde(rename_all = "camelCase")]` attribute. The SQL was returning snake_case column names (`chain_id`, `orderbook_address`, `token_address`) but serde expected camelCase (`chainId`, `orderbookAddress`, `tokenAddress`).

**Data Source Logic Fix**: Simplified `get_all_vault_tokens` to follow the same pattern as `get_vaults` and `get_orders` - check local DB first, fall back to subgraph. The previous implementation had complex logic that defaulted to subgraph when no chain IDs were provided, even when local DB was available.

## Checks

By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)

fix https://github.com/rainlanguage/rain.orderbook/issues/2425

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Deterministic ordering of token query results for more consistent responses
  * Simplified token retrieval logic to use a single source per call, improving efficiency and predictability
* **Refactor**
  * Token fields now use camelCase names (e.g., chainId, orderbookAddress, tokenAddress)
* **Tests**
  * Added tests ensuring local DB is used when available and validating SQL aliasing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->