### PR TITLE
Subgraph vaultless block handler

### DIFF
--- a/.github/workflows/deploy-subgraph.yaml
+++ b/.github/workflows/deploy-subgraph.yaml
@@ -55,6 +55,8 @@ jobs:
 
       - run: >
           (cd lib/rain.interpreter/lib/rain.interpreter.interface/lib/rain.math.float && nix develop -c rainix-sol-prelude)
+      - run: >
+          (nix develop -c bash -c "cd lib/rain.interpreter/lib/rain.interpreter.interface/lib/forge-std && forge build")
 
       - run: nix develop -c bash -c rainix-sol-prelude
 

--- a/.github/workflows/test-subgraph.yml
+++ b/.github/workflows/test-subgraph.yml
@@ -45,6 +45,8 @@ jobs:
 
       - run: |
           (cd lib/rain.interpreter/lib/rain.interpreter.interface/lib/rain.math.float && nix develop -c rainix-sol-prelude)
+      - run: >
+          (nix develop -c bash -c "cd lib/rain.interpreter/lib/rain.interpreter.interface/lib/forge-std && forge build")
 
       - name: Build subgraph
         run: nix develop -c subgraph-build

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -40,6 +40,13 @@ type Vault @entity {
   balance: Bytes!
   "All balance changes for this vault"
   balanceChanges: [VaultBalanceChange!]! @derivedFrom(field: "vault")
+  "reference VaultList singleton record to derive the vaults list from"
+  vaultList: VaultList!
+}
+
+type VaultList @entity {
+  id: String!
+  vaults: [Vault!]! @derivedFrom(field: "vaultList") # list of all vaults
 }
 
 interface VaultBalanceChange {

--- a/subgraph/src/handlers.ts
+++ b/subgraph/src/handlers.ts
@@ -22,6 +22,8 @@ import {
 } from "./clear";
 import { createTransactionEntity } from "./transaction";
 import { createOrderbookEntity } from "./orderbook";
+import { ethereum } from "@graphprotocol/graph-ts";
+import { handleVaultlessBalance } from "./vault";
 
 export function handleDeposit(event: DepositV2): void {
   createTransactionEntity(event);
@@ -69,4 +71,8 @@ export function handleAfterClear(event: AfterClearV2): void {
   createTransactionEntity(event);
   createOrderbookEntity(event);
   _handleAfterClear(event);
+}
+
+export function vaultBlockHandler(_block: ethereum.Block): void {
+  handleVaultlessBalance();
 }

--- a/subgraph/src/vault.ts
+++ b/subgraph/src/vault.ts
@@ -1,7 +1,13 @@
-import { Bytes, crypto } from "@graphprotocol/graph-ts";
-import { Vault } from "../generated/schema";
+import { Address, Bytes, crypto, dataSource } from "@graphprotocol/graph-ts";
+import { Vault, VaultList } from "../generated/schema";
 import { getERC20Entity } from "./erc20";
 import { Float, getCalculator } from "./float";
+import { ethereum } from "@graphprotocol/graph-ts"
+import { Multicall3 } from "../generated/OrderBook/Multicall3";
+
+export const VAULT_LIST_ID = "SINGLETON";
+export const MUTLICALL3_ADDRESS = "0xcA11bde05977b3631167028862bE2a173976CA11";
+export const ZERO_BYTES_32 = "0x0000000000000000000000000000000000000000000000000000000000000000";
 
 export type VaultId = Bytes;
 
@@ -21,14 +27,14 @@ export function createEmptyVault(
   vaultId: VaultId,
   token: Bytes
 ): Vault {
+  getVaultList(); // make sure vault list exists
   let vault = new Vault(vaultEntityId(orderbook, owner, vaultId, token));
   vault.orderbook = orderbook;
   vault.vaultId = vaultId;
   vault.token = getERC20Entity(token);
   vault.owner = owner;
-  vault.balance = Bytes.fromHexString(
-    "0x0000000000000000000000000000000000000000000000000000000000000000"
-  );
+  vault.balance = Bytes.fromHexString(ZERO_BYTES_32);
+  vault.vaultList = VAULT_LIST_ID;
   vault.save();
   return vault;
 }
@@ -69,4 +75,91 @@ export function handleVaultBalanceChange(
     oldVaultBalance,
     newVaultBalance: vault.balance,
   };
+}
+
+export function getVaultList(): VaultList {
+  let vaultList = VaultList.load(VAULT_LIST_ID);
+  if (!vaultList) {
+    vaultList = new VaultList(VAULT_LIST_ID);
+    vaultList.save();
+  }
+  return vaultList;
+}
+
+// updates vaultless for all vautless vaults using multicall
+// this is used in block handler and is updated at each block
+export function handleVaultlessBalance(): void {  
+  // Get the OrderBook  and multicall3 contract instance
+  const orderBookAddress = dataSource.address()
+  const multicall3 = Multicall3.bind(Address.fromString(MUTLICALL3_ADDRESS));
+
+  // Load all vaults from the store
+  const BATCH_SIZE = 1000;
+  const vaultList = getVaultList().vaults.load();
+  const vaultlessVaultsBatch: Vault[][] = [[]];
+
+  for (let i = 0; i < vaultList.length; i++) {
+    const vault = vaultList[i];
+
+    // skip non vautless vaults
+    if (vault.vaultId.notEqual(Bytes.fromHexString(ZERO_BYTES_32))) continue;
+
+    if (vaultlessVaultsBatch[vaultlessVaultsBatch.length - 1].length < BATCH_SIZE) {
+      vaultlessVaultsBatch[vaultlessVaultsBatch.length - 1].push(vault)
+    } else {
+      vaultlessVaultsBatch.push([vault]);
+    }
+  }
+
+  // Batch calls using tryAggregate for better performance
+  const batchCalls: ethereum.Tuple[][] = [];
+  for (let i = 0; i < vaultlessVaultsBatch.length; i++) {
+    const vaultlessVaults = vaultlessVaultsBatch[i];
+    const calls: ethereum.Tuple[] = [];
+    for (let j = 0; j < vaultlessVaults.length; j++) {
+      let vault = vaultlessVaults[j];
+      
+      // Encode vaultBalance2(address owner, address token, bytes32 vaultId) call
+      const callData = ethereum.encode(
+        ethereum.Value.fromTuple(
+          changetype<ethereum.Tuple>([
+            ethereum.Value.fromAddress(Address.fromBytes(vault.owner)),
+            ethereum.Value.fromAddress(Address.fromBytes(vault.token)),
+            ethereum.Value.fromFixedBytes(vault.vaultId)
+          ])
+        )
+      )!;
+      const call3 = changetype<ethereum.Tuple>([
+        ethereum.Value.fromAddress(orderBookAddress),
+        ethereum.Value.fromBoolean(true), // allowFailure = true
+        ethereum.Value.fromBytes(callData)
+      ]);
+      calls.push(call3);
+    }
+    batchCalls.push(calls);
+  }
+
+  for (let i = 0; i < batchCalls.length; i++) {
+    // Make multicall
+    const result = multicall3.tryCall(
+      "aggregate3",
+      "aggregate3((address,bool,bytes)[]):((bool,bytes)[])",
+      [ethereum.Value.fromTupleArray(batchCalls[i])]
+    );
+    
+    if (result.reverted) continue;
+    const results = result.value[0].toTupleArray<ethereum.Tuple>();
+    if (results.length !== vaultlessVaultsBatch[i].length) continue;
+
+    for (let j = 0; j < vaultlessVaultsBatch[i].length; j++) {
+      const success = results[j][0].toBoolean();
+      const returnData = results[j][1].toBytes();
+      if (!success) continue;
+      const decoded = ethereum.decode('bytes32', returnData);
+      if (decoded) {
+        vaultlessVaultsBatch[i][j].balance = decoded.toBytes();
+        vaultlessVaultsBatch[i][j].save();
+      }
+    }
+  }
 }

--- a/subgraph/subgraph.yaml
+++ b/subgraph/subgraph.yaml
@@ -24,6 +24,8 @@ dataSources:
           file: ../out/ERC20.sol/ERC20.json
         - name: DecimalFloat
           file: ../lib/rain.interpreter/lib/rain.interpreter.interface/lib/rain.math.float/out/DecimalFloat.sol/DecimalFloat.json
+        - name: Multicall3
+          file: ../lib/rain.interpreter/lib/rain.interpreter.interface/lib/forge-std/out/IMulticall3.sol/IMulticall3.json
       eventHandlers:
         - event: DepositV2(address,address,bytes32,uint256)
           handler: handleDeposit
@@ -41,4 +43,6 @@ dataSources:
           handler: handleClear
         - event: AfterClearV2(address,(bytes32,bytes32,bytes32,bytes32))
           handler: handleAfterClear
+      blockHandlers:
+        - handler: vaultBlockHandler
       file: ./src/handlers.ts

--- a/subgraph/tsconfig.json
+++ b/subgraph/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@graphprotocol/graph-ts/types/tsconfig.base.json",
+  "include": ["src", "tests"]
+}


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation
> [!caution]
> Do NOT merge before #1988 

This PR updates balance handler for valueless vaults.
since its dynamic and subject to change at each block, we need to call `vaultBalance2()` for vaultless vaults at each block using multicall3 and subgraph block handlers
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)
