### PR TITLE
Add get trades by owner API

### DIFF
--- a/crates/common/src/local_db/query/fetch_owner_trades/mod.rs
+++ b/crates/common/src/local_db/query/fetch_owner_trades/mod.rs
@@ -1,0 +1,66 @@
+use crate::local_db::{
+    query::{SqlBuildError, SqlStatement, SqlValue},
+    OrderbookIdentifier,
+};
+use alloy::primitives::Address;
+
+const QUERY_TEMPLATE: &str = include_str!("query.sql");
+const DEFAULT_PAGE_SIZE: u16 = 100;
+
+pub fn build_fetch_owner_trades_stmt(
+    ob_id: &OrderbookIdentifier,
+    owner: Address,
+    page: Option<u16>,
+) -> Result<SqlStatement, SqlBuildError> {
+    let mut stmt = SqlStatement::new(QUERY_TEMPLATE);
+    stmt.push(SqlValue::from(ob_id.chain_id));
+    stmt.push(SqlValue::from(ob_id.orderbook_address));
+    stmt.push(SqlValue::from(owner));
+
+    let page_num = page.unwrap_or(1).max(1);
+    let limit = DEFAULT_PAGE_SIZE as i64;
+    let offset = (page_num as i64 - 1) * limit;
+    stmt.push(SqlValue::I64(limit));
+    stmt.push(SqlValue::I64(offset));
+
+    Ok(stmt)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::primitives::Address;
+
+    #[test]
+    fn builds_with_default_page() {
+        let owner = Address::repeat_byte(0xaa);
+        let stmt = build_fetch_owner_trades_stmt(
+            &OrderbookIdentifier::new(42161, Address::ZERO),
+            owner,
+            None,
+        )
+        .unwrap();
+        assert_eq!(stmt.params.len(), 5);
+        assert_eq!(stmt.params[0], SqlValue::U64(42161));
+        assert_eq!(stmt.params[1], SqlValue::Text(Address::ZERO.to_string()));
+        assert!(
+            matches!(&stmt.params[2], SqlValue::Text(s) if s.to_lowercase() == owner.to_string().to_lowercase())
+        );
+        assert_eq!(stmt.params[3], SqlValue::I64(100));
+        assert_eq!(stmt.params[4], SqlValue::I64(0));
+    }
+
+    #[test]
+    fn builds_with_page_2() {
+        let owner = Address::repeat_byte(0xbb);
+        let stmt = build_fetch_owner_trades_stmt(
+            &OrderbookIdentifier::new(1, Address::ZERO),
+            owner,
+            Some(2),
+        )
+        .unwrap();
+        assert_eq!(stmt.params.len(), 5);
+        assert_eq!(stmt.params[3], SqlValue::I64(100));
+        assert_eq!(stmt.params[4], SqlValue::I64(100));
+    }
+}

--- a/crates/common/src/local_db/query/fetch_owner_trades/mod.rs
+++ b/crates/common/src/local_db/query/fetch_owner_trades/mod.rs
@@ -2,23 +2,53 @@ use crate::local_db::{
     query::{SqlBuildError, SqlStatement, SqlValue},
     OrderbookIdentifier,
 };
+use crate::raindex_client::types::{PaginationParams, TimeFilter};
 use alloy::primitives::Address;
 
 const QUERY_TEMPLATE: &str = include_str!("query.sql");
 const DEFAULT_PAGE_SIZE: u16 = 100;
 
+const START_TS_CLAUSE: &str = "/*START_TS_CLAUSE*/";
+const START_TS_BODY: &str = "\nAND tws.block_timestamp >= {param}\n";
+const END_TS_CLAUSE: &str = "/*END_TS_CLAUSE*/";
+const END_TS_BODY: &str = "\nAND tws.block_timestamp <= {param}\n";
+
 pub fn build_fetch_owner_trades_stmt(
     ob_id: &OrderbookIdentifier,
     owner: Address,
-    page: Option<u16>,
+    pagination: &PaginationParams,
+    time_filter: &TimeFilter,
 ) -> Result<SqlStatement, SqlBuildError> {
     let mut stmt = SqlStatement::new(QUERY_TEMPLATE);
     stmt.push(SqlValue::from(ob_id.chain_id));
     stmt.push(SqlValue::from(ob_id.orderbook_address));
     stmt.push(SqlValue::from(owner));
 
-    let page_num = page.unwrap_or(1).max(1);
-    let limit = DEFAULT_PAGE_SIZE as i64;
+    let start_param = if let Some(v) = time_filter.start {
+        let i = i64::try_from(v).map_err(|e| {
+            SqlBuildError::new(format!(
+                "start_timestamp out of range for i64: {} ({})",
+                v, e
+            ))
+        })?;
+        Some(SqlValue::I64(i))
+    } else {
+        None
+    };
+    stmt.bind_param_clause(START_TS_CLAUSE, START_TS_BODY, start_param)?;
+
+    let end_param = if let Some(v) = time_filter.end {
+        let i = i64::try_from(v).map_err(|e| {
+            SqlBuildError::new(format!("end_timestamp out of range for i64: {} ({})", v, e))
+        })?;
+        Some(SqlValue::I64(i))
+    } else {
+        None
+    };
+    stmt.bind_param_clause(END_TS_CLAUSE, END_TS_BODY, end_param)?;
+
+    let page_num = pagination.page.unwrap_or(1).max(1);
+    let limit = pagination.page_size.unwrap_or(DEFAULT_PAGE_SIZE) as i64;
     let offset = (page_num as i64 - 1) * limit;
     stmt.push(SqlValue::I64(limit));
     stmt.push(SqlValue::I64(offset));
@@ -37,7 +67,8 @@ mod tests {
         let stmt = build_fetch_owner_trades_stmt(
             &OrderbookIdentifier::new(42161, Address::ZERO),
             owner,
-            None,
+            &PaginationParams::default(),
+            &TimeFilter::default(),
         )
         .unwrap();
         assert_eq!(stmt.params.len(), 5);
@@ -48,6 +79,10 @@ mod tests {
         );
         assert_eq!(stmt.params[3], SqlValue::I64(100));
         assert_eq!(stmt.params[4], SqlValue::I64(0));
+        assert!(!stmt.sql.contains("tws.block_timestamp >="));
+        assert!(!stmt.sql.contains("tws.block_timestamp <="));
+        assert!(!stmt.sql.contains(START_TS_CLAUSE));
+        assert!(!stmt.sql.contains(END_TS_CLAUSE));
     }
 
     #[test]
@@ -56,11 +91,61 @@ mod tests {
         let stmt = build_fetch_owner_trades_stmt(
             &OrderbookIdentifier::new(1, Address::ZERO),
             owner,
-            Some(2),
+            &PaginationParams {
+                page: Some(2),
+                ..Default::default()
+            },
+            &TimeFilter::default(),
         )
         .unwrap();
         assert_eq!(stmt.params.len(), 5);
         assert_eq!(stmt.params[3], SqlValue::I64(100));
         assert_eq!(stmt.params[4], SqlValue::I64(100));
+    }
+
+    #[test]
+    fn builds_with_custom_page_size() {
+        let owner = Address::repeat_byte(0xcc);
+        let stmt = build_fetch_owner_trades_stmt(
+            &OrderbookIdentifier::new(42161, Address::ZERO),
+            owner,
+            &PaginationParams {
+                page: Some(1),
+                page_size: Some(50),
+            },
+            &TimeFilter::default(),
+        )
+        .unwrap();
+        assert_eq!(stmt.params.len(), 5);
+        assert_eq!(stmt.params[3], SqlValue::I64(50));
+        assert_eq!(stmt.params[4], SqlValue::I64(0));
+    }
+
+    #[test]
+    fn builds_with_time_filters() {
+        let owner = Address::repeat_byte(0xdd);
+        let stmt = build_fetch_owner_trades_stmt(
+            &OrderbookIdentifier::new(137, Address::ZERO),
+            owner,
+            &PaginationParams {
+                page: Some(1),
+                ..Default::default()
+            },
+            &TimeFilter {
+                start: Some(1000),
+                end: Some(2000),
+            },
+        )
+        .unwrap();
+        assert!(!stmt.sql.contains(START_TS_CLAUSE));
+        assert!(!stmt.sql.contains(END_TS_CLAUSE));
+        assert!(stmt.sql.contains("tws.block_timestamp >="));
+        assert!(stmt.sql.contains("tws.block_timestamp <="));
+        assert_eq!(stmt.params.len(), 7);
+        assert_eq!(stmt.params[0], SqlValue::U64(137));
+        assert_eq!(stmt.params[1], SqlValue::Text(Address::ZERO.to_string()));
+        assert!(
+            matches!(&stmt.params[2], SqlValue::Text(s) if s.to_lowercase() == owner.to_string().to_lowercase())
+        );
     }
 }

--- a/crates/common/src/local_db/query/fetch_owner_trades/query.sql
+++ b/crates/common/src/local_db/query/fetch_owner_trades/query.sql
@@ -344,5 +344,8 @@ LEFT JOIN erc20_tokens tok_out
   ON tok_out.chain_id = tws.chain_id
  AND tok_out.orderbook_address = tws.orderbook_address
  AND tok_out.token_address = tws.output_token
+WHERE 1 = 1
+/*START_TS_CLAUSE*/
+/*END_TS_CLAUSE*/
 ORDER BY tws.block_timestamp DESC, tws.block_number DESC, tws.log_index DESC, tws.trade_kind
 LIMIT ?4 OFFSET ?5;

--- a/crates/common/src/local_db/query/fetch_owner_trades/query.sql
+++ b/crates/common/src/local_db/query/fetch_owner_trades/query.sql
@@ -1,0 +1,348 @@
+WITH
+params AS (
+  SELECT
+    ?1 AS chain_id,
+    ?2 AS orderbook_address,
+    ?3 AS owner
+),
+order_add_events AS (
+  SELECT
+    oe.chain_id,
+    oe.orderbook_address,
+    oe.transaction_hash,
+    oe.log_index,
+    oe.block_number,
+    oe.block_timestamp,
+    oe.order_owner,
+    oe.order_nonce,
+    oe.order_hash
+  FROM order_events oe
+  JOIN params p
+    ON oe.chain_id = p.chain_id
+   AND oe.orderbook_address = p.orderbook_address
+   AND oe.order_owner = p.owner
+  WHERE oe.event_type = 'AddOrderV3'
+),
+take_trades AS (
+  SELECT
+    'take' AS trade_kind,
+    t.chain_id,
+    t.orderbook_address,
+    oe.order_hash,
+    t.order_owner,
+    t.order_nonce,
+    t.transaction_hash,
+    t.log_index,
+    t.block_number,
+    t.block_timestamp,
+    t.sender AS transaction_sender,
+    io_in.vault_id AS input_vault_id,
+    io_in.token AS input_token,
+    t.taker_output AS input_delta,
+    io_out.vault_id AS output_vault_id,
+    io_out.token AS output_token,
+    FLOAT_NEGATE(t.taker_input) AS output_delta
+  FROM take_orders t
+  JOIN params p
+    ON t.chain_id = p.chain_id
+   AND t.orderbook_address = p.orderbook_address
+   AND t.order_owner = p.owner
+  JOIN order_add_events oe
+    ON oe.chain_id = t.chain_id
+   AND oe.orderbook_address = t.orderbook_address
+   AND oe.order_owner = t.order_owner
+   AND oe.order_nonce = t.order_nonce
+   AND (
+        oe.block_number < t.block_number
+     OR (oe.block_number = t.block_number AND oe.log_index <= t.log_index)
+   )
+   AND NOT EXISTS (
+     SELECT 1
+     FROM order_add_events newer
+     WHERE newer.chain_id = oe.chain_id
+      AND newer.orderbook_address = oe.orderbook_address
+      AND newer.order_owner = oe.order_owner
+       AND newer.order_nonce = oe.order_nonce
+       AND (
+            newer.block_number < t.block_number
+         OR (newer.block_number = t.block_number AND newer.log_index <= t.log_index)
+       )
+       AND (
+            newer.block_number > oe.block_number
+         OR (newer.block_number = oe.block_number AND newer.log_index > oe.log_index)
+       )
+   )
+  JOIN order_ios io_in
+    ON io_in.chain_id = oe.chain_id
+   AND io_in.orderbook_address = oe.orderbook_address
+   AND io_in.transaction_hash = oe.transaction_hash
+   AND io_in.log_index = oe.log_index
+   AND io_in.io_index = t.input_io_index
+   AND io_in.io_type = 'input'
+  JOIN order_ios io_out
+    ON io_out.chain_id = oe.chain_id
+   AND io_out.orderbook_address = oe.orderbook_address
+   AND io_out.transaction_hash = oe.transaction_hash
+   AND io_out.log_index = oe.log_index
+   AND io_out.io_index = t.output_io_index
+   AND io_out.io_type = 'output'
+),
+clear_alice AS (
+  SELECT DISTINCT
+    'clear' AS trade_kind,
+    c.chain_id,
+    c.orderbook_address,
+    oe.order_hash,
+    oe.order_owner,
+    oe.order_nonce,
+    c.transaction_hash,
+    c.log_index,
+    c.block_number,
+    c.block_timestamp,
+    c.sender AS transaction_sender,
+    c.alice_input_vault_id AS input_vault_id,
+    io_in.token AS input_token,
+    a.alice_input AS input_delta,
+    c.alice_output_vault_id AS output_vault_id,
+    io_out.token AS output_token,
+    FLOAT_NEGATE(a.alice_output) AS output_delta
+  FROM clear_v3_events c
+  JOIN params p
+    ON c.chain_id = p.chain_id
+   AND c.orderbook_address = p.orderbook_address
+  JOIN order_add_events oe
+    ON oe.chain_id = c.chain_id
+   AND oe.orderbook_address = c.orderbook_address
+   AND oe.order_hash = c.alice_order_hash
+   AND oe.order_owner = p.owner
+   AND (
+        oe.block_number < c.block_number
+     OR (oe.block_number = c.block_number AND oe.log_index <= c.log_index)
+   )
+   AND NOT EXISTS (
+     SELECT 1
+     FROM order_add_events newer
+     WHERE newer.chain_id = oe.chain_id
+      AND newer.orderbook_address = oe.orderbook_address
+      AND newer.order_hash = oe.order_hash
+       AND (
+            newer.block_number < c.block_number
+         OR (newer.block_number = c.block_number AND newer.log_index <= c.log_index)
+       )
+       AND (
+            newer.block_number > oe.block_number
+         OR (newer.block_number = oe.block_number AND newer.log_index > oe.log_index)
+       )
+   )
+  JOIN after_clear_v2_events a
+    ON a.chain_id = c.chain_id
+   AND a.orderbook_address = c.orderbook_address
+   AND a.transaction_hash = c.transaction_hash
+   AND a.log_index = (
+       SELECT MIN(ac.log_index)
+       FROM after_clear_v2_events ac
+       WHERE ac.chain_id = c.chain_id
+         AND ac.orderbook_address = c.orderbook_address
+         AND ac.transaction_hash = c.transaction_hash
+         AND ac.log_index > c.log_index
+   )
+  JOIN order_ios io_in
+    ON io_in.chain_id = oe.chain_id
+   AND io_in.orderbook_address = oe.orderbook_address
+   AND io_in.transaction_hash = oe.transaction_hash
+   AND io_in.log_index = oe.log_index
+   AND io_in.io_index = c.alice_input_io_index
+   AND io_in.io_type = 'input'
+  JOIN order_ios io_out
+    ON io_out.chain_id = oe.chain_id
+   AND io_out.orderbook_address = oe.orderbook_address
+   AND io_out.transaction_hash = oe.transaction_hash
+   AND io_out.log_index = oe.log_index
+   AND io_out.io_index = c.alice_output_io_index
+   AND io_out.io_type = 'output'
+),
+clear_bob AS (
+  SELECT DISTINCT
+    'clear' AS trade_kind,
+    c.chain_id,
+    c.orderbook_address,
+    oe.order_hash,
+    oe.order_owner,
+    oe.order_nonce,
+    c.transaction_hash,
+    c.log_index,
+    c.block_number,
+    c.block_timestamp,
+    c.sender AS transaction_sender,
+    c.bob_input_vault_id AS input_vault_id,
+    io_in.token AS input_token,
+    a.bob_input AS input_delta,
+    c.bob_output_vault_id AS output_vault_id,
+    io_out.token AS output_token,
+    FLOAT_NEGATE(a.bob_output) AS output_delta
+  FROM clear_v3_events c
+  JOIN params p
+    ON c.chain_id = p.chain_id
+   AND c.orderbook_address = p.orderbook_address
+  JOIN order_add_events oe
+    ON oe.chain_id = c.chain_id
+   AND oe.orderbook_address = c.orderbook_address
+   AND oe.order_hash = c.bob_order_hash
+   AND oe.order_owner = p.owner
+   AND (
+        oe.block_number < c.block_number
+     OR (oe.block_number = c.block_number AND oe.log_index <= c.log_index)
+   )
+   AND NOT EXISTS (
+     SELECT 1
+     FROM order_add_events newer
+     WHERE newer.chain_id = oe.chain_id
+      AND newer.orderbook_address = oe.orderbook_address
+      AND newer.order_hash = oe.order_hash
+       AND (
+            newer.block_number < c.block_number
+         OR (newer.block_number = c.block_number AND newer.log_index <= c.log_index)
+       )
+       AND (
+            newer.block_number > oe.block_number
+         OR (newer.block_number = oe.block_number AND newer.log_index > oe.log_index)
+       )
+   )
+  JOIN after_clear_v2_events a
+    ON a.chain_id = c.chain_id
+   AND a.orderbook_address = c.orderbook_address
+   AND a.transaction_hash = c.transaction_hash
+   AND a.log_index = (
+       SELECT MIN(ac.log_index)
+       FROM after_clear_v2_events ac
+       WHERE ac.chain_id = c.chain_id
+         AND ac.orderbook_address = c.orderbook_address
+         AND ac.transaction_hash = c.transaction_hash
+         AND ac.log_index > c.log_index
+   )
+  JOIN order_ios io_in
+    ON io_in.chain_id = oe.chain_id
+   AND io_in.orderbook_address = oe.orderbook_address
+   AND io_in.transaction_hash = oe.transaction_hash
+   AND io_in.log_index = oe.log_index
+   AND io_in.io_index = c.bob_input_io_index
+   AND io_in.io_type = 'input'
+  JOIN order_ios io_out
+    ON io_out.chain_id = oe.chain_id
+   AND io_out.orderbook_address = oe.orderbook_address
+   AND io_out.transaction_hash = oe.transaction_hash
+   AND io_out.log_index = oe.log_index
+   AND io_out.io_index = c.bob_output_io_index
+   AND io_out.io_type = 'output'
+),
+clear_trades AS (
+  SELECT * FROM clear_alice
+  UNION ALL
+  SELECT * FROM clear_bob
+),
+unioned_trades AS (
+  SELECT * FROM take_trades
+  UNION ALL
+  SELECT * FROM clear_trades
+),
+trade_rows AS (
+  SELECT
+    ut.trade_kind,
+    ut.chain_id,
+    ut.orderbook_address,
+    ut.order_hash,
+    ut.order_owner,
+    ut.order_nonce,
+    ut.transaction_hash,
+    ut.log_index,
+    ut.block_number,
+    ut.block_timestamp,
+    ut.transaction_sender,
+    ut.input_vault_id,
+    ut.input_token,
+    ut.input_delta,
+    ut.output_vault_id,
+    ut.output_token,
+    ut.output_delta
+  FROM unioned_trades ut
+),
+trade_with_snapshots AS (
+  SELECT
+    tr.*,
+    mvb_in.balance AS input_base_balance,
+    mvb_in.last_block AS input_base_block,
+    mvb_in.last_log_index AS input_base_log_index,
+    mvb_out.balance AS output_base_balance,
+    mvb_out.last_block AS output_base_block,
+    mvb_out.last_log_index AS output_base_log_index
+  FROM trade_rows tr
+  LEFT JOIN running_vault_balances mvb_in
+    ON mvb_in.chain_id = tr.chain_id
+   AND mvb_in.orderbook_address = tr.orderbook_address
+   AND mvb_in.owner = tr.order_owner
+   AND mvb_in.token = tr.input_token
+   AND mvb_in.vault_id = tr.input_vault_id
+  LEFT JOIN running_vault_balances mvb_out
+    ON mvb_out.chain_id = tr.chain_id
+   AND mvb_out.orderbook_address = tr.orderbook_address
+   AND mvb_out.owner = tr.order_owner
+   AND mvb_out.token = tr.output_token
+   AND mvb_out.vault_id = tr.output_vault_id
+)
+SELECT
+  tws.trade_kind,
+  tws.orderbook_address AS orderbook,
+  tws.order_hash,
+  tws.order_owner,
+  tws.order_nonce,
+  tws.transaction_hash,
+  tws.log_index,
+  tws.block_number,
+  tws.block_timestamp,
+  tws.transaction_sender,
+  tws.input_vault_id,
+  tws.input_token,
+  tok_in.name AS input_token_name,
+  tok_in.symbol AS input_token_symbol,
+  tok_in.decimals AS input_token_decimals,
+  tws.input_delta,
+  vbc_input.running_balance AS input_running_balance,
+  tws.output_vault_id,
+  tws.output_token,
+  tok_out.name AS output_token_name,
+  tok_out.symbol AS output_token_symbol,
+  tok_out.decimals AS output_token_decimals,
+  tws.output_delta,
+  vbc_output.running_balance AS output_running_balance,
+  (
+    '0x' ||
+    lower(replace(tws.transaction_hash, '0x', '')) ||
+    printf('%016x', tws.log_index)
+  ) AS trade_id
+FROM trade_with_snapshots tws
+LEFT JOIN vault_balance_changes vbc_input
+  ON vbc_input.chain_id = tws.chain_id
+ AND vbc_input.orderbook_address = tws.orderbook_address
+ AND vbc_input.owner = tws.order_owner
+ AND vbc_input.token = tws.input_token
+ AND vbc_input.vault_id = tws.input_vault_id
+ AND vbc_input.block_number = tws.block_number
+ AND vbc_input.log_index = tws.log_index
+LEFT JOIN vault_balance_changes vbc_output
+  ON vbc_output.chain_id = tws.chain_id
+ AND vbc_output.orderbook_address = tws.orderbook_address
+ AND vbc_output.owner = tws.order_owner
+ AND vbc_output.token = tws.output_token
+ AND vbc_output.vault_id = tws.output_vault_id
+ AND vbc_output.block_number = tws.block_number
+ AND vbc_output.log_index = tws.log_index
+LEFT JOIN erc20_tokens tok_in
+  ON tok_in.chain_id = tws.chain_id
+ AND tok_in.orderbook_address = tws.orderbook_address
+ AND tok_in.token_address = tws.input_token
+LEFT JOIN erc20_tokens tok_out
+  ON tok_out.chain_id = tws.chain_id
+ AND tok_out.orderbook_address = tws.orderbook_address
+ AND tok_out.token_address = tws.output_token
+ORDER BY tws.block_timestamp DESC, tws.block_number DESC, tws.log_index DESC, tws.trade_kind
+LIMIT ?4 OFFSET ?5;

--- a/crates/common/src/local_db/query/fetch_owner_trades_count/mod.rs
+++ b/crates/common/src/local_db/query/fetch_owner_trades_count/mod.rs
@@ -1,0 +1,44 @@
+use crate::local_db::{
+    query::{SqlBuildError, SqlStatement, SqlValue},
+    OrderbookIdentifier,
+};
+use alloy::primitives::Address;
+
+const QUERY_TEMPLATE: &str = include_str!("query.sql");
+
+pub use crate::local_db::query::fetch_order_trades_count::{
+    extract_trade_count, LocalDbTradeCountRow,
+};
+
+pub fn build_fetch_owner_trades_count_stmt(
+    ob_id: &OrderbookIdentifier,
+    owner: Address,
+) -> Result<SqlStatement, SqlBuildError> {
+    let mut stmt = SqlStatement::new(QUERY_TEMPLATE);
+    stmt.push(SqlValue::from(ob_id.chain_id));
+    stmt.push(SqlValue::from(ob_id.orderbook_address));
+    stmt.push(SqlValue::from(owner));
+    Ok(stmt)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::primitives::Address;
+
+    #[test]
+    fn builds_stmt() {
+        let owner = Address::repeat_byte(0xcc);
+        let stmt = build_fetch_owner_trades_count_stmt(
+            &OrderbookIdentifier::new(42161, Address::ZERO),
+            owner,
+        )
+        .unwrap();
+        assert_eq!(stmt.params.len(), 3);
+        assert_eq!(stmt.params[0], SqlValue::U64(42161));
+        assert_eq!(stmt.params[1], SqlValue::Text(Address::ZERO.to_string()));
+        assert!(
+            matches!(&stmt.params[2], SqlValue::Text(s) if s.to_lowercase() == owner.to_string().to_lowercase())
+        );
+    }
+}

--- a/crates/common/src/local_db/query/fetch_owner_trades_count/mod.rs
+++ b/crates/common/src/local_db/query/fetch_owner_trades_count/mod.rs
@@ -2,6 +2,7 @@ use crate::local_db::{
     query::{SqlBuildError, SqlStatement, SqlValue},
     OrderbookIdentifier,
 };
+use crate::raindex_client::types::TimeFilter;
 use alloy::primitives::Address;
 
 const QUERY_TEMPLATE: &str = include_str!("query.sql");
@@ -10,14 +11,44 @@ pub use crate::local_db::query::fetch_order_trades_count::{
     extract_trade_count, LocalDbTradeCountRow,
 };
 
+const START_TS_CLAUSE: &str = "/*START_TS_CLAUSE*/";
+const START_TS_BODY: &str = "\nAND block_timestamp >= {param}\n";
+const END_TS_CLAUSE: &str = "/*END_TS_CLAUSE*/";
+const END_TS_BODY: &str = "\nAND block_timestamp <= {param}\n";
+
 pub fn build_fetch_owner_trades_count_stmt(
     ob_id: &OrderbookIdentifier,
     owner: Address,
+    time_filter: &TimeFilter,
 ) -> Result<SqlStatement, SqlBuildError> {
     let mut stmt = SqlStatement::new(QUERY_TEMPLATE);
     stmt.push(SqlValue::from(ob_id.chain_id));
     stmt.push(SqlValue::from(ob_id.orderbook_address));
     stmt.push(SqlValue::from(owner));
+
+    let start_param = if let Some(v) = time_filter.start {
+        let i = i64::try_from(v).map_err(|e| {
+            SqlBuildError::new(format!(
+                "start_timestamp out of range for i64: {} ({})",
+                v, e
+            ))
+        })?;
+        Some(SqlValue::I64(i))
+    } else {
+        None
+    };
+    stmt.bind_param_clause(START_TS_CLAUSE, START_TS_BODY, start_param)?;
+
+    let end_param = if let Some(v) = time_filter.end {
+        let i = i64::try_from(v).map_err(|e| {
+            SqlBuildError::new(format!("end_timestamp out of range for i64: {} ({})", v, e))
+        })?;
+        Some(SqlValue::I64(i))
+    } else {
+        None
+    };
+    stmt.bind_param_clause(END_TS_CLAUSE, END_TS_BODY, end_param)?;
+
     Ok(stmt)
 }
 
@@ -27,15 +58,44 @@ mod tests {
     use alloy::primitives::Address;
 
     #[test]
-    fn builds_stmt() {
+    fn builds_without_time_filters_when_none() {
         let owner = Address::repeat_byte(0xcc);
         let stmt = build_fetch_owner_trades_count_stmt(
             &OrderbookIdentifier::new(42161, Address::ZERO),
             owner,
+            &TimeFilter::default(),
         )
         .unwrap();
         assert_eq!(stmt.params.len(), 3);
         assert_eq!(stmt.params[0], SqlValue::U64(42161));
+        assert_eq!(stmt.params[1], SqlValue::Text(Address::ZERO.to_string()));
+        assert!(
+            matches!(&stmt.params[2], SqlValue::Text(s) if s.to_lowercase() == owner.to_string().to_lowercase())
+        );
+        assert!(!stmt.sql.contains("block_timestamp >="));
+        assert!(!stmt.sql.contains("block_timestamp <="));
+        assert!(!stmt.sql.contains(START_TS_CLAUSE));
+        assert!(!stmt.sql.contains(END_TS_CLAUSE));
+    }
+
+    #[test]
+    fn builds_with_time_filters() {
+        let owner = Address::repeat_byte(0xdd);
+        let stmt = build_fetch_owner_trades_count_stmt(
+            &OrderbookIdentifier::new(137, Address::ZERO),
+            owner,
+            &TimeFilter {
+                start: Some(1000),
+                end: Some(2000),
+            },
+        )
+        .unwrap();
+        assert!(!stmt.sql.contains(START_TS_CLAUSE));
+        assert!(!stmt.sql.contains(END_TS_CLAUSE));
+        assert!(stmt.sql.contains("block_timestamp >="));
+        assert!(stmt.sql.contains("block_timestamp <="));
+        assert_eq!(stmt.params.len(), 5);
+        assert_eq!(stmt.params[0], SqlValue::U64(137));
         assert_eq!(stmt.params[1], SqlValue::Text(Address::ZERO.to_string()));
         assert!(
             matches!(&stmt.params[2], SqlValue::Text(s) if s.to_lowercase() == owner.to_string().to_lowercase())

--- a/crates/common/src/local_db/query/fetch_owner_trades_count/query.sql
+++ b/crates/common/src/local_db/query/fetch_owner_trades_count/query.sql
@@ -1,6 +1,6 @@
 SELECT COUNT(*) AS trade_count
 FROM (
-  SELECT t.transaction_hash, t.log_index
+  SELECT t.transaction_hash, t.log_index, t.block_timestamp
   FROM take_orders t
   JOIN order_events oe
     ON oe.chain_id = ?1
@@ -37,7 +37,7 @@ FROM (
 
   UNION ALL
 
-  SELECT c.transaction_hash, c.log_index
+  SELECT c.transaction_hash, c.log_index, c.block_timestamp
   FROM clear_v3_events c
   JOIN order_events oe
     ON oe.chain_id = ?1
@@ -71,7 +71,7 @@ FROM (
 
   UNION ALL
 
-  SELECT c.transaction_hash, c.log_index
+  SELECT c.transaction_hash, c.log_index, c.block_timestamp
   FROM clear_v3_events c
   JOIN order_events oe
     ON oe.chain_id = ?1
@@ -102,4 +102,7 @@ FROM (
    )
   WHERE c.chain_id = ?1
     AND c.orderbook_address = ?2
-) AS combined_trades;
+) AS combined_trades
+WHERE 1=1
+/*START_TS_CLAUSE*/
+/*END_TS_CLAUSE*/;

--- a/crates/common/src/local_db/query/fetch_owner_trades_count/query.sql
+++ b/crates/common/src/local_db/query/fetch_owner_trades_count/query.sql
@@ -1,0 +1,105 @@
+SELECT COUNT(*) AS trade_count
+FROM (
+  SELECT t.transaction_hash, t.log_index
+  FROM take_orders t
+  JOIN order_events oe
+    ON oe.chain_id = ?1
+   AND oe.orderbook_address = ?2
+   AND oe.order_owner = ?3
+   AND oe.event_type = 'AddOrderV3'
+   AND oe.order_owner = t.order_owner
+   AND oe.order_nonce = t.order_nonce
+   AND (
+        oe.block_number < t.block_number
+     OR (oe.block_number = t.block_number AND oe.log_index <= t.log_index)
+   )
+   AND NOT EXISTS (
+     SELECT 1
+     FROM order_events oe2
+    WHERE oe2.chain_id = ?1
+      AND oe2.orderbook_address = ?2
+      AND oe2.order_owner = ?3
+      AND oe2.event_type = 'AddOrderV3'
+      AND oe2.order_owner = t.order_owner
+      AND oe2.order_nonce = t.order_nonce
+       AND (
+            oe2.block_number < t.block_number
+         OR (oe2.block_number = t.block_number AND oe2.log_index <= t.log_index)
+       )
+       AND (
+            oe2.block_number > oe.block_number
+         OR (oe2.block_number = oe.block_number AND oe2.log_index > oe.log_index)
+       )
+   )
+  WHERE t.chain_id = ?1
+    AND t.orderbook_address = ?2
+    AND t.order_owner = ?3
+
+  UNION ALL
+
+  SELECT c.transaction_hash, c.log_index
+  FROM clear_v3_events c
+  JOIN order_events oe
+    ON oe.chain_id = ?1
+   AND oe.orderbook_address = ?2
+   AND oe.order_owner = ?3
+   AND oe.order_hash = c.alice_order_hash
+   AND oe.event_type = 'AddOrderV3'
+   AND (
+        oe.block_number < c.block_number
+     OR (oe.block_number = c.block_number AND oe.log_index <= c.log_index)
+   )
+   AND NOT EXISTS (
+     SELECT 1
+     FROM order_events oe2
+    WHERE oe2.chain_id = ?1
+      AND oe2.orderbook_address = ?2
+      AND oe2.order_owner = ?3
+      AND oe2.order_hash = c.alice_order_hash
+      AND oe2.event_type = 'AddOrderV3'
+       AND (
+            oe2.block_number < c.block_number
+         OR (oe2.block_number = c.block_number AND oe2.log_index <= c.log_index)
+       )
+       AND (
+            oe2.block_number > oe.block_number
+         OR (oe2.block_number = oe.block_number AND oe2.log_index > oe.log_index)
+       )
+   )
+  WHERE c.chain_id = ?1
+    AND c.orderbook_address = ?2
+
+  UNION ALL
+
+  SELECT c.transaction_hash, c.log_index
+  FROM clear_v3_events c
+  JOIN order_events oe
+    ON oe.chain_id = ?1
+   AND oe.orderbook_address = ?2
+   AND oe.order_owner = ?3
+   AND oe.order_hash = c.bob_order_hash
+   AND oe.event_type = 'AddOrderV3'
+   AND (
+        oe.block_number < c.block_number
+     OR (oe.block_number = c.block_number AND oe.log_index <= c.log_index)
+   )
+   AND NOT EXISTS (
+     SELECT 1
+     FROM order_events oe2
+    WHERE oe2.chain_id = ?1
+      AND oe2.orderbook_address = ?2
+      AND oe2.order_owner = ?3
+      AND oe2.order_hash = c.bob_order_hash
+      AND oe2.event_type = 'AddOrderV3'
+       AND (
+            oe2.block_number < c.block_number
+         OR (oe2.block_number = c.block_number AND oe2.log_index <= c.log_index)
+       )
+       AND (
+            oe2.block_number > oe.block_number
+         OR (oe2.block_number = oe.block_number AND oe2.log_index > oe.log_index)
+       )
+   )
+  WHERE c.chain_id = ?1
+    AND c.orderbook_address = ?2
+) AS combined_trades;

--- a/crates/common/src/local_db/query/mod.rs
+++ b/crates/common/src/local_db/query/mod.rs
@@ -11,6 +11,8 @@ pub mod fetch_order_trades;
 pub mod fetch_order_trades_count;
 pub mod fetch_order_vaults_volume;
 pub mod fetch_orders;
+pub mod fetch_owner_trades;
+pub mod fetch_owner_trades_count;
 pub mod fetch_store_addresses;
 pub mod fetch_tables;
 pub mod fetch_target_watermark;

--- a/crates/common/src/raindex_client/local_db/mod.rs
+++ b/crates/common/src/raindex_client/local_db/mod.rs
@@ -16,7 +16,6 @@ pub mod executor;
 pub mod orders;
 pub mod pipeline;
 pub mod query;
-pub mod trades;
 pub mod transactions;
 pub mod vaults;
 

--- a/crates/common/src/raindex_client/local_db/query/fetch_owner_trades.rs
+++ b/crates/common/src/raindex_client/local_db/query/fetch_owner_trades.rs
@@ -1,0 +1,60 @@
+use crate::local_db::query::fetch_order_trades::LocalDbOrderTrade;
+use crate::local_db::query::fetch_owner_trades::build_fetch_owner_trades_stmt;
+use crate::local_db::query::{LocalDbQueryError, LocalDbQueryExecutor};
+use crate::local_db::OrderbookIdentifier;
+use alloy::primitives::Address;
+
+pub async fn fetch_owner_trades<E: LocalDbQueryExecutor + ?Sized>(
+    exec: &E,
+    ob_id: &OrderbookIdentifier,
+    owner: Address,
+    page: Option<u16>,
+) -> Result<Vec<LocalDbOrderTrade>, LocalDbQueryError> {
+    let stmt = build_fetch_owner_trades_stmt(ob_id, owner, page)?;
+    exec.query_json(&stmt).await
+}
+
+#[cfg(all(test, target_family = "wasm"))]
+mod wasm_tests {
+    use super::*;
+    use crate::raindex_client::local_db::executor::tests::create_sql_capturing_callback;
+    use crate::raindex_client::local_db::executor::JsCallbackExecutor;
+    use alloy::primitives::Address;
+    use std::cell::RefCell;
+    use std::rc::Rc;
+    use wasm_bindgen_test::*;
+    use wasm_bindgen_utils::prelude::*;
+
+    #[wasm_bindgen_test]
+    async fn wrapper_uses_builder_sql_exactly() {
+        let chain_id = 111;
+        let orderbook = Address::from([0x77; 20]);
+        let owner = Address::from([0x88; 20]);
+
+        let expected_stmt = build_fetch_owner_trades_stmt(
+            &OrderbookIdentifier::new(chain_id, orderbook),
+            owner,
+            Some(2),
+        )
+        .unwrap();
+
+        let store = Rc::new(RefCell::new((
+            String::new(),
+            wasm_bindgen::JsValue::UNDEFINED,
+        )));
+        let callback = create_sql_capturing_callback("[]", store.clone());
+        let exec = JsCallbackExecutor::from_ref(&callback);
+
+        let res = super::fetch_owner_trades(
+            &exec,
+            &OrderbookIdentifier::new(chain_id, orderbook),
+            owner,
+            Some(2),
+        )
+        .await;
+        assert!(res.is_ok());
+
+        let captured = store.borrow().clone();
+        assert_eq!(captured.0, expected_stmt.sql);
+    }
+}

--- a/crates/common/src/raindex_client/local_db/query/fetch_owner_trades_count.rs
+++ b/crates/common/src/raindex_client/local_db/query/fetch_owner_trades_count.rs
@@ -1,0 +1,60 @@
+use crate::local_db::query::fetch_owner_trades_count::{
+    build_fetch_owner_trades_count_stmt, extract_trade_count, LocalDbTradeCountRow,
+};
+use crate::local_db::query::{LocalDbQueryError, LocalDbQueryExecutor};
+use crate::local_db::OrderbookIdentifier;
+use alloy::primitives::Address;
+
+pub async fn fetch_owner_trades_count<E: LocalDbQueryExecutor + ?Sized>(
+    exec: &E,
+    ob_id: &OrderbookIdentifier,
+    owner: Address,
+) -> Result<u64, LocalDbQueryError> {
+    let stmt = build_fetch_owner_trades_count_stmt(ob_id, owner)?;
+    let rows: Vec<LocalDbTradeCountRow> = exec.query_json(&stmt).await?;
+    Ok(extract_trade_count(&rows))
+}
+
+#[cfg(all(test, target_family = "wasm"))]
+mod wasm_tests {
+    use super::*;
+    use crate::raindex_client::local_db::executor::tests::create_sql_capturing_callback;
+    use crate::raindex_client::local_db::executor::JsCallbackExecutor;
+    use alloy::primitives::Address;
+    use std::cell::RefCell;
+    use std::rc::Rc;
+    use wasm_bindgen_test::*;
+    use wasm_bindgen_utils::prelude::*;
+
+    #[wasm_bindgen_test]
+    async fn wrapper_uses_builder_sql_exactly() {
+        let chain_id = 111;
+        let orderbook = Address::from([0x77; 20]);
+        let owner = Address::from([0x88; 20]);
+
+        let expected_stmt = build_fetch_owner_trades_count_stmt(
+            &OrderbookIdentifier::new(chain_id, orderbook),
+            owner,
+        )
+        .unwrap();
+
+        let store = Rc::new(RefCell::new((
+            String::new(),
+            wasm_bindgen::JsValue::UNDEFINED,
+        )));
+        let callback = create_sql_capturing_callback("[{\"trade_count\":5}]", store.clone());
+        let exec = JsCallbackExecutor::from_ref(&callback);
+
+        let res = super::fetch_owner_trades_count(
+            &exec,
+            &OrderbookIdentifier::new(chain_id, orderbook),
+            owner,
+        )
+        .await;
+        assert!(res.is_ok());
+        assert_eq!(res.unwrap(), 5);
+
+        let captured = store.borrow().clone();
+        assert_eq!(captured.0, expected_stmt.sql);
+    }
+}

--- a/crates/common/src/raindex_client/local_db/query/mod.rs
+++ b/crates/common/src/raindex_client/local_db/query/mod.rs
@@ -7,6 +7,8 @@ pub mod fetch_order_trades;
 pub mod fetch_order_trades_count;
 pub mod fetch_order_vaults_volume;
 pub mod fetch_orders;
+pub mod fetch_owner_trades;
+pub mod fetch_owner_trades_count;
 pub mod fetch_store_addresses;
 pub mod fetch_tables;
 pub mod fetch_trades_by_tx;

--- a/crates/common/src/raindex_client/mod.rs
+++ b/crates/common/src/raindex_client/mod.rs
@@ -41,6 +41,7 @@ pub mod remove_orders;
 pub mod take_orders;
 pub mod trades;
 pub mod transactions;
+pub mod types;
 pub mod vaults;
 pub mod vaults_list;
 

--- a/crates/common/src/raindex_client/trades/get_by_owner.rs
+++ b/crates/common/src/raindex_client/trades/get_by_owner.rs
@@ -1,0 +1,286 @@
+use super::LocalDbTrades;
+use super::RaindexTradesListResult;
+use super::SubgraphTrades;
+use super::*;
+use crate::local_db::is_chain_supported_local_db;
+use crate::local_db::OrderbookIdentifier;
+use alloy::primitives::Address;
+use std::str::FromStr;
+
+#[wasm_export]
+impl RaindexClient {
+    #[wasm_export(
+        js_name = "getTradesForOwner",
+        return_description = "Paginated trades list with total count",
+        unchecked_return_type = "RaindexTradesListResult",
+        preserve_js_class
+    )]
+    pub async fn get_trades_for_owner(
+        &self,
+        #[wasm_export(js_name = "chainId", param_description = "Chain ID for the network")]
+        chain_id: u32,
+        #[wasm_export(
+            js_name = "orderbookAddress",
+            param_description = "Orderbook contract address",
+            unchecked_param_type = "Address"
+        )]
+        orderbook_address: String,
+        #[wasm_export(
+            js_name = "owner",
+            param_description = "Owner address to filter trades by",
+            unchecked_param_type = "Address"
+        )]
+        owner: String,
+        #[wasm_export(
+            js_name = "page",
+            param_description = "Optional page number (defaults to 1)"
+        )]
+        page: Option<u16>,
+    ) -> Result<RaindexTradesListResult, RaindexError> {
+        let orderbook_address = Address::from_str(&orderbook_address)?;
+        let owner = Address::from_str(&owner)?;
+        let ob_id = OrderbookIdentifier::new(chain_id, orderbook_address);
+
+        if is_chain_supported_local_db(chain_id) {
+            if let Some(local_db) = self.local_db() {
+                let local_source = LocalDbTrades::new(&local_db);
+                let trades = local_source.get_by_owner(&ob_id, owner, page).await?;
+                let total_count = local_source.count_by_owner(&ob_id, owner).await?;
+                return Ok(RaindexTradesListResult {
+                    trades,
+                    total_count,
+                });
+            }
+        }
+
+        let sg_source = SubgraphTrades::new(self);
+        let trades = sg_source.get_by_owner(&ob_id, owner, page).await?;
+        let total_count = sg_source.count_by_owner(&ob_id, owner).await?;
+        Ok(RaindexTradesListResult {
+            trades,
+            total_count,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(not(target_family = "wasm"))]
+    mod non_wasm {
+        use super::super::super::super::*;
+        use crate::raindex_client::tests::{get_test_yaml, CHAIN_ID_1_ORDERBOOK_ADDRESS};
+        use alloy::primitives::{Address, Bytes, U256};
+        use httpmock::MockServer;
+        use rain_orderbook_subgraph_client::utils::float::*;
+        use serde_json::{json, Value};
+        use std::str::FromStr;
+
+        fn sample_owner_trades_response() -> Value {
+            json!({
+                "data": {
+                    "trades": [
+                        {
+                            "id": "0xabc1",
+                            "tradeEvent": {
+                                "transaction": {
+                                    "id": "0x0000000000000000000000000000000000000000000000000000000000000abc",
+                                    "from": "0x0000000000000000000000000000000000000001",
+                                    "blockNumber": "200",
+                                    "timestamp": "1700000000"
+                                },
+                                "sender": "0x0000000000000000000000000000000000000002"
+                            },
+                            "outputVaultBalanceChange": {
+                                "id": "0xout1",
+                                "__typename": "TradeVaultBalanceChange",
+                                "amount": NEG2,
+                                "newVaultBalance": F0,
+                                "oldVaultBalance": F0,
+                                "vault": {
+                                    "id": "0xv1",
+                                    "vaultId": "0x01",
+                                    "token": {
+                                        "id": "0x12e605bc104e93b45e1ad99f9e555f659051c2bb",
+                                        "address": "0x12e605bc104e93b45e1ad99f9e555f659051c2bb",
+                                        "name": "Staked FLR",
+                                        "symbol": "sFLR",
+                                        "decimals": "18"
+                                    }
+                                },
+                                "timestamp": "1700000000",
+                                "transaction": {
+                                    "id": "0x0000000000000000000000000000000000000000000000000000000000000abc",
+                                    "from": "0x0000000000000000000000000000000000000001",
+                                    "blockNumber": "200",
+                                    "timestamp": "1700000000"
+                                },
+                                "orderbook": { "id": "0x1234567890123456789012345678901234567890" },
+                                "trade": { "tradeEvent": { "__typename": "TakeOrder" } }
+                            },
+                            "order": {
+                                "id": "0x0000000000000000000000000000000000000001",
+                                "orderHash": "0x00000000000000000000000000000000000000000000000000000000000abc01"
+                            },
+                            "inputVaultBalanceChange": {
+                                "id": "0xin1",
+                                "__typename": "TradeVaultBalanceChange",
+                                "amount": F1,
+                                "newVaultBalance": F0,
+                                "oldVaultBalance": F0,
+                                "vault": {
+                                    "id": "0xv2",
+                                    "vaultId": "0x02",
+                                    "token": {
+                                        "id": "0x1d80c49bbbcd1c0911346656b529df9e5c2f783d",
+                                        "address": "0x1d80c49bbbcd1c0911346656b529df9e5c2f783d",
+                                        "name": "Wrapped Flare",
+                                        "symbol": "WFLR",
+                                        "decimals": "18"
+                                    }
+                                },
+                                "timestamp": "1700000000",
+                                "transaction": {
+                                    "id": "0x0000000000000000000000000000000000000000000000000000000000000abc",
+                                    "from": "0x0000000000000000000000000000000000000001",
+                                    "blockNumber": "200",
+                                    "timestamp": "1700000000"
+                                },
+                                "orderbook": { "id": "0x1234567890123456789012345678901234567890" },
+                                "trade": { "tradeEvent": { "__typename": "TakeOrder" } }
+                            },
+                            "timestamp": "1700000000",
+                            "orderbook": { "id": "0x1234567890123456789012345678901234567890" }
+                        }
+                    ]
+                }
+            })
+        }
+
+        fn empty_trades_response() -> Value {
+            json!({
+                "data": {
+                    "trades": []
+                }
+            })
+        }
+
+        #[tokio::test]
+        async fn test_get_trades_for_owner_found() {
+            let sg_server = MockServer::start_async().await;
+            sg_server.mock(|when, then| {
+                when.path("/sg").body_contains("SgOwnerTradesListQuery");
+                then.status(200)
+                    .json_body_obj(&sample_owner_trades_response());
+            });
+            sg_server.mock(|when, then| {
+                when.path("/sg").body_contains("SgOwnerTradesCountQuery");
+                then.status(200)
+                    .json_body_obj(&sample_owner_trades_response());
+            });
+            sg_server.mock(|when, then| {
+                when.path("/sg").body_contains("SgOwnerTradesCountQuery");
+                then.status(200).json_body_obj(&empty_trades_response());
+            });
+
+            let raindex_client = RaindexClient::new(
+                vec![get_test_yaml(
+                    &sg_server.url("/sg"),
+                    "http://localhost:3000",
+                    "http://localhost:3000",
+                    "http://localhost:3000",
+                )],
+                None,
+            )
+            .unwrap();
+
+            let result = raindex_client
+                .get_trades_for_owner(
+                    1,
+                    CHAIN_ID_1_ORDERBOOK_ADDRESS.to_string(),
+                    "0xf08bcbce72f62c95dcb7c07dcb5ed26acfcfbc11".to_string(),
+                    None,
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(result.trades().len(), 1);
+            assert_eq!(result.total_count(), 1);
+
+            let trade = &result.trades()[0];
+            assert_eq!(trade.id(), Bytes::from_str("0xabc1").unwrap());
+            assert_eq!(trade.timestamp(), U256::from(1700000000u64));
+            assert_eq!(
+                trade.orderbook(),
+                Address::from_str(CHAIN_ID_1_ORDERBOOK_ADDRESS).unwrap()
+            );
+        }
+
+        #[tokio::test]
+        async fn test_get_trades_for_owner_empty() {
+            let sg_server = MockServer::start_async().await;
+            sg_server.mock(|when, then| {
+                when.path("/sg").body_contains("SgOwnerTradesListQuery");
+                then.status(200).json_body_obj(&empty_trades_response());
+            });
+            sg_server.mock(|when, then| {
+                when.path("/sg").body_contains("SgOwnerTradesCountQuery");
+                then.status(200).json_body_obj(&empty_trades_response());
+            });
+
+            let raindex_client = RaindexClient::new(
+                vec![get_test_yaml(
+                    &sg_server.url("/sg"),
+                    "http://localhost:3000",
+                    "http://localhost:3000",
+                    "http://localhost:3000",
+                )],
+                None,
+            )
+            .unwrap();
+
+            let result = raindex_client
+                .get_trades_for_owner(
+                    1,
+                    CHAIN_ID_1_ORDERBOOK_ADDRESS.to_string(),
+                    "0x0000000000000000000000000000000000000099".to_string(),
+                    None,
+                )
+                .await
+                .unwrap();
+
+            assert!(result.trades().is_empty());
+            assert_eq!(result.total_count(), 0);
+        }
+
+        #[tokio::test]
+        async fn test_get_trades_for_owner_network_error() {
+            let sg_server = MockServer::start_async().await;
+            sg_server.mock(|when, then| {
+                when.path("/sg");
+                then.status(500);
+            });
+
+            let raindex_client = RaindexClient::new(
+                vec![get_test_yaml(
+                    &sg_server.url("/sg"),
+                    "http://localhost:3000",
+                    "http://localhost:3000",
+                    "http://localhost:3000",
+                )],
+                None,
+            )
+            .unwrap();
+
+            let result = raindex_client
+                .get_trades_for_owner(
+                    1,
+                    CHAIN_ID_1_ORDERBOOK_ADDRESS.to_string(),
+                    "0xf08bcbce72f62c95dcb7c07dcb5ed26acfcfbc11".to_string(),
+                    None,
+                )
+                .await;
+
+            assert!(result.is_err());
+        }
+    }
+}

--- a/crates/common/src/raindex_client/trades/local_db.rs
+++ b/crates/common/src/raindex_client/trades/local_db.rs
@@ -1,10 +1,13 @@
-use super::super::trades::RaindexTrade;
-use super::query::fetch_trades_by_tx::fetch_trades_by_tx;
-use super::{LocalDb, RaindexError};
+use super::RaindexTrade;
 use crate::local_db::OrderbookIdentifier;
-use alloy::primitives::B256;
+use crate::raindex_client::local_db::query::fetch_owner_trades::fetch_owner_trades;
+use crate::raindex_client::local_db::query::fetch_owner_trades_count::fetch_owner_trades_count;
+use crate::raindex_client::local_db::query::fetch_trades_by_tx::fetch_trades_by_tx;
+use crate::raindex_client::local_db::LocalDb;
+use crate::raindex_client::RaindexError;
+use alloy::primitives::{Address, B256};
 
-pub struct LocalDbTrades<'a> {
+pub(crate) struct LocalDbTrades<'a> {
     pub(crate) db: &'a LocalDb,
 }
 
@@ -23,6 +26,27 @@ impl<'a> LocalDbTrades<'a> {
             .into_iter()
             .map(|trade| RaindexTrade::try_from_local_db_trade(ob_id.chain_id, trade))
             .collect()
+    }
+
+    pub async fn get_by_owner(
+        &self,
+        ob_id: &OrderbookIdentifier,
+        owner: Address,
+        page: Option<u16>,
+    ) -> Result<Vec<RaindexTrade>, RaindexError> {
+        let local_trades = fetch_owner_trades(self.db, ob_id, owner, page).await?;
+        local_trades
+            .into_iter()
+            .map(|trade| RaindexTrade::try_from_local_db_trade(ob_id.chain_id, trade))
+            .collect()
+    }
+
+    pub async fn count_by_owner(
+        &self,
+        ob_id: &OrderbookIdentifier,
+        owner: Address,
+    ) -> Result<u64, RaindexError> {
+        Ok(fetch_owner_trades_count(self.db, ob_id, owner).await?)
     }
 }
 
@@ -150,6 +174,113 @@ mod tests {
 
             assert!(result.is_ok());
             assert!(result.unwrap().is_empty());
+        }
+
+        #[wasm_bindgen_test]
+        async fn test_get_by_owner_returns_trades_when_found() {
+            let tx_hash =
+                b256!("0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890");
+            let orderbook = address!("0x2222222222222222222222222222222222222222");
+            let order_hash =
+                b256!("0x1111111111111111111111111111111111111111111111111111111111111111");
+            let input_token = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+            let output_token = address!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+            let sender = address!("0x3333333333333333333333333333333333333333");
+            let owner = address!("0x4444444444444444444444444444444444444444");
+
+            let trade_json = json!([{
+                "trade_kind": "take",
+                "orderbook": orderbook.to_string(),
+                "order_hash": order_hash.to_string(),
+                "order_owner": owner.to_string(),
+                "order_nonce": "1",
+                "transaction_hash": tx_hash.to_string(),
+                "log_index": 5,
+                "block_number": 12345,
+                "block_timestamp": 1700000000u64,
+                "transaction_sender": sender.to_string(),
+                "input_vault_id": "0x01",
+                "input_token": input_token.to_string(),
+                "input_token_name": "Token A",
+                "input_token_symbol": "TKNA",
+                "input_token_decimals": 18,
+                "input_delta": "0x0000000000000000000000000000000000000000000000000000000000000001",
+                "input_running_balance": "0x0000000000000000000000000000000000000000000000000000000000000003",
+                "output_vault_id": "0x02",
+                "output_token": output_token.to_string(),
+                "output_token_name": "Token B",
+                "output_token_symbol": "TKNB",
+                "output_token_decimals": 6,
+                "output_delta": "0x00000000fffffffffffffffffffffffffffffffffffffffffffffffffffffffe",
+                "output_running_balance": "0x0000000000000000000000000000000000000000000000000000000000000001",
+                "trade_id": format!(
+                    "0x{}{:016x}",
+                    tx_hash.to_string().trim_start_matches("0x"),
+                    5u64
+                )
+            }]);
+
+            let callback = create_mock_callback(&trade_json.to_string());
+            let exec = JsCallbackExecutor::from_ref(&callback);
+            let local_db = LocalDb::new(exec);
+
+            let trades = LocalDbTrades::new(&local_db);
+            let ob_id = OrderbookIdentifier::new(42161, orderbook);
+
+            let result = trades.get_by_owner(&ob_id, owner, None).await;
+
+            assert!(result.is_ok());
+            let trades = result.unwrap();
+            assert_eq!(trades.len(), 1);
+
+            let trade = &trades[0];
+            assert_eq!(trade.orderbook(), orderbook.to_string());
+            assert_eq!(
+                trade
+                    .timestamp()
+                    .unwrap()
+                    .to_string(10)
+                    .unwrap()
+                    .as_string()
+                    .unwrap(),
+                "1700000000"
+            );
+        }
+
+        #[wasm_bindgen_test]
+        async fn test_get_by_owner_returns_empty_when_not_found() {
+            let orderbook = address!("0x2222222222222222222222222222222222222222");
+            let owner = address!("0x4444444444444444444444444444444444444444");
+
+            let callback = create_mock_callback("[]");
+            let exec = JsCallbackExecutor::from_ref(&callback);
+            let local_db = LocalDb::new(exec);
+
+            let trades = LocalDbTrades::new(&local_db);
+            let ob_id = OrderbookIdentifier::new(42161, orderbook);
+
+            let result = trades.get_by_owner(&ob_id, owner, None).await;
+
+            assert!(result.is_ok());
+            assert!(result.unwrap().is_empty());
+        }
+
+        #[wasm_bindgen_test]
+        async fn test_count_by_owner_returns_count() {
+            let orderbook = address!("0x2222222222222222222222222222222222222222");
+            let owner = address!("0x4444444444444444444444444444444444444444");
+
+            let callback = create_mock_callback("[{\"trade_count\":7}]");
+            let exec = JsCallbackExecutor::from_ref(&callback);
+            let local_db = LocalDb::new(exec);
+
+            let trades = LocalDbTrades::new(&local_db);
+            let ob_id = OrderbookIdentifier::new(42161, orderbook);
+
+            let result = trades.count_by_owner(&ob_id, owner).await;
+
+            assert!(result.is_ok());
+            assert_eq!(result.unwrap(), 7);
         }
     }
 }

--- a/crates/common/src/raindex_client/trades/mod.rs
+++ b/crates/common/src/raindex_client/trades/mod.rs
@@ -113,6 +113,12 @@ impl RaindexTradesListResult {
 }
 #[cfg(not(target_family = "wasm"))]
 impl RaindexTradesListResult {
+    pub fn new(trades: Vec<RaindexTrade>, total_count: u64) -> Self {
+        Self {
+            trades,
+            total_count,
+        }
+    }
     pub fn trades(&self) -> Vec<RaindexTrade> {
         self.trades.clone()
     }

--- a/crates/common/src/raindex_client/trades/mod.rs
+++ b/crates/common/src/raindex_client/trades/mod.rs
@@ -1,4 +1,9 @@
+mod get_by_owner;
 mod get_by_tx;
+mod local_db;
+mod subgraph;
+pub(crate) use local_db::LocalDbTrades;
+pub(crate) use subgraph::SubgraphTrades;
 
 use super::local_db::orders::LocalDbOrders;
 use super::orders::{OrdersDataSource, SubgraphOrders};
@@ -84,6 +89,35 @@ impl RaindexTrade {
     }
     pub fn orderbook(&self) -> Address {
         self.orderbook
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+#[wasm_bindgen]
+pub struct RaindexTradesListResult {
+    trades: Vec<RaindexTrade>,
+    total_count: u64,
+}
+#[cfg(target_family = "wasm")]
+#[wasm_bindgen]
+impl RaindexTradesListResult {
+    #[wasm_bindgen(getter)]
+    pub fn trades(&self) -> Vec<RaindexTrade> {
+        self.trades.clone()
+    }
+    #[wasm_bindgen(getter = totalCount)]
+    pub fn total_count(&self) -> u64 {
+        self.total_count
+    }
+}
+#[cfg(not(target_family = "wasm"))]
+impl RaindexTradesListResult {
+    pub fn trades(&self) -> Vec<RaindexTrade> {
+        self.trades.clone()
+    }
+    pub fn total_count(&self) -> u64 {
+        self.total_count
     }
 }
 

--- a/crates/common/src/raindex_client/trades/subgraph.rs
+++ b/crates/common/src/raindex_client/trades/subgraph.rs
@@ -1,0 +1,445 @@
+use super::RaindexTrade;
+use super::*;
+use crate::local_db::OrderbookIdentifier;
+use alloy::primitives::{Address, B256};
+use rain_orderbook_subgraph_client::types::common::SgBytes;
+use rain_orderbook_subgraph_client::types::Id;
+use rain_orderbook_subgraph_client::SgPaginationArgs;
+
+const DEFAULT_PAGE_SIZE: u16 = 100;
+
+pub(crate) struct SubgraphTrades<'a> {
+    client: &'a RaindexClient,
+}
+
+impl<'a> SubgraphTrades<'a> {
+    pub(crate) fn new(client: &'a RaindexClient) -> Self {
+        Self { client }
+    }
+
+    pub async fn get_by_tx_hash(
+        &self,
+        ob_id: &OrderbookIdentifier,
+        tx_hash: B256,
+    ) -> Result<Vec<RaindexTrade>, RaindexError> {
+        let client = self.client.get_orderbook_client(ob_id.orderbook_address)?;
+        let sg_trades = client
+            .transaction_trades(Id::new(tx_hash.to_string()))
+            .await?;
+        sg_trades
+            .into_iter()
+            .map(|t| RaindexTrade::try_from_sg_trade(ob_id.chain_id, t))
+            .collect()
+    }
+
+    pub async fn get_by_owner(
+        &self,
+        ob_id: &OrderbookIdentifier,
+        owner: Address,
+        page: Option<u16>,
+    ) -> Result<Vec<RaindexTrade>, RaindexError> {
+        let client = self.client.get_orderbook_client(ob_id.orderbook_address)?;
+        let owner_bytes = SgBytes(owner.to_string());
+        let page_num = page.unwrap_or(1);
+        let sg_trades = client
+            .owner_trades_list(
+                owner_bytes,
+                SgPaginationArgs {
+                    page: page_num,
+                    page_size: DEFAULT_PAGE_SIZE,
+                },
+            )
+            .await?;
+        sg_trades
+            .into_iter()
+            .map(|t| RaindexTrade::try_from_sg_trade(ob_id.chain_id, t))
+            .collect()
+    }
+
+    pub async fn count_by_owner(
+        &self,
+        ob_id: &OrderbookIdentifier,
+        owner: Address,
+    ) -> Result<u64, RaindexError> {
+        let client = self.client.get_orderbook_client(ob_id.orderbook_address)?;
+        let owner_bytes = SgBytes(owner.to_string());
+        Ok(client.owner_trades_count(owner_bytes).await?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(not(target_family = "wasm"))]
+    mod non_wasm {
+        use super::super::*;
+        use crate::local_db::OrderbookIdentifier;
+        use crate::raindex_client::tests::{get_test_yaml, CHAIN_ID_1_ORDERBOOK_ADDRESS};
+        use alloy::primitives::{b256, Address, Bytes, U256};
+        use httpmock::MockServer;
+        use rain_orderbook_subgraph_client::utils::float::*;
+        use serde_json::{json, Value};
+        use std::str::FromStr;
+
+        fn sample_trades_response() -> Value {
+            json!({
+                "data": {
+                    "trades": [
+                        {
+                            "id": "0xabc1",
+                            "tradeEvent": {
+                                "transaction": {
+                                    "id": "0x0000000000000000000000000000000000000000000000000000000000000456",
+                                    "from": "0x0000000000000000000000000000000000000001",
+                                    "blockNumber": "100",
+                                    "timestamp": "1700000000"
+                                },
+                                "sender": "0x0000000000000000000000000000000000000002"
+                            },
+                            "outputVaultBalanceChange": {
+                                "id": "0xout1",
+                                "__typename": "TradeVaultBalanceChange",
+                                "amount": NEG2,
+                                "newVaultBalance": F0,
+                                "oldVaultBalance": F0,
+                                "vault": {
+                                    "id": "0xv1",
+                                    "vaultId": "0x01",
+                                    "token": {
+                                        "id": "0x12e605bc104e93b45e1ad99f9e555f659051c2bb",
+                                        "address": "0x12e605bc104e93b45e1ad99f9e555f659051c2bb",
+                                        "name": "Staked FLR",
+                                        "symbol": "sFLR",
+                                        "decimals": "18"
+                                    }
+                                },
+                                "timestamp": "1700000000",
+                                "transaction": {
+                                    "id": "0x0000000000000000000000000000000000000000000000000000000000000456",
+                                    "from": "0x0000000000000000000000000000000000000001",
+                                    "blockNumber": "100",
+                                    "timestamp": "1700000000"
+                                },
+                                "orderbook": { "id": "0x1234567890123456789012345678901234567890" },
+                                "trade": { "tradeEvent": { "__typename": "TakeOrder" } }
+                            },
+                            "order": {
+                                "id": "0x0000000000000000000000000000000000000001",
+                                "orderHash": "0x00000000000000000000000000000000000000000000000000000000000abc01"
+                            },
+                            "inputVaultBalanceChange": {
+                                "id": "0xin1",
+                                "__typename": "TradeVaultBalanceChange",
+                                "amount": F1,
+                                "newVaultBalance": F0,
+                                "oldVaultBalance": F0,
+                                "vault": {
+                                    "id": "0xv2",
+                                    "vaultId": "0x02",
+                                    "token": {
+                                        "id": "0x1d80c49bbbcd1c0911346656b529df9e5c2f783d",
+                                        "address": "0x1d80c49bbbcd1c0911346656b529df9e5c2f783d",
+                                        "name": "Wrapped Flare",
+                                        "symbol": "WFLR",
+                                        "decimals": "18"
+                                    }
+                                },
+                                "timestamp": "1700000000",
+                                "transaction": {
+                                    "id": "0x0000000000000000000000000000000000000000000000000000000000000456",
+                                    "from": "0x0000000000000000000000000000000000000001",
+                                    "blockNumber": "100",
+                                    "timestamp": "1700000000"
+                                },
+                                "orderbook": { "id": "0x1234567890123456789012345678901234567890" },
+                                "trade": { "tradeEvent": { "__typename": "TakeOrder" } }
+                            },
+                            "timestamp": "1700000000",
+                            "orderbook": { "id": "0x1234567890123456789012345678901234567890" }
+                        }
+                    ]
+                }
+            })
+        }
+
+        fn empty_trades_response() -> Value {
+            json!({
+                "data": {
+                    "trades": []
+                }
+            })
+        }
+
+        fn sample_owner_trades_response() -> Value {
+            json!({
+                "data": {
+                    "trades": [
+                        {
+                            "id": "0xabc1",
+                            "tradeEvent": {
+                                "transaction": {
+                                    "id": "0x0000000000000000000000000000000000000000000000000000000000000abc",
+                                    "from": "0x0000000000000000000000000000000000000001",
+                                    "blockNumber": "200",
+                                    "timestamp": "1700000000"
+                                },
+                                "sender": "0x0000000000000000000000000000000000000002"
+                            },
+                            "outputVaultBalanceChange": {
+                                "id": "0xout1",
+                                "__typename": "TradeVaultBalanceChange",
+                                "amount": NEG2,
+                                "newVaultBalance": F0,
+                                "oldVaultBalance": F0,
+                                "vault": {
+                                    "id": "0xv1",
+                                    "vaultId": "0x01",
+                                    "token": {
+                                        "id": "0x12e605bc104e93b45e1ad99f9e555f659051c2bb",
+                                        "address": "0x12e605bc104e93b45e1ad99f9e555f659051c2bb",
+                                        "name": "Staked FLR",
+                                        "symbol": "sFLR",
+                                        "decimals": "18"
+                                    }
+                                },
+                                "timestamp": "1700000000",
+                                "transaction": {
+                                    "id": "0x0000000000000000000000000000000000000000000000000000000000000abc",
+                                    "from": "0x0000000000000000000000000000000000000001",
+                                    "blockNumber": "200",
+                                    "timestamp": "1700000000"
+                                },
+                                "orderbook": { "id": "0x1234567890123456789012345678901234567890" },
+                                "trade": { "tradeEvent": { "__typename": "TakeOrder" } }
+                            },
+                            "order": {
+                                "id": "0x0000000000000000000000000000000000000001",
+                                "orderHash": "0x00000000000000000000000000000000000000000000000000000000000abc01"
+                            },
+                            "inputVaultBalanceChange": {
+                                "id": "0xin1",
+                                "__typename": "TradeVaultBalanceChange",
+                                "amount": F1,
+                                "newVaultBalance": F0,
+                                "oldVaultBalance": F0,
+                                "vault": {
+                                    "id": "0xv2",
+                                    "vaultId": "0x02",
+                                    "token": {
+                                        "id": "0x1d80c49bbbcd1c0911346656b529df9e5c2f783d",
+                                        "address": "0x1d80c49bbbcd1c0911346656b529df9e5c2f783d",
+                                        "name": "Wrapped Flare",
+                                        "symbol": "WFLR",
+                                        "decimals": "18"
+                                    }
+                                },
+                                "timestamp": "1700000000",
+                                "transaction": {
+                                    "id": "0x0000000000000000000000000000000000000000000000000000000000000abc",
+                                    "from": "0x0000000000000000000000000000000000000001",
+                                    "blockNumber": "200",
+                                    "timestamp": "1700000000"
+                                },
+                                "orderbook": { "id": "0x1234567890123456789012345678901234567890" },
+                                "trade": { "tradeEvent": { "__typename": "TakeOrder" } }
+                            },
+                            "timestamp": "1700000000",
+                            "orderbook": { "id": "0x1234567890123456789012345678901234567890" }
+                        }
+                    ]
+                }
+            })
+        }
+
+        #[tokio::test]
+        async fn test_get_by_tx_hash_returns_trades() {
+            let sg_server = MockServer::start_async().await;
+            sg_server.mock(|when, then| {
+                when.path("/sg").body_contains("SgTransactionTradesQuery");
+                then.status(200).json_body_obj(&sample_trades_response());
+            });
+
+            let raindex_client = RaindexClient::new(
+                vec![get_test_yaml(
+                    &sg_server.url("/sg"),
+                    "http://localhost:3000",
+                    "http://localhost:3000",
+                    "http://localhost:3000",
+                )],
+                None,
+            )
+            .unwrap();
+
+            let ob_id = OrderbookIdentifier::new(
+                1,
+                Address::from_str(CHAIN_ID_1_ORDERBOOK_ADDRESS).unwrap(),
+            );
+            let sg_source = SubgraphTrades::new(&raindex_client);
+            let trades = sg_source
+                .get_by_tx_hash(
+                    &ob_id,
+                    b256!("0x0000000000000000000000000000000000000000000000000000000000000456"),
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(trades.len(), 1);
+            let trade = &trades[0];
+            assert_eq!(trade.id(), Bytes::from_str("0xabc1").unwrap());
+            assert_eq!(trade.timestamp(), U256::from(1700000000u64));
+            assert_eq!(
+                trade.orderbook(),
+                Address::from_str(CHAIN_ID_1_ORDERBOOK_ADDRESS).unwrap()
+            );
+        }
+
+        #[tokio::test]
+        async fn test_get_by_tx_hash_empty_propagates_error() {
+            let sg_server = MockServer::start_async().await;
+            sg_server.mock(|when, then| {
+                when.path("/sg").body_contains("SgTransactionTradesQuery");
+                then.status(200).json_body_obj(&empty_trades_response());
+            });
+
+            let raindex_client = RaindexClient::new(
+                vec![get_test_yaml(
+                    &sg_server.url("/sg"),
+                    "http://localhost:3000",
+                    "http://localhost:3000",
+                    "http://localhost:3000",
+                )],
+                None,
+            )
+            .unwrap();
+
+            let ob_id = OrderbookIdentifier::new(
+                1,
+                Address::from_str(CHAIN_ID_1_ORDERBOOK_ADDRESS).unwrap(),
+            );
+            let sg_source = SubgraphTrades::new(&raindex_client);
+            let result = sg_source
+                .get_by_tx_hash(
+                    &ob_id,
+                    b256!("0x0000000000000000000000000000000000000000000000000000000000000789"),
+                )
+                .await;
+
+            assert!(result.is_err());
+        }
+
+        #[tokio::test]
+        async fn test_get_by_owner_returns_trades() {
+            let sg_server = MockServer::start_async().await;
+            sg_server.mock(|when, then| {
+                when.path("/sg").body_contains("SgOwnerTradesListQuery");
+                then.status(200)
+                    .json_body_obj(&sample_owner_trades_response());
+            });
+
+            let raindex_client = RaindexClient::new(
+                vec![get_test_yaml(
+                    &sg_server.url("/sg"),
+                    "http://localhost:3000",
+                    "http://localhost:3000",
+                    "http://localhost:3000",
+                )],
+                None,
+            )
+            .unwrap();
+
+            let ob_id = OrderbookIdentifier::new(
+                1,
+                Address::from_str(CHAIN_ID_1_ORDERBOOK_ADDRESS).unwrap(),
+            );
+            let sg_source = SubgraphTrades::new(&raindex_client);
+            let trades = sg_source
+                .get_by_owner(
+                    &ob_id,
+                    Address::from_str("0xf08bcbce72f62c95dcb7c07dcb5ed26acfcfbc11").unwrap(),
+                    None,
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(trades.len(), 1);
+            let trade = &trades[0];
+            assert_eq!(trade.id(), Bytes::from_str("0xabc1").unwrap());
+            assert_eq!(trade.timestamp(), U256::from(1700000000u64));
+        }
+
+        #[tokio::test]
+        async fn test_get_by_owner_empty() {
+            let sg_server = MockServer::start_async().await;
+            sg_server.mock(|when, then| {
+                when.path("/sg").body_contains("SgOwnerTradesListQuery");
+                then.status(200).json_body_obj(&empty_trades_response());
+            });
+
+            let raindex_client = RaindexClient::new(
+                vec![get_test_yaml(
+                    &sg_server.url("/sg"),
+                    "http://localhost:3000",
+                    "http://localhost:3000",
+                    "http://localhost:3000",
+                )],
+                None,
+            )
+            .unwrap();
+
+            let ob_id = OrderbookIdentifier::new(
+                1,
+                Address::from_str(CHAIN_ID_1_ORDERBOOK_ADDRESS).unwrap(),
+            );
+            let sg_source = SubgraphTrades::new(&raindex_client);
+            let trades = sg_source
+                .get_by_owner(
+                    &ob_id,
+                    Address::from_str("0x0000000000000000000000000000000000000099").unwrap(),
+                    None,
+                )
+                .await
+                .unwrap();
+
+            assert!(trades.is_empty());
+        }
+
+        #[tokio::test]
+        async fn test_count_by_owner() {
+            let sg_server = MockServer::start_async().await;
+            sg_server.mock(|when, then| {
+                when.path("/sg").body_contains("SgOwnerTradesCountQuery");
+                then.status(200)
+                    .json_body_obj(&sample_owner_trades_response());
+            });
+            sg_server.mock(|when, then| {
+                when.path("/sg").body_contains("SgOwnerTradesCountQuery");
+                then.status(200).json_body_obj(&empty_trades_response());
+            });
+
+            let raindex_client = RaindexClient::new(
+                vec![get_test_yaml(
+                    &sg_server.url("/sg"),
+                    "http://localhost:3000",
+                    "http://localhost:3000",
+                    "http://localhost:3000",
+                )],
+                None,
+            )
+            .unwrap();
+
+            let ob_id = OrderbookIdentifier::new(
+                1,
+                Address::from_str(CHAIN_ID_1_ORDERBOOK_ADDRESS).unwrap(),
+            );
+            let sg_source = SubgraphTrades::new(&raindex_client);
+            let count = sg_source
+                .count_by_owner(
+                    &ob_id,
+                    Address::from_str("0xf08bcbce72f62c95dcb7c07dcb5ed26acfcfbc11").unwrap(),
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(count, 1);
+        }
+    }
+}

--- a/crates/common/src/raindex_client/trades/subgraph.rs
+++ b/crates/common/src/raindex_client/trades/subgraph.rs
@@ -41,7 +41,7 @@ impl<'a> SubgraphTrades<'a> {
         time_filter: &TimeFilter,
     ) -> Result<Vec<RaindexTrade>, RaindexError> {
         let client = self.client.get_orderbook_client(ob_id.orderbook_address)?;
-        let owner_bytes = SgBytes(owner.to_string());
+        let owner_bytes = SgBytes(format!("{:#x}", owner));
         let page_num = pagination.page.unwrap_or(1);
         let sg_trades = client
             .owner_trades_list(
@@ -67,7 +67,7 @@ impl<'a> SubgraphTrades<'a> {
         time_filter: &TimeFilter,
     ) -> Result<u64, RaindexError> {
         let client = self.client.get_orderbook_client(ob_id.orderbook_address)?;
-        let owner_bytes = SgBytes(owner.to_string());
+        let owner_bytes = SgBytes(format!("{:#x}", owner));
         Ok(client
             .owner_trades_count(owner_bytes, time_filter.start, time_filter.end)
             .await?)

--- a/crates/common/src/raindex_client/types.rs
+++ b/crates/common/src/raindex_client/types.rs
@@ -10,7 +10,6 @@ pub struct PaginationParams {
     pub(crate) page_size: Option<u16>,
 }
 
-#[cfg(target_family = "wasm")]
 #[wasm_bindgen]
 impl PaginationParams {
     #[wasm_bindgen(constructor)]
@@ -26,7 +25,6 @@ pub struct TimeFilter {
     pub(crate) end: Option<u64>,
 }
 
-#[cfg(target_family = "wasm")]
 #[wasm_bindgen]
 impl TimeFilter {
     #[wasm_bindgen(constructor)]
@@ -42,7 +40,6 @@ pub struct OrderbookIdentifierParams {
     pub(crate) orderbook_address: String,
 }
 
-#[cfg(target_family = "wasm")]
 #[wasm_bindgen]
 impl OrderbookIdentifierParams {
     #[wasm_bindgen(constructor)]

--- a/crates/common/src/raindex_client/types.rs
+++ b/crates/common/src/raindex_client/types.rs
@@ -1,0 +1,66 @@
+use crate::local_db::OrderbookIdentifier;
+use alloy::primitives::Address;
+use std::str::FromStr;
+use wasm_bindgen_utils::prelude::*;
+
+#[derive(Default, Clone, Debug)]
+#[wasm_bindgen]
+pub struct PaginationParams {
+    pub(crate) page: Option<u16>,
+    pub(crate) page_size: Option<u16>,
+}
+
+#[cfg(target_family = "wasm")]
+#[wasm_bindgen]
+impl PaginationParams {
+    #[wasm_bindgen(constructor)]
+    pub fn new(page: Option<u16>, page_size: Option<u16>) -> Self {
+        Self { page, page_size }
+    }
+}
+
+#[derive(Default, Clone, Debug)]
+#[wasm_bindgen]
+pub struct TimeFilter {
+    pub(crate) start: Option<u64>,
+    pub(crate) end: Option<u64>,
+}
+
+#[cfg(target_family = "wasm")]
+#[wasm_bindgen]
+impl TimeFilter {
+    #[wasm_bindgen(constructor)]
+    pub fn new(start: Option<u64>, end: Option<u64>) -> Self {
+        Self { start, end }
+    }
+}
+
+#[derive(Default, Clone, Debug)]
+#[wasm_bindgen]
+pub struct OrderbookIdentifierParams {
+    pub(crate) chain_id: u32,
+    pub(crate) orderbook_address: String,
+}
+
+#[cfg(target_family = "wasm")]
+#[wasm_bindgen]
+impl OrderbookIdentifierParams {
+    #[wasm_bindgen(constructor)]
+    pub fn new(chain_id: u32, orderbook_address: String) -> Self {
+        Self {
+            chain_id,
+            orderbook_address,
+        }
+    }
+}
+
+impl OrderbookIdentifierParams {
+    pub fn try_into_ob_id(
+        self,
+    ) -> Result<OrderbookIdentifier, alloy::primitives::hex::FromHexError> {
+        Ok(OrderbookIdentifier::new(
+            self.chain_id,
+            Address::from_str(&self.orderbook_address)?,
+        ))
+    }
+}

--- a/crates/subgraph/src/orderbook_client/mod.rs
+++ b/crates/subgraph/src/orderbook_client/mod.rs
@@ -7,8 +7,8 @@ use crate::types::order::{
     SgOrderDetailByHashQueryVariables, SgOrderDetailByIdQuery, SgOrderIdList, SgOrdersListQuery,
 };
 use crate::types::order_trade::{
-    SgOrderTradeDetailQuery, SgOrderTradesListQuery, SgTransactionTradesQuery,
-    TransactionTradesVariables,
+    OwnerTradesVariables, SgOrderTradeDetailQuery, SgOrderTradesListQuery, SgOwnerTradesCountQuery,
+    SgOwnerTradesListQuery, SgTransactionTradesQuery, TransactionTradesVariables,
 };
 use crate::types::remove_order::{
     SgTransactionRemoveOrdersQuery, TransactionRemoveOrdersVariables,

--- a/crates/subgraph/src/orderbook_client/order_trade.rs
+++ b/crates/subgraph/src/orderbook_client/order_trade.rs
@@ -74,6 +74,50 @@ impl OrderbookSubgraphClient {
         }
         Ok(all_pages_merged)
     }
+
+    pub async fn owner_trades_list(
+        &self,
+        owner: SgBytes,
+        pagination_args: SgPaginationArgs,
+    ) -> Result<Vec<SgTrade>, OrderbookSubgraphClientError> {
+        let pagination_variables = Self::parse_pagination_args(pagination_args);
+        let data = self
+            .query::<SgOwnerTradesListQuery, OwnerTradesVariables>(OwnerTradesVariables {
+                owner,
+                first: pagination_variables.first,
+                skip: pagination_variables.skip,
+            })
+            .await?;
+        Ok(data.trades)
+    }
+
+    pub async fn owner_trades_count(
+        &self,
+        owner: SgBytes,
+    ) -> Result<u64, OrderbookSubgraphClientError> {
+        let mut total: u64 = 0;
+        let mut page: u16 = 1;
+        loop {
+            let pagination_variables = Self::parse_pagination_args(SgPaginationArgs {
+                page,
+                page_size: ALL_PAGES_QUERY_PAGE_SIZE,
+            });
+            let data = self
+                .query::<SgOwnerTradesCountQuery, OwnerTradesVariables>(OwnerTradesVariables {
+                    owner: owner.clone(),
+                    first: pagination_variables.first,
+                    skip: pagination_variables.skip,
+                })
+                .await?;
+            let count = data.trades.len() as u64;
+            total += count;
+            if count < ALL_PAGES_QUERY_PAGE_SIZE as u64 {
+                break;
+            }
+            page += 1;
+        }
+        Ok(total)
+    }
 }
 
 #[cfg(test)]
@@ -500,6 +544,126 @@ mod tests {
         });
 
         let result = client.order_trades_list_all(order_id, None, None).await;
+        assert!(matches!(
+            result,
+            Err(OrderbookSubgraphClientError::CynicClientError(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_owner_trades_list_found() {
+        let sg_server = MockServer::start_async().await;
+        let client = setup_client(&sg_server);
+        let owner = SgBytes("0xowner123".to_string());
+        let expected_trades = vec![default_sg_trade(), default_sg_trade()];
+
+        sg_server.mock(|when, then| {
+            when.method(POST).path("/");
+            then.status(200)
+                .json_body(json!({"data": {"trades": expected_trades}}));
+        });
+
+        let result = client
+            .owner_trades_list(
+                owner,
+                SgPaginationArgs {
+                    page: 1,
+                    page_size: 10,
+                },
+            )
+            .await;
+        assert!(result.is_ok());
+        let trades = result.unwrap();
+        assert_eq!(trades.len(), 2);
+        for (actual, expected) in trades.iter().zip(expected_trades.iter()) {
+            assert_sg_trade_eq(actual, expected);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_owner_trades_list_empty() {
+        let sg_server = MockServer::start_async().await;
+        let client = setup_client(&sg_server);
+        let owner = SgBytes("0xowner_empty".to_string());
+
+        sg_server.mock(|when, then| {
+            when.method(POST).path("/");
+            then.status(200).json_body(json!({"data": {"trades": []}}));
+        });
+
+        let result = client
+            .owner_trades_list(
+                owner,
+                SgPaginationArgs {
+                    page: 1,
+                    page_size: 10,
+                },
+            )
+            .await;
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_owner_trades_count_single_page() {
+        let sg_server = MockServer::start_async().await;
+        let client = setup_client(&sg_server);
+        let owner = SgBytes("0xowner_count".to_string());
+        let trade_ids: Vec<serde_json::Value> = (0..5)
+            .map(|i| json!({"id": format!("0xtrade_{}", i)}))
+            .collect();
+
+        sg_server.mock(|when, then| {
+            when.method(POST).path("/");
+            then.status(200)
+                .json_body(json!({"data": {"trades": trade_ids}}));
+        });
+        sg_server.mock(|when, then| {
+            when.method(POST).path("/");
+            then.status(200).json_body(json!({"data": {"trades": []}}));
+        });
+
+        let result = client.owner_trades_count(owner).await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), 5);
+    }
+
+    #[tokio::test]
+    async fn test_owner_trades_count_no_trades() {
+        let sg_server = MockServer::start_async().await;
+        let client = setup_client(&sg_server);
+        let owner = SgBytes("0xowner_no_trades".to_string());
+
+        sg_server.mock(|when, then| {
+            when.method(POST).path("/");
+            then.status(200).json_body(json!({"data": {"trades": []}}));
+        });
+
+        let result = client.owner_trades_count(owner).await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_owner_trades_list_network_error() {
+        let sg_server = MockServer::start_async().await;
+        let client = setup_client(&sg_server);
+        let owner = SgBytes("0xowner_err".to_string());
+
+        sg_server.mock(|when, then| {
+            when.method(POST).path("/");
+            then.status(500);
+        });
+
+        let result = client
+            .owner_trades_list(
+                owner,
+                SgPaginationArgs {
+                    page: 1,
+                    page_size: 10,
+                },
+            )
+            .await;
         assert!(matches!(
             result,
             Err(OrderbookSubgraphClientError::CynicClientError(_))

--- a/crates/subgraph/src/types/order_trade.rs
+++ b/crates/subgraph/src/types/order_trade.rs
@@ -53,6 +53,8 @@ pub struct OwnerTradesVariables {
     pub owner: SgBytes,
     pub first: Option<i32>,
     pub skip: Option<i32>,
+    pub timestamp_gte: Option<SgBigInt>,
+    pub timestamp_lte: Option<SgBigInt>,
 }
 
 #[derive(cynic::QueryFragment, Debug, Serialize)]
@@ -65,7 +67,11 @@ pub struct SgOwnerTradesListQuery {
         first: $first,
         orderBy: "timestamp",
         orderDirection: "desc",
-        where: { order_: { owner: $owner } }
+        where: {
+            order_: { owner: $owner },
+            timestamp_gte: $timestamp_gte,
+            timestamp_lte: $timestamp_lte
+        }
     )]
     pub trades: Vec<SgTrade>,
 }
@@ -84,7 +90,11 @@ pub struct SgOwnerTradesCountQuery {
     #[arguments(
         skip: $skip,
         first: $first,
-        where: { order_: { owner: $owner } }
+        where: {
+            order_: { owner: $owner },
+            timestamp_gte: $timestamp_gte,
+            timestamp_lte: $timestamp_lte
+        }
     )]
     pub trades: Vec<SgTradeId>,
 }

--- a/crates/subgraph/src/types/order_trade.rs
+++ b/crates/subgraph/src/types/order_trade.rs
@@ -47,3 +47,44 @@ pub struct SgTransactionTradesQuery {
     #[arguments(where: { tradeEvent_: { transaction: $id } })]
     pub trades: Vec<SgTrade>,
 }
+
+#[derive(cynic::QueryVariables, Debug)]
+pub struct OwnerTradesVariables {
+    pub owner: SgBytes,
+    pub first: Option<i32>,
+    pub skip: Option<i32>,
+}
+
+#[derive(cynic::QueryFragment, Debug, Serialize)]
+#[cynic(graphql_type = "Query", variables = "OwnerTradesVariables")]
+#[cfg_attr(target_family = "wasm", derive(Tsify))]
+#[serde(rename_all = "camelCase")]
+pub struct SgOwnerTradesListQuery {
+    #[arguments(
+        skip: $skip,
+        first: $first,
+        orderBy: "timestamp",
+        orderDirection: "desc",
+        where: { order_: { owner: $owner } }
+    )]
+    pub trades: Vec<SgTrade>,
+}
+
+#[derive(cynic::QueryFragment, Debug, Clone, Serialize)]
+#[cynic(graphql_type = "Trade")]
+pub struct SgTradeId {
+    pub id: SgBytes,
+}
+
+#[derive(cynic::QueryFragment, Debug, Serialize)]
+#[cynic(graphql_type = "Query", variables = "OwnerTradesVariables")]
+#[cfg_attr(target_family = "wasm", derive(Tsify))]
+#[serde(rename_all = "camelCase")]
+pub struct SgOwnerTradesCountQuery {
+    #[arguments(
+        skip: $skip,
+        first: $first,
+        where: { order_: { owner: $owner } }
+    )]
+    pub trades: Vec<SgTradeId>,
+}


### PR DESCRIPTION
## Chained PRs
- https://github.com/rainlanguage/rain.orderbook/pull/2465

## Motivation

See issues:
- https://github.com/ST0x-Technology/st0x.rest.api/issues/29

The trades public API needed a way to query trades filtered by order owner address. Additionally, the existing trade query code had inline subgraph logic in the fallback path while the local DB path was cleanly abstracted into `LocalDbTrades`. This asymmetry made the code harder to maintain and extend.

## Solution

**Subgraph layer:** Added `SgOwnerTradesListQuery`, `SgOwnerTradesCountQuery` types and `owner_trades_list`/`owner_trades_count` client methods for querying trades by owner address with pagination support.

**Local DB layer:** Added `fetch_owner_trades` and `fetch_owner_trades_count` query modules with SQL queries that join trade events with token metadata, supporting paginated lookups by owner address from SQLite.

**Public API:** Added `get_trades_for_owner` on `RaindexClient` returning `RaindexTradesListResult` (paginated trades + total count), with local DB as the primary path and subgraph fallback.

**SubgraphTrades struct:** Extracted inline subgraph trade logic into a `SubgraphTrades` struct mirroring `LocalDbTrades`, with `get_by_tx_hash`, `get_by_owner`, and `count_by_owner` methods. Refactored `get_by_tx` to use it for consistency.

**Code organization:** Co-located `LocalDbTrades` and `SubgraphTrades` in the `trades/` module so both data source structs live next to the API that consumes them.

## Checks

By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)