### PR TITLE
Add contract address field to MetaboardCfg

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6827,6 +6827,7 @@ dependencies = [
  "httpmock",
  "itertools 0.14.0",
  "rain-math-float",
+ "rain-metaboard-subgraph",
  "rain-metadata 0.0.2-alpha.6",
  "rain_orderbook_app_settings",
  "rain_orderbook_bindings",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -16,6 +16,7 @@ rain_orderbook_bindings = { workspace = true }
 rain_orderbook_common = { workspace = true }
 rain_orderbook_app_settings = { workspace = true }
 rain_orderbook_quote = { workspace = true }
+rain-metaboard-subgraph = { workspace = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 clap = { workspace = true }

--- a/crates/cli/src/commands/chart.rs
+++ b/crates/cli/src/commands/chart.rs
@@ -83,7 +83,9 @@ networks:
 subgraphs:
   flare: "https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/ob4-flare/2024-12-13-9dc7/gn"
 metaboards:
-  flare: "https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-flare-0x893BBFB7/0.1/gn"
+  flare:
+    url: "https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-flare-0x893BBFB7/0.1/gn"
+    address: 0x59401c9302e79eb8ac6aea659b8b3ae475715e86
 orderbooks:
   flare:
     address: {orderbook}

--- a/crates/cli/src/commands/words.rs
+++ b/crates/cli/src/commands/words.rs
@@ -153,9 +153,11 @@ impl Execute for Words {
                     .clone();
                 let metaboard_address =
                     resolve_metaboard_address(&dotrain_order, network_name, v).await?;
-                dotrain_order
-                    .orderbook_yaml()
-                    .set_metaboard(network_name, v, &metaboard_address)?;
+                dotrain_order.orderbook_yaml().set_metaboard(
+                    network_name,
+                    v,
+                    &metaboard_address,
+                )?;
             }
             if self.deployer_only {
                 match dotrain_order
@@ -202,9 +204,11 @@ impl Execute for Words {
                 let network_key = deployment.scenario.deployer.network.key.clone();
                 let metaboard_address =
                     resolve_metaboard_address(&dotrain_order, &network_key, v).await?;
-                dotrain_order
-                    .orderbook_yaml()
-                    .set_metaboard(&network_key, v, &metaboard_address)?;
+                dotrain_order.orderbook_yaml().set_metaboard(
+                    &network_key,
+                    v,
+                    &metaboard_address,
+                )?;
             }
             let result = dotrain_order.get_all_words_for_scenario(scenario).await?;
             let mut words = vec![];

--- a/crates/common/src/dotrain_order.rs
+++ b/crates/common/src/dotrain_order.rs
@@ -1479,7 +1479,9 @@ _ _: 0 0;
             bindings:
                 key1: 10
     metaboards:
-        sepolia: {metaboard_url}
+        sepolia:
+          url: {metaboard_url}
+          address: 0x59401c9302e79eb8ac6aea659b8b3ae475715e86
     ---
     #key1 !Test binding
     #calculate-io
@@ -1530,7 +1532,9 @@ _ _: 0 0;
             bindings:
                 key1: 10
     metaboards:
-        sepolia: {metaboard_url}
+        sepolia:
+          url: {metaboard_url}
+          address: 0x59401c9302e79eb8ac6aea659b8b3ae475715e86
     ---
     #key1 !Test binding
     #calculate-io
@@ -1586,7 +1590,9 @@ _ _: 0 0;
             bindings:
                 key1: 10
     metaboards:
-        sepolia: {metaboard_url}
+        sepolia:
+          url: {metaboard_url}
+          address: 0x59401c9302e79eb8ac6aea659b8b3ae475715e86
     ---
     #calculate-io
     using-words-from 0xbc609623F5020f6Fc7481024862cD5EE3FFf52D7
@@ -1642,7 +1648,9 @@ _ _: 0 0;
             bindings:
                 key1: 10
     metaboards:
-        sepolia: {metaboard_url}
+        sepolia:
+          url: {metaboard_url}
+          address: 0x59401c9302e79eb8ac6aea659b8b3ae475715e86
     ---
     #key1 !Test binding
     #calculate-io
@@ -1722,7 +1730,9 @@ _ _: 0 0;
             bindings:
                 key1: 40
     metaboards:
-        sepolia: {metaboard_url}
+        sepolia:
+          url: {metaboard_url}
+          address: 0x59401c9302e79eb8ac6aea659b8b3ae475715e86
     ---
     #key1 !Test binding
     #calculate-io

--- a/crates/common/src/raindex_client/mod.rs
+++ b/crates/common/src/raindex_client/mod.rs
@@ -542,8 +542,12 @@ subgraphs:
     mainnet: {subgraph1}
     polygon: {subgraph2}
 metaboards:
-    mainnet: https://api.thegraph.com/subgraphs/name/xyz
-    polygon: https://api.thegraph.com/subgraphs/name/polygon
+    mainnet:
+      url: https://api.thegraph.com/subgraphs/name/xyz
+      address: 0x59401c9302e79eb8ac6aea659b8b3ae475715e86
+    polygon:
+      url: https://api.thegraph.com/subgraphs/name/polygon
+      address: 0x59401c9302e79eb8ac6aea659b8b3ae475715e86
 orderbooks:
     mainnet-orderbook:
         address: 0x1234567890123456789012345678901234567890
@@ -611,7 +615,9 @@ networks:
 subgraphs:
     arbitrum: https://arb.subgraph
 metaboards:
-    arbitrum: https://arb.metaboard
+    arbitrum:
+      url: https://arb.metaboard
+      address: 0x59401c9302e79eb8ac6aea659b8b3ae475715e86
 orderbooks:
     arbitrum-orderbook:
         address: 0x2f209e5b67A33B8fE96E28f24628dF6Da301c8eB
@@ -845,7 +851,9 @@ accounts:
     subgraphs:
         test: https://test.subgraph
     metaboards:
-        test: https://test.metaboard
+        test:
+          url: https://test.metaboard
+          address: 0x59401c9302e79eb8ac6aea659b8b3ae475715e86
     tokens:
         test-token:
             network: isolated

--- a/crates/common/src/take_orders.rs
+++ b/crates/common/src/take_orders.rs
@@ -248,7 +248,9 @@ networks:
 subgraphs:
     test-sg: http://localhost:0/notused
 metaboards:
-    test-mb: http://localhost:0/notused
+    test-mb:
+      url: http://localhost:0/notused
+      address: 0x59401c9302e79eb8ac6aea659b8b3ae475715e86
 deployers:
     test-deployer:
         address: {deployer}

--- a/crates/common/src/test_helpers.rs
+++ b/crates/common/src/test_helpers.rs
@@ -17,8 +17,12 @@ subgraphs:
     mainnet: https://mainnet-subgraph.com
     testnet: https://testnet-subgraph.com
 metaboards:
-    mainnet: https://mainnet-metaboard.com
-    testnet: https://testnet-metaboard.com
+    mainnet:
+      url: https://mainnet-metaboard.com
+      address: 0x59401c9302e79eb8ac6aea659b8b3ae475715e86
+    testnet:
+      url: https://testnet-metaboard.com
+      address: 0x59401c9302e79eb8ac6aea659b8b3ae475715e86
 orderbooks:
     mainnet:
         address: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266

--- a/crates/js_api/src/gui/mod.rs
+++ b/crates/js_api/src/gui/mod.rs
@@ -931,7 +931,9 @@ networks:
 subgraphs:
     some-sg: https://www.some-sg.com
 metaboards:
-    test: https://metaboard.com
+    test:
+      url: https://metaboard.com
+      address: 0x59401c9302e79eb8ac6aea659b8b3ae475715e86
 deployers:
     some-deployer:
         network: some-network
@@ -1993,7 +1995,9 @@ gui:
 subgraphs:
     some-sg: https://www.some-sg.com
 metaboards:
-    test: https://metaboard.com
+    test:
+      url: https://metaboard.com
+      address: 0x59401c9302e79eb8ac6aea659b8b3ae475715e86
 deployers:
     some-deployer:
         network: some-network

--- a/crates/js_api/src/gui/select_tokens.rs
+++ b/crates/js_api/src/gui/select_tokens.rs
@@ -860,7 +860,9 @@ networks:
 subgraphs:
   some-sg: https://www.some-sg.com
 metaboards:
-  test: https://metaboard.com
+  test:
+    url: https://metaboard.com
+    address: 0x59401c9302e79eb8ac6aea659b8b3ae475715e86
 deployers:
   some-deployer:
     network: some-network

--- a/crates/js_api/src/gui/state_management.rs
+++ b/crates/js_api/src/gui/state_management.rs
@@ -555,7 +555,7 @@ mod tests {
     use std::str::FromStr;
     use wasm_bindgen_test::wasm_bindgen_test;
 
-    const SERIALIZED_STATE: &str = "H4sIAAAAAAAA_21QTWvCQBDdtaWl0JMUeir0B3TJJrE0K_TQQouQmoYivYrG1SSuuyGuX_FP-JMlOhsxOId5b_a9nRmmgY5xBzhM5CiRE2IjE1eANqV1k4PhgaKKGXIDqNWUS_dSt8vO8-oeqrmacSK5Xql8av49AcZaZ23LEioaiFjNdduj3quVZxFZ5GJbOnCZsRn91es8AG22_te7WsJNfAtyr9zh2cXXpvYDFzXQKc6WtasJNmO4rjqV6jD2ApR0fEbDwksL7-_jOx0m3da4Hyx-0uIzLH7f_DAWmyXPg4nqvj-aU3DBI00OTcmIZ0JtZlzqPZbVzufJAQAA";
+    const SERIALIZED_STATE: &str = "H4sIAAAAAAAA_21QXUvDMBRNpiiCT0PwSfAHGJq0E9OBj-JEmBNDFV-ktsHNpUltM_f1J_aTR7ebjpXdh3vOzTm593JbaBtngN8jnY70D2HIxREgo7Rp8jE8UFQzR04ArRlLHRzqdti5X51DVZpMEi3t1BRj9-8KcGht3vU8ZZJYDU1pu5zyW6_IEzIp1LJy4CpjN_pB9C6AtjvRbNVIuI1PQRbVDtcBPnb1cz9ALbSLvWVZPYGFIW6qfq36YXgD9CX67Bcf7zL7m_13fP77KtIvxhd5JMpYUMHfBj3D4sfB5O7p_tKdQiqZWLJpSlKZKzPPpLZr250X_ckBAAA=";
 
     fn encode_state(state: &SerializedGuiState) -> String {
         let bytes = bincode::serialize(state).unwrap();
@@ -698,7 +698,7 @@ mod tests {
     #[wasm_bindgen_test]
     async fn test_new_from_state_invalid_dotrain() {
         let dotrain = r#"
-            version: 4
+            version: 5
             networks:
                 test:
                     rpcs:

--- a/crates/js_api/src/gui/state_management.rs
+++ b/crates/js_api/src/gui/state_management.rs
@@ -555,7 +555,7 @@ mod tests {
     use std::str::FromStr;
     use wasm_bindgen_test::wasm_bindgen_test;
 
-    const SERIALIZED_STATE: &str = "H4sIAAAAAAAA_21Qy2rDMBCU0tJS6CkUeir0Ayos2S5YgR7bmjb4UEIOvQRHURJjRTLOmrx-Ip8cnEgOMdnDzo5mtLtsB53iweI405NMzwhDLm4sMkrbJh_bB4qayhV3FsHkUgfXul13XrJHy5ZmIYmWsDJl7v69WJwDFD3PU0akam6W0Ito9O6VhSBVqXa1A9cZu9Gfg_jJlt1wuN63Eu7ieysP6h1eA3zr-G8SoA46x8WyrJnAOMdt1W9Un_M3ZwQq6JDwUI03f6zaQtzPov80qfTPV5jqeDTVZb_4TiqRfzy7U0glBZBjUzKRhTKbhdRwAGw0tlzJAQAA";
+    const SERIALIZED_STATE: &str = "H4sIAAAAAAAA_21QTWvCQBDdtaWl0JMUeir0B3TJJrE0K_TQQouQmoYivYrG1SSuuyGuX_FP-JMlOhsxOId5b_a9nRmmgY5xBzhM5CiRE2IjE1eANqV1k4PhgaKKGXIDqNWUS_dSt8vO8-oeqrmacSK5Xql8av49AcZaZ23LEioaiFjNdduj3quVZxFZ5GJbOnCZsRn91es8AG22_te7WsJNfAtyr9zh2cXXpvYDFzXQKc6WtasJNmO4rjqV6jD2ApR0fEbDwksL7-_jOx0m3da4Hyx-0uIzLH7f_DAWmyXPg4nqvj-aU3DBI00OTcmIZ0JtZlzqPZbVzufJAQAA";
 
     fn encode_state(state: &SerializedGuiState) -> String {
         let bytes = bincode::serialize(state).unwrap();

--- a/crates/js_api/src/registry.rs
+++ b/crates/js_api/src/registry.rs
@@ -687,8 +687,12 @@ subgraphs:
   flare: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/ob4-flare/0.8/gn
   base: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/ob4-base/0.9/gn
 metaboards:
-  flare: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-flare-0x893BBFB7/0.1/gn
-  base: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-base-0x59401C93/0.1/gn
+  flare:
+    url: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-flare-0x893BBFB7/0.1/gn
+    address: 0x59401c9302e79eb8ac6aea659b8b3ae475715e86
+  base:
+    url: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-base-0x59401C93/0.1/gn
+    address: 0x59401c9302e79eb8ac6aea659b8b3ae475715e86
 orderbooks:
   flare:
     address: 0xCEe8Cd002F151A536394E564b84076c41bBBcD4d

--- a/crates/js_api/src/yaml/mod.rs
+++ b/crates/js_api/src/yaml/mod.rs
@@ -231,8 +231,12 @@ mod tests {
         mainnet: https://api.thegraph.com/subgraphs/name/xyz
         secondary: https://api.thegraph.com/subgraphs/name/abc
     metaboards:
-        board1: https://meta.example.com/board1
-        board2: https://meta.example.com/board2
+        board1:
+          url: https://meta.example.com/board1
+          address: 0x59401c9302e79eb8ac6aea659b8b3ae475715e86
+        board2:
+          url: https://meta.example.com/board2
+          address: 0x59401c9302e79eb8ac6aea659b8b3ae475715e86
     orderbooks:
         orderbook1:
             address: 0x0000000000000000000000000000000000000002

--- a/crates/js_api/src/yaml/mod.rs
+++ b/crates/js_api/src/yaml/mod.rs
@@ -35,7 +35,7 @@ impl OrderbookYaml {
     /// ```javascript
     /// // Basic usage with single YAML source
     /// const yamlConfig = `
-    /// version: "4"
+    /// version: "5"
     /// networks:
     ///   mainnet:
     ///     rpc: https://mainnet.infura.io

--- a/crates/settings/ARCHITECTURE.md
+++ b/crates/settings/ARCHITECTURE.md
@@ -145,8 +145,8 @@ All core configs implement `YamlParsableHash` unless noted, and each instance ca
 
 ### Metaboards (`metaboard.rs`)
 
-- `MetaboardCfg { key, url }` from `metaboards:` map of key → URL.
-- `add_record_to_yaml(document, key, url)` to append entries.
+- `MetaboardCfg { key, url, address }` from `metaboards:` map of key → `{ url, address }`.
+- `add_record_to_yaml(document, key, url, address)` to append entries.
 
 ### Spec Version and Sentry
 
@@ -334,7 +334,7 @@ When building for `wasm32`, many types derive `Tsify` and implement WASM trait h
   - `tokens: { key: { network, address, decimals?, label?, symbol? } }`
   - `subgraphs: { key: url }`
   - `orderbooks: { key: { address, network?, subgraph?, label?, deployment-block } }`
-  - `metaboards: { key: url }`
+  - `metaboards: { key: { url, address } }`
   - `deployers: { key: { address, network? } }`
   - `accounts: { key: address }`
   - `orders: { key: { inputs: [{ token, vault-id? }, ...], outputs: [...], deployer?, orderbook? } }`

--- a/crates/settings/src/spec_version.rs
+++ b/crates/settings/src/spec_version.rs
@@ -5,7 +5,7 @@ use strict_yaml_rust::StrictYaml;
 #[derive(Clone, Debug)]
 pub struct SpecVersion;
 
-pub const CURRENT_SPEC_VERSION: &str = "4";
+pub const CURRENT_SPEC_VERSION: &str = "5";
 
 impl SpecVersion {
     pub fn current() -> String {
@@ -90,13 +90,13 @@ mod tests {
 
     #[test]
     fn test_is_current() {
-        assert!(SpecVersion::is_current("4"));
+        assert!(SpecVersion::is_current("5"));
         assert!(!SpecVersion::is_current("1"));
     }
 
     #[test]
     fn test_current() {
-        assert_eq!(SpecVersion::current(), "4");
+        assert_eq!(SpecVersion::current(), "5");
     }
 
     #[test]

--- a/crates/settings/src/yaml/orderbook.rs
+++ b/crates/settings/src/yaml/orderbook.rs
@@ -377,8 +377,11 @@ impl OrderbookYaml {
         let context = self.build_context();
         MetaboardCfg::parse_from_yaml(self.documents.clone(), key, Some(&context))
     }
-    pub fn add_metaboard(&self, key: &str, value: &str) -> Result<(), YamlError> {
-        MetaboardCfg::add_record_to_yaml(self.documents[0].clone(), key, value)
+    pub fn add_metaboard(&self, key: &str, url: &str, address: &str) -> Result<(), YamlError> {
+        MetaboardCfg::add_record_to_yaml(self.documents[0].clone(), key, url, address)
+    }
+    pub fn set_metaboard(&self, key: &str, url: &str, address: &str) -> Result<(), YamlError> {
+        MetaboardCfg::set_record_to_yaml(self.documents[0].clone(), key, url, address)
     }
 
     pub fn get_deployer_keys(&self) -> Result<Vec<String>, YamlError> {
@@ -618,8 +621,12 @@ mod tests {
     local-db-remotes:
         mainnet: https://example.com/localdb/mainnet
     metaboards:
-        board1: https://meta.example.com/board1
-        board2: https://meta.example.com/board2
+        board1:
+            url: https://meta.example.com/board1
+            address: 0x1111111111111111111111111111111111111111
+        board2:
+            url: https://meta.example.com/board2
+            address: 0x2222222222222222222222222222222222222222
     orderbooks:
         orderbook1:
             address: 0x0000000000000000000000000000000000000002
@@ -657,7 +664,9 @@ mod tests {
     subgraphs:
         mainnet: https://api.thegraph.com/subgraphs/name/xyz
     metaboards:
-        board1: https://meta.example.com/board1
+        board1:
+            url: https://meta.example.com/board1
+            address: 0x1111111111111111111111111111111111111111
     orderbooks:
         orderbook1:
             address: 0x1234567890abcdef
@@ -754,8 +763,16 @@ mod tests {
             Url::parse("https://meta.example.com/board1").unwrap()
         );
         assert_eq!(
+            ob_yaml.get_metaboard("board1").unwrap().address,
+            Address::from_str("0x1111111111111111111111111111111111111111").unwrap()
+        );
+        assert_eq!(
             ob_yaml.get_metaboard("board2").unwrap().url,
             Url::parse("https://meta.example.com/board2").unwrap()
+        );
+        assert_eq!(
+            ob_yaml.get_metaboard("board2").unwrap().address,
+            Address::from_str("0x2222222222222222222222222222222222222222").unwrap()
         );
 
         assert_eq!(ob_yaml.get_deployer_keys().unwrap().len(), 1);
@@ -910,7 +927,11 @@ test: test
         let ob_yaml = OrderbookYaml::new(vec![yaml], OrderbookYamlValidation::default()).unwrap();
 
         ob_yaml
-            .add_metaboard("test-metaboard", "https://test-metaboard.com")
+            .add_metaboard(
+                "test-metaboard",
+                "https://test-metaboard.com",
+                "0x59401c9302e79eb8ac6aea659b8b3ae475715e86",
+            )
             .unwrap();
 
         assert_eq!(
@@ -920,6 +941,10 @@ test: test
         assert_eq!(
             ob_yaml.get_metaboard("test-metaboard").unwrap().url,
             Url::parse("https://test-metaboard.com").unwrap()
+        );
+        assert_eq!(
+            ob_yaml.get_metaboard("test-metaboard").unwrap().address,
+            Address::from_str("0x59401c9302e79eb8ac6aea659b8b3ae475715e86").unwrap()
         );
     }
 

--- a/packages/orderbook/README.md
+++ b/packages/orderbook/README.md
@@ -60,7 +60,9 @@ networks:
     currency: ETH
 
 metaboards:
-  base: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/metadata-base/2025-07-06-594f/gn
+  base:
+    url: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/metadata-base/2025-07-06-594f/gn
+    address: 0x59401c9302e79eb8ac6aea659b8b3ae475715e86
 
 subgraphs:
   base: https://example.com/subgraph

--- a/packages/orderbook/test/js_api/dotrainRegistry.test.ts
+++ b/packages/orderbook/test/js_api/dotrainRegistry.test.ts
@@ -32,8 +32,12 @@ subgraphs:
   flare: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/ob4-flare/0.8/gn
   base: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/ob4-base/0.9/gn
 metaboards:
-  flare: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-flare-0x893BBFB7/0.1/gn
-  base: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-base-0x59401C93/0.1/gn
+  flare:
+    url: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-flare-0x893BBFB7/0.1/gn
+    address: 0x59401c9302e79eb8ac6aea659b8b3ae475715e86
+  base:
+    url: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-base-0x59401C93/0.1/gn
+    address: 0x59401c9302e79eb8ac6aea659b8b3ae475715e86
 orderbooks:
   flare:
     address: 0xCEe8Cd002F151A536394E564b84076c41bBBcD4d

--- a/packages/orderbook/test/js_api/gui.test.ts
+++ b/packages/orderbook/test/js_api/gui.test.ts
@@ -152,8 +152,12 @@ networks:
 subgraphs:
     some-sg: https://www.some-sg.com
 metaboards:
-    test: http://localhost:8085/metaboard
-    some-network: http://localhost:8085/metaboard
+    test:
+      url: http://localhost:8085/metaboard
+      address: 0x59401c9302e79eb8ac6aea659b8b3ae475715e86
+    some-network:
+      url: http://localhost:8085/metaboard
+      address: 0x59401c9302e79eb8ac6aea659b8b3ae475715e86
 
 deployers:
     some-deployer:
@@ -232,8 +236,12 @@ networks:
 subgraphs:
     some-sg: https://www.some-sg.com
 metaboards:
-    test: http://localhost:8085/metaboard
-    some-network: http://localhost:8085/metaboard
+    test:
+      url: http://localhost:8085/metaboard
+      address: 0x59401c9302e79eb8ac6aea659b8b3ae475715e86
+    some-network:
+      url: http://localhost:8085/metaboard
+      address: 0x59401c9302e79eb8ac6aea659b8b3ae475715e86
 
 deployers:
     some-deployer:
@@ -305,7 +313,9 @@ networks:
 subgraphs:
     some-sg: https://www.some-sg.com
 metaboards:
-    test: http://localhost:8085/metaboard
+    test:
+      url: http://localhost:8085/metaboard
+      address: 0x59401c9302e79eb8ac6aea659b8b3ae475715e86
 
 deployers:
     some-deployer:
@@ -393,8 +403,12 @@ subgraphs:
     some-sg: https://www.some-sg.com
     other-sg: https://www.other-sg.com
 metaboards:
-    test: http://localhost:8085/metaboard
-    some-network: http://localhost:8085/metaboard
+    test:
+      url: http://localhost:8085/metaboard
+      address: 0x59401c9302e79eb8ac6aea659b8b3ae475715e86
+    some-network:
+      url: http://localhost:8085/metaboard
+      address: 0x59401c9302e79eb8ac6aea659b8b3ae475715e86
 deployers:
     some-deployer:
         network: remote-network
@@ -1020,7 +1034,7 @@ describe('Rain Orderbook JS API Package Bindgen Tests - Gui', async function () 
 
 	describe('state management tests', async () => {
 		let serializedState =
-			'H4sIAAAAAAAA_21QT0vDMBRvqiiIBxGvguDV2ixZwzbmQUScFPyDRcTb1sa1NEtKklXED-HRq19g-Am8evPziDcpJnVle4f8kvf7vV_ee8D5i02DmirtjTKeZHwMTA46G_NsOWRT6prMmmVETnnLsbFqMICHpCFBtWTFYAtCsMwMNV-2QSUm1ONUPwqZ27pdg6nWRc_3mYiHLBVK9zqwE_iyiL2pZM-VAlQnsF-fRoMdc33pf8_2v_qzj9fg_efORd3Ptxhsg3VDR1UPewjYsSPkuM5_NLdQ-xNCwMJYNYsxPrB2A1hkKinD68uzk6vb_GGEw252fxHj4zK8OZdJGBDVbuMxUUdbpkbolEovoQUTTxPK9S-tddtKygEAAA==';
+			'H4sIAAAAAAAA_21QwUoDMRBNVlEQDyJeBcGrcdOs2dZSbwoqrKIuYr2UdRvdpWmyTVKl-hEevfoDxS_w6s3vEW-ymKwu-g55k3lvJjOB4BuLlg3TBl3lop-LG2hzGCz8Vm8TPmaezcw5RQ6YaACHWcsUb4Y1C6ksM5YbGMP_mpH6zQ2o5ZAhwcydVANXt2o5M6Zo-z6XacIzqU27hVvUV0WKxoo_lA5YntA9vRfvr9jwsfMxXX_vTF-f6MvnhUe2355TuAznrRyXM6wR6NaOCfDAD-q_UPUPwxD-WatSgyDYsOFRczc5ibPoIMoT1cWjcxros3x0qItmF20pRq8vj3v3E3Xai3aWbI00GVOozwouJ0MmzBdWqK-OygEAAA==';
 		let dotrain3: string;
 		let gui: DotrainOrderGui;
 		beforeAll(async () => {
@@ -1917,7 +1931,7 @@ ${dotrainWithoutVaultIds}`;
 
 			const emitMetaCall = result.emitMetaCall;
 			assert.ok(emitMetaCall);
-			assert.equal(emitMetaCall?.to, '0x0000000000000000000000000000000000000000');
+			assert.equal(emitMetaCall?.to, '0x59401c9302e79eb8ac6aea659b8b3ae475715e86');
 			const decoded = decodeFunctionData({
 				abi: metaBoardAbi,
 				data: emitMetaCall!.calldata as `0x${string}`
@@ -1942,7 +1956,10 @@ ${dotrainWithoutVaultIds}`;
 
 			const emitMetaCallAfterUnset = result.emitMetaCall;
 			assert.ok(emitMetaCallAfterUnset);
-			assert.equal(emitMetaCallAfterUnset?.to, '0x0000000000000000000000000000000000000000');
+			assert.equal(
+				emitMetaCallAfterUnset?.to,
+				'0x59401c9302e79eb8ac6aea659b8b3ae475715e86'
+			);
 			const decodedAfterUnset = decodeFunctionData({
 				abi: metaBoardAbi,
 				data: emitMetaCallAfterUnset!.calldata as `0x${string}`

--- a/packages/orderbook/test/js_api/gui.test.ts
+++ b/packages/orderbook/test/js_api/gui.test.ts
@@ -1034,7 +1034,7 @@ describe('Rain Orderbook JS API Package Bindgen Tests - Gui', async function () 
 
 	describe('state management tests', async () => {
 		let serializedState =
-			'H4sIAAAAAAAA_21QwUoDMRBNVlEQDyJeBcGrcdOs2dZSbwoqrKIuYr2UdRvdpWmyTVKl-hEevfoDxS_w6s3vEW-ymKwu-g55k3lvJjOB4BuLlg3TBl3lop-LG2hzGCz8Vm8TPmaezcw5RQ6YaACHWcsUb4Y1C6ksM5YbGMP_mpH6zQ2o5ZAhwcydVANXt2o5M6Zo-z6XacIzqU27hVvUV0WKxoo_lA5YntA9vRfvr9jwsfMxXX_vTF-f6MvnhUe2355TuAznrRyXM6wR6NaOCfDAD-q_UPUPwxD-WatSgyDYsOFRczc5ibPoIMoT1cWjcxros3x0qItmF20pRq8vj3v3E3Xai3aWbI00GVOozwouJ0MmzBdWqK-OygEAAA==';
+			'H4sIAAAAAAAA_21Qu07DMBSNAwIJMSDEioTESojrPAhV2Siq1EpQZF5T1SSGVHFsk7igwkcwsvIDFV_Aysb3IDYUYYdG7Rl8ru859_peA-MP64olKaQVjlg8YndA5aCxNqs-DOmYmCqzohWeEtYwNJYVe3Dfr1lQZVlS3IAQLGqG6jc9YMEzYjEiH3me6rptxYmUomnblEdDmvBCNgMYeHYuImuc0-fSAcoT6KfbuLOlwpfW93T3qzX9ePXef65NdPj5FoFNsKpkXM6wg4BeGyPDNP5R_4Wqv-_7YG6tSnUcZ0-FJ4N73Anjg_QKtzO3FxanrtulVvcp7Pcuzs_E4LZ_KY4nTAY3RxuqhsuE5FZMBOWTjDD5C4W8JUfKAQAA';
 		let dotrain3: string;
 		let gui: DotrainOrderGui;
 		beforeAll(async () => {
@@ -1956,10 +1956,7 @@ ${dotrainWithoutVaultIds}`;
 
 			const emitMetaCallAfterUnset = result.emitMetaCall;
 			assert.ok(emitMetaCallAfterUnset);
-			assert.equal(
-				emitMetaCallAfterUnset?.to,
-				'0x59401c9302e79eb8ac6aea659b8b3ae475715e86'
-			);
+			assert.equal(emitMetaCallAfterUnset?.to, '0x59401c9302e79eb8ac6aea659b8b3ae475715e86');
 			const decodedAfterUnset = decodeFunctionData({
 				abi: metaBoardAbi,
 				data: emitMetaCallAfterUnset!.calldata as `0x${string}`

--- a/packages/orderbook/test/js_api/orderbookYaml.test.ts
+++ b/packages/orderbook/test/js_api/orderbookYaml.test.ts
@@ -20,7 +20,9 @@ subgraphs:
     some-sg: https://www.some-sg.com
 
 metaboards:
-    test: https://metaboard.com
+    test:
+      url: https://metaboard.com
+      address: 0x59401c9302e79eb8ac6aea659b8b3ae475715e86
 
 deployers:
     some-deployer:

--- a/packages/orderbook/test/js_api/raindexClient.test.ts
+++ b/packages/orderbook/test/js_api/raindexClient.test.ts
@@ -41,7 +41,9 @@ subgraphs:
     some-sg: http://localhost:8230/sg1
     other-sg: http://localhost:8230/sg2
 metaboards:
-    test: https://metaboard.com
+    test:
+      url: https://metaboard.com
+      address: 0x59401c9302e79eb8ac6aea659b8b3ae475715e86
 deployers:
     some-deployer:
         network: some-network

--- a/packages/ui-components/src/lib/__fixtures__/settings.yaml
+++ b/packages/ui-components/src/lib/__fixtures__/settings.yaml
@@ -47,15 +47,33 @@ subgraphs:
   linea: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/ob4-linea/2024-10-14-12fc/gn
   ethereum: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/metadata-mainnet/2024-10-25-2857/gn
 metaboards:
-  flare: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-flare-0x893BBFB7/0.1/gn
-  base: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-base-0x59401C93/0.1/gn
-  sepolia: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-sepolia-0x77991674/0.1/gn
-  polygon: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-polygon/0.1/gn
-  arbitrum: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-arbitrum/0.1/gn
-  matchain: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-polygon/0.1/gn
-  bsc: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-bsc/0.1/gn
-  linea: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-linea-0xed7d6156/1.0.0/gn
-  ethereum: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/metadata-mainnet/2024-10-25-2857/gn
+  flare:
+    url: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-flare-0x893BBFB7/0.1/gn
+    address: 0x59401c9302e79eb8ac6aea659b8b3ae475715e86
+  base:
+    url: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-base-0x59401C93/0.1/gn
+    address: 0x59401c9302e79eb8ac6aea659b8b3ae475715e86
+  sepolia:
+    url: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-sepolia-0x77991674/0.1/gn
+    address: 0x59401c9302e79eb8ac6aea659b8b3ae475715e86
+  polygon:
+    url: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-polygon/0.1/gn
+    address: 0x59401c9302e79eb8ac6aea659b8b3ae475715e86
+  arbitrum:
+    url: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-arbitrum/0.1/gn
+    address: 0x59401c9302e79eb8ac6aea659b8b3ae475715e86
+  matchain:
+    url: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-polygon/0.1/gn
+    address: 0x59401c9302e79eb8ac6aea659b8b3ae475715e86
+  bsc:
+    url: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-bsc/0.1/gn
+    address: 0x59401c9302e79eb8ac6aea659b8b3ae475715e86
+  linea:
+    url: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-linea-0xed7d6156/1.0.0/gn
+    address: 0x59401c9302e79eb8ac6aea659b8b3ae475715e86
+  ethereum:
+    url: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/metadata-mainnet/2024-10-25-2857/gn
+    address: 0x59401c9302e79eb8ac6aea659b8b3ae475715e86
 orderbooks:
   flare:
     address: 0xCEe8Cd002F151A536394E564b84076c41bBBcD4d

--- a/packages/webapp/src/lib/constants.ts
+++ b/packages/webapp/src/lib/constants.ts
@@ -1,2 +1,2 @@
 export const REGISTRY_URL =
-	'https://raw.githubusercontent.com/rainlanguage/rain.strategies/e7e60182eb4cc350ec59be41f33588af7967e7e2/registry';
+	'https://raw.githubusercontent.com/rainlanguage/rain.strategies/3f42f173b366cf0de8a62d4af2698b35ac769339/registry';


### PR DESCRIPTION
## Dependent PRs
- https://github.com/rainlanguage/rain.strategies/pull/84

## Motivation

See issues:
- https://github.com/rainlanguage/rain.orderbook/issues/2444

The metaboard config previously only stored a subgraph URL. The sync pipeline and GUI need to know the on-chain metaboard contract address to index events and emit meta calls. Previously, the GUI had to make an extra subgraph query at runtime to resolve the metaboard address, which was fragile and unnecessary when the address can be provided upfront in configuration.

## Solution

- Added a required `address` field (`Address` type) to `MetaboardCfg` in the settings crate. The YAML format changes from `metaboards: { key: url }` to `metaboards: { key: { url, address } }`.
- Added `set_record_to_yaml` for upsert semantics alongside the existing `add_record_to_yaml`.
- Bumped spec version from 4 to 5 to reflect the breaking config change.
- Refactored the GUI's `order_operations.rs` to read the metaboard address directly from config (`get_metaboard_cfg`) instead of querying the subgraph at runtime.
- Updated the CLI `words` command to resolve the metaboard address — first from config, then falling back to a subgraph query — when a metaboard URL is passed via CLI flag.
- Updated the strategies registry URL to point to the commit from the dependent PR.
- Updated all YAML fixtures and tests across `settings`, `common`, `js_api`, `orderbook`, `ui-components`, and `webapp` to the new metaboard format.

## Checks

By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)

fix https://github.com/rainlanguage/rain.orderbook/issues/2444

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Metaboards now include an explicit on‑chain address alongside URLs.
  * Automatic metaboard address resolution via subgraph when not defined in the orderbook.

* **Documentation**
  * Spec version bumped to 5.
  * Metaboards configuration examples and architecture docs updated to show url+address shape.

* **Chores**
  * Updated registry source reference.
  * Added workspace dependency for metaboard subgraph integration.

* **Tests**
  * Updated test fixtures and expectations to the new metaboard structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->