### PR TITLE
Update Vercel production deployment to trigger on v5 branch

### DIFF
--- a/.github/workflows/vercel-prod.yaml
+++ b/.github/workflows/vercel-prod.yaml
@@ -5,7 +5,7 @@ env:
 on:
   push:
     branches:
-      - main
+      - v5
 jobs:
   Deploy-Preview:
     permissions:


### PR DESCRIPTION
## Motivation

The Vercel production deployment workflow (`vercel-prod.yaml`) on the `v5` branch was configured to trigger only on pushes to `main`. This meant updates pushed to `v5` did not trigger a production deployment.

## Solution

Replaced the `main` branch trigger with `v5` in the workflow's `on.push.branches` configuration. The `main` branch retains its own copy of the workflow for its deployments.

## Checks

By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [ ] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)