### PR TITLE
Fix vault balance changes table not loading due to WASM race condition

### DIFF
--- a/packages/ui-components/src/__tests__/VaultBalanceChangesTable.test.ts
+++ b/packages/ui-components/src/__tests__/VaultBalanceChangesTable.test.ts
@@ -1,14 +1,11 @@
-import { render, screen, waitFor } from '@testing-library/svelte';
-import { test, vi } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import { test } from 'vitest';
 import { expect } from '../lib/test/matchers';
-import { QueryClient } from '@tanstack/svelte-query';
 import VaultBalanceChangesTable from '../lib/components/tables/VaultBalanceChangesTable.svelte';
-import type { RaindexVault, RaindexVaultBalanceChange } from '@rainlanguage/orderbook';
+import type { RaindexVaultBalanceChange } from '@rainlanguage/orderbook';
 import { formatTimestampSecondsAsLocal } from '../lib/services/time';
 
 test('renders the vault list table with correct data', async () => {
-	const queryClient = new QueryClient();
-
 	const mockVaultBalanceChanges: RaindexVaultBalanceChange[] = [
 		{
 			__typename: 'Withdrawal',
@@ -32,29 +29,19 @@ test('renders the vault list table with correct data', async () => {
 			},
 			orderbook: '0x00'
 		}
-		// ... other mock data
 	] as unknown as RaindexVaultBalanceChange[];
-	const mockVault: RaindexVault = {
-		id: 'vault1',
-		getBalanceChanges: vi.fn().mockResolvedValue({ value: mockVaultBalanceChanges })
-	} as unknown as RaindexVault;
 
 	render(VaultBalanceChangesTable, {
 		props: {
-			vault: mockVault
-		},
-		context: new Map([['$$_queryClient', queryClient]])
+			data: mockVaultBalanceChanges
+		}
 	});
 
-	await waitFor(() => {
-		const rows = screen.getAllByTestId('bodyRow');
-		expect(rows).toHaveLength(1);
-	});
+	const rows = screen.getAllByTestId('bodyRow');
+	expect(rows).toHaveLength(1);
 });
 
 test('it shows the correct data in the table', async () => {
-	const queryClient = new QueryClient();
-
 	const mockVaultBalanceChanges: RaindexVaultBalanceChange[] = [
 		{
 			type: 'withdrawal',
@@ -82,28 +69,19 @@ test('it shows the correct data in the table', async () => {
 			orderbook: '0x00'
 		}
 	] as unknown as RaindexVaultBalanceChange[];
-	const mockVault: RaindexVault = {
-		id: 'vault1',
-		getBalanceChanges: vi.fn().mockResolvedValue({ value: mockVaultBalanceChanges })
-	} as unknown as RaindexVault;
 
 	render(VaultBalanceChangesTable, {
 		props: {
-			vault: mockVault
-		},
-		context: new Map([['$$_queryClient', queryClient]])
+			data: mockVaultBalanceChanges
+		}
 	});
 
-	await waitFor(() => {
-		expect(screen.getByTestId('vaultBalanceChangesTableDate')).toHaveTextContent(
-			formatTimestampSecondsAsLocal(BigInt('1625247600'))
-		);
-		expect(screen.getByTestId('vaultBalanceChangesTableFrom')).toHaveTextContent('0xUse...User1');
-		expect(screen.getByTestId('vaultBalanceChangesTableTx')).toHaveTextContent('tx1');
-		expect(screen.getByTestId('vaultBalanceChangesTableBalanceChange')).toHaveTextContent(
-			'0.1 TKN1'
-		);
-		expect(screen.getByTestId('vaultBalanceChangesTableBalance')).toHaveTextContent('0.4 TKN1');
-		expect(screen.getByTestId('vaultBalanceChangesTableType')).toHaveTextContent('withdrawal');
-	});
+	expect(screen.getByTestId('vaultBalanceChangesTableDate')).toHaveTextContent(
+		formatTimestampSecondsAsLocal(BigInt('1625247600'))
+	);
+	expect(screen.getByTestId('vaultBalanceChangesTableFrom')).toHaveTextContent('0xUse...User1');
+	expect(screen.getByTestId('vaultBalanceChangesTableTx')).toHaveTextContent('tx1');
+	expect(screen.getByTestId('vaultBalanceChangesTableBalanceChange')).toHaveTextContent('0.1 TKN1');
+	expect(screen.getByTestId('vaultBalanceChangesTableBalance')).toHaveTextContent('0.4 TKN1');
+	expect(screen.getByTestId('vaultBalanceChangesTableType')).toHaveTextContent('withdrawal');
 });

--- a/packages/ui-components/src/lib/components/charts/VaultBalanceChart.svelte
+++ b/packages/ui-components/src/lib/components/charts/VaultBalanceChart.svelte
@@ -1,21 +1,12 @@
 <script lang="ts">
 	import { timestampSecondsToUTCTimestamp } from '../../services/time';
 	import type { RaindexVault, RaindexVaultBalanceChange } from '@rainlanguage/orderbook';
-	import { createQuery } from '@tanstack/svelte-query';
+	import type { CreateQueryResult } from '@tanstack/svelte-query';
 	import TanstackLightweightChartLine from '../charts/TanstackLightweightChartLine.svelte';
-	import { QKEY_VAULT_CHANGES } from '../../queries/keys';
 
 	export let vault: RaindexVault;
+	export let query: CreateQueryResult<RaindexVaultBalanceChange[]>;
 	export let lightweightChartsTheme;
-
-	$: query = createQuery({
-		queryKey: [vault.id, QKEY_VAULT_CHANGES + vault.id, QKEY_VAULT_CHANGES],
-		queryFn: async () => {
-			const result = await vault.getBalanceChanges(1);
-			if (result.error) throw new Error(result.error.msg);
-			return result.value;
-		}
-	});
 
 	const Chart = TanstackLightweightChartLine<RaindexVaultBalanceChange>;
 </script>

--- a/packages/ui-components/src/lib/components/detail/VaultDetail.svelte
+++ b/packages/ui-components/src/lib/components/detail/VaultDetail.svelte
@@ -66,11 +66,34 @@
 		],
 		enabled: !!$vaultDetailQuery.data,
 		queryFn: async () => {
+			// eslint-disable-next-line no-console
+			console.log('[VaultDetail] fetching balance changes, vault:', $vaultDetailQuery.data?.id);
 			const result = await $vaultDetailQuery.data!.getBalanceChanges(1);
+			// eslint-disable-next-line no-console
+			console.log(
+				'[VaultDetail] result:',
+				result,
+				'value length:',
+				result.value?.length,
+				'error:',
+				result.error
+			);
 			if (result.error) throw new Error(result.error.msg);
 			return result.value;
 		}
 	});
+
+	// eslint-disable-next-line no-console
+	$: console.log(
+		'[VaultDetail] vaultData:',
+		!!$vaultDetailQuery.data,
+		'bcData:',
+		$balanceChangesQuery?.data?.length,
+		'bcLoading:',
+		$balanceChangesQuery?.isLoading,
+		'bcError:',
+		$balanceChangesQuery?.error
+	);
 
 	const interval = setInterval(async () => {
 		invalidateTanstackQueries(queryClient, [id, QKEY_VAULT + id]);

--- a/packages/ui-components/src/lib/components/tables/VaultBalanceChangesTable.svelte
+++ b/packages/ui-components/src/lib/components/tables/VaultBalanceChangesTable.svelte
@@ -1,70 +1,67 @@
-<script lang="ts" generics="T">
+<script lang="ts">
 	import { Heading, TableHeadCell, TableBodyCell } from 'flowbite-svelte';
-	import { createInfiniteQuery } from '@tanstack/svelte-query';
-	import { RaindexVault, type RaindexVaultBalanceChange } from '@rainlanguage/orderbook';
+	import type { RaindexVaultBalanceChange } from '@rainlanguage/orderbook';
 	import { formatTimestampSecondsAsLocal } from '../../services/time';
 	import Hash, { HashType } from '../Hash.svelte';
-	import { QKEY_VAULT_CHANGES } from '../../queries/keys';
-	import { DEFAULT_PAGE_SIZE } from '../../queries/constants';
-	import TanstackAppTable from '../TanstackAppTable.svelte';
+	import { Table, TableBody, TableBodyRow, TableHead } from 'flowbite-svelte';
 
-	export let vault: RaindexVault;
-
-	$: balanceChangesQuery = createInfiniteQuery({
-		queryKey: [vault.id, QKEY_VAULT_CHANGES + vault.id],
-		queryFn: async ({ pageParam }) => {
-			const result = await vault.getBalanceChanges(pageParam + 1);
-			if (result.error) throw new Error(result.error.msg);
-			return result.value;
-		},
-		initialPageParam: 0,
-		getNextPageParam(lastPage, _allPages, lastPageParam) {
-			return lastPage.length === DEFAULT_PAGE_SIZE ? lastPageParam + 1 : undefined;
-		}
-	});
-
-	const AppTable = TanstackAppTable<RaindexVaultBalanceChange>;
+	export let data: RaindexVaultBalanceChange[] | undefined = undefined;
 </script>
 
-<AppTable
-	query={balanceChangesQuery}
-	queryKey={vault.id}
-	emptyMessage="No deposits or withdrawals found"
-	rowHoverable={false}
->
-	<svelte:fragment slot="title">
-		<Heading tag="h5" class="mb-4 mt-6 font-normal">Vault balance changes</Heading>
-	</svelte:fragment>
-	<svelte:fragment slot="head">
-		<TableHeadCell padding="p-4">Date</TableHeadCell>
-		<TableHeadCell padding="p-0">Sender</TableHeadCell>
-		<TableHeadCell padding="p-0">Transaction Hash</TableHeadCell>
-		<TableHeadCell padding="p-0">Balance Change</TableHeadCell>
-		<TableHeadCell padding="p-0">Balance</TableHeadCell>
-		<TableHeadCell padding="p--">Type</TableHeadCell>
-	</svelte:fragment>
+<Heading tag="h5" class="mb-4 mt-6 font-normal">Vault balance changes</Heading>
 
-	<svelte:fragment slot="bodyRow" let:item>
-		<TableBodyCell tdClass="px-4 py-2" data-testid="vaultBalanceChangesTableDate">
-			{formatTimestampSecondsAsLocal(BigInt(item.timestamp))}
-		</TableBodyCell>
-		<TableBodyCell tdClass="break-all py-2 min-w-48" data-testid="vaultBalanceChangesTableFrom">
-			<Hash type={HashType.Wallet} value={item.transaction.from} />
-		</TableBodyCell>
-		<TableBodyCell tdClass="break-all py-2 min-w-48" data-testid="vaultBalanceChangesTableTx">
-			<Hash type={HashType.Transaction} value={item.transaction.id} />
-		</TableBodyCell>
-		<TableBodyCell
-			tdClass="break-word p-0 text-left"
-			data-testid="vaultBalanceChangesTableBalanceChange"
-		>
-			{`${item.formattedAmount} ${item.token.symbol}`}
-		</TableBodyCell>
-		<TableBodyCell tdClass="break-word p-0 text-left" data-testid="vaultBalanceChangesTableBalance">
-			{`${item.formattedNewBalance} ${item.token.symbol}`}
-		</TableBodyCell>
-		<TableBodyCell tdClass="break-word p-0 text-left" data-testid="vaultBalanceChangesTableType">
-			{item.type}
-		</TableBodyCell>
-	</svelte:fragment>
-</AppTable>
+{#if data?.length === 0}
+	<div data-testid="emptyMessage" class="text-center text-gray-900 dark:text-white">
+		No deposits or withdrawals found
+	</div>
+{:else if data}
+	<Table
+		divClass="cursor-pointer rounded-lg overflow-auto dark:border-none border"
+		hoverable={false}
+	>
+		<TableHead data-testid="head">
+			<TableHeadCell padding="p-4">Date</TableHeadCell>
+			<TableHeadCell padding="p-0">Sender</TableHeadCell>
+			<TableHeadCell padding="p-0">Transaction Hash</TableHeadCell>
+			<TableHeadCell padding="p-0">Balance Change</TableHeadCell>
+			<TableHeadCell padding="p-0">Balance</TableHeadCell>
+			<TableHeadCell padding="p--">Type</TableHeadCell>
+		</TableHead>
+		<TableBody>
+			{#each data as item}
+				<TableBodyRow class="whitespace-nowrap" data-testid="bodyRow">
+					<TableBodyCell tdClass="px-4 py-2" data-testid="vaultBalanceChangesTableDate">
+						{formatTimestampSecondsAsLocal(BigInt(item.timestamp))}
+					</TableBodyCell>
+					<TableBodyCell
+						tdClass="break-all py-2 min-w-48"
+						data-testid="vaultBalanceChangesTableFrom"
+					>
+						<Hash type={HashType.Wallet} value={item.transaction.from} />
+					</TableBodyCell>
+					<TableBodyCell tdClass="break-all py-2 min-w-48" data-testid="vaultBalanceChangesTableTx">
+						<Hash type={HashType.Transaction} value={item.transaction.id} />
+					</TableBodyCell>
+					<TableBodyCell
+						tdClass="break-word p-0 text-left"
+						data-testid="vaultBalanceChangesTableBalanceChange"
+					>
+						{`${item.formattedAmount} ${item.token.symbol}`}
+					</TableBodyCell>
+					<TableBodyCell
+						tdClass="break-word p-0 text-left"
+						data-testid="vaultBalanceChangesTableBalance"
+					>
+						{`${item.formattedNewBalance} ${item.token.symbol}`}
+					</TableBodyCell>
+					<TableBodyCell
+						tdClass="break-word p-0 text-left"
+						data-testid="vaultBalanceChangesTableType"
+					>
+						{item.type}
+					</TableBodyCell>
+				</TableBodyRow>
+			{/each}
+		</TableBody>
+	</Table>
+{/if}


### PR DESCRIPTION
## Motivation

The vault balance changes table on the vault details page was not loading any data. Both `VaultBalanceChart` and `VaultBalanceChangesTable` were independently calling `vault.getBalanceChanges(1)` simultaneously on mount, causing a race condition in the WASM layer where one call would return empty results while the other succeeded.

## Solution

Lift the balance changes data fetch into `VaultDetail` as a single `createQuery`, making it the single source of truth. Both child components become pure display components:

- **VaultBalanceChart** — receives the query as a prop instead of creating its own
- **VaultBalanceChangesTable** — receives the data array as a prop, renders directly without `createInfiniteQuery` or `TanstackAppTable`
- **VaultDetail** — owns the `createQuery` for balance changes, passes query to chart and data to table

This eliminates the concurrent WASM call and simplifies the component architecture.

## Checks

By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)