### PR TITLE
feat: add get_trades_for_owner API with local DB and subgraph support

### DIFF
--- a/crates/common/src/local_db/query/fetch_owner_trades/mod.rs
+++ b/crates/common/src/local_db/query/fetch_owner_trades/mod.rs
@@ -1,23 +1,20 @@
+use crate::local_db::query::fetch_owner_trades_common::{
+    bind_common_owner_trade_filters, TAKE_ORDERS_CHAIN_IDS_CLAUSE, TAKE_ORDERS_ORDERBOOKS_CLAUSE,
+};
 use crate::local_db::query::{SqlBuildError, SqlStatement, SqlValue};
+use crate::raindex_client::{PaginationParams, TimeFilter};
 use alloy::primitives::Address;
-use std::convert::TryFrom;
 
 const QUERY_TEMPLATE: &str = include_str!("query.sql");
 
-const TAKE_ORDERS_CHAIN_IDS_CLAUSE: &str = "/*TAKE_ORDERS_CHAIN_IDS_CLAUSE*/";
-const TAKE_ORDERS_CHAIN_IDS_CLAUSE_BODY: &str = "AND t.chain_id IN ({list})";
-const TAKE_ORDERS_ORDERBOOKS_CLAUSE: &str = "/*TAKE_ORDERS_ORDERBOOKS_CLAUSE*/";
-const TAKE_ORDERS_ORDERBOOKS_CLAUSE_BODY: &str = "AND t.orderbook_address IN ({list})";
+const START_TS_BODY: &str = "\nAND tws.block_timestamp >= {param}\n";
+const END_TS_BODY: &str = "\nAND tws.block_timestamp <= {param}\n";
 
 const CLEAR_EVENTS_CHAIN_IDS_CLAUSE: &str = "/*CLEAR_EVENTS_CHAIN_IDS_CLAUSE*/";
 const CLEAR_EVENTS_CHAIN_IDS_CLAUSE_BODY: &str = "AND c.chain_id IN ({list})";
 const CLEAR_EVENTS_ORDERBOOKS_CLAUSE: &str = "/*CLEAR_EVENTS_ORDERBOOKS_CLAUSE*/";
 const CLEAR_EVENTS_ORDERBOOKS_CLAUSE_BODY: &str = "AND c.orderbook_address IN ({list})";
 
-const START_TS_CLAUSE: &str = "/*START_TS_CLAUSE*/";
-const START_TS_BODY: &str = "\nAND tws.block_timestamp >= {param}\n";
-const END_TS_CLAUSE: &str = "/*END_TS_CLAUSE*/";
-const END_TS_BODY: &str = "\nAND tws.block_timestamp <= {param}\n";
 const PAGINATION_CLAUSE: &str = "/*PAGINATION_CLAUSE*/";
 
 #[derive(Debug, Clone)]
@@ -25,45 +22,34 @@ pub struct FetchOwnerTradesArgs {
     pub owner: Address,
     pub chain_ids: Vec<u32>,
     pub orderbook_addresses: Vec<Address>,
-    pub start_timestamp: Option<u64>,
-    pub end_timestamp: Option<u64>,
-    pub page: Option<u16>,
+    pub time_filter: TimeFilter,
+    pub pagination: PaginationParams,
 }
 
-pub const PAGE_SIZE: u16 = 100;
+pub const DEFAULT_PAGE_SIZE: u16 = 100;
 
 pub fn build_fetch_owner_trades_stmt(
     args: &FetchOwnerTradesArgs,
 ) -> Result<SqlStatement, SqlBuildError> {
     let mut stmt = SqlStatement::new(QUERY_TEMPLATE);
 
-    stmt.push(SqlValue::from(args.owner));
-
-    let mut chain_ids = args.chain_ids.clone();
-    chain_ids.sort_unstable();
-    chain_ids.dedup();
-
-    let mut orderbooks = args.orderbook_addresses.clone();
-    orderbooks.sort();
-    orderbooks.dedup();
-
-    let chain_ids_iter = || chain_ids.iter().cloned().map(SqlValue::from);
-    let orderbooks_iter = || orderbooks.iter().cloned().map(SqlValue::from);
-
-    stmt.bind_list_clause(
-        TAKE_ORDERS_CHAIN_IDS_CLAUSE,
-        TAKE_ORDERS_CHAIN_IDS_CLAUSE_BODY,
-        chain_ids_iter(),
+    let filters = bind_common_owner_trade_filters(
+        &mut stmt,
+        args.owner,
+        &args.chain_ids,
+        &args.orderbook_addresses,
+        &args.time_filter,
+        START_TS_BODY,
+        END_TS_BODY,
     )?;
+
+    let chain_ids_iter = || filters.chain_ids.iter().cloned().map(SqlValue::from);
+    let orderbooks_iter = || filters.orderbooks.iter().cloned().map(SqlValue::from);
+
     stmt.bind_list_clause(
         CLEAR_EVENTS_CHAIN_IDS_CLAUSE,
         CLEAR_EVENTS_CHAIN_IDS_CLAUSE_BODY,
         chain_ids_iter(),
-    )?;
-    stmt.bind_list_clause(
-        TAKE_ORDERS_ORDERBOOKS_CLAUSE,
-        TAKE_ORDERS_ORDERBOOKS_CLAUSE_BODY,
-        orderbooks_iter(),
     )?;
     stmt.bind_list_clause(
         CLEAR_EVENTS_ORDERBOOKS_CLAUSE,
@@ -71,37 +57,8 @@ pub fn build_fetch_owner_trades_stmt(
         orderbooks_iter(),
     )?;
 
-    if let (Some(start), Some(end)) = (args.start_timestamp, args.end_timestamp) {
-        if start > end {
-            return Err(SqlBuildError::new("start_timestamp > end_timestamp"));
-        }
-    }
-
-    let start_param = if let Some(v) = args.start_timestamp {
-        let i = i64::try_from(v).map_err(|e| {
-            SqlBuildError::new(format!(
-                "start_timestamp out of range for i64: {} ({})",
-                v, e
-            ))
-        })?;
-        Some(SqlValue::I64(i))
-    } else {
-        None
-    };
-    stmt.bind_param_clause(START_TS_CLAUSE, START_TS_BODY, start_param)?;
-
-    let end_param = if let Some(v) = args.end_timestamp {
-        let i = i64::try_from(v).map_err(|e| {
-            SqlBuildError::new(format!("end_timestamp out of range for i64: {} ({})", v, e))
-        })?;
-        Some(SqlValue::I64(i))
-    } else {
-        None
-    };
-    stmt.bind_param_clause(END_TS_CLAUSE, END_TS_BODY, end_param)?;
-
-    if let Some(page) = args.page {
-        let page_size = PAGE_SIZE;
+    if let Some(page) = args.pagination.page {
+        let page_size = args.pagination.page_size.unwrap_or(DEFAULT_PAGE_SIZE);
         let offset = (page.saturating_sub(1) as u64) * (page_size as u64);
         let limit_placeholder = format!("?{}", stmt.params.len() + 1);
         let offset_placeholder = format!("?{}", stmt.params.len() + 2);
@@ -119,6 +76,7 @@ pub fn build_fetch_owner_trades_stmt(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::local_db::query::fetch_owner_trades_common::{END_TS_CLAUSE, START_TS_CLAUSE};
     use alloy::{hex, primitives::address};
 
     #[test]
@@ -128,9 +86,8 @@ mod tests {
             owner,
             chain_ids: vec![137, 1, 137],
             orderbook_addresses: vec![],
-            start_timestamp: None,
-            end_timestamp: None,
-            page: None,
+            time_filter: TimeFilter::default(),
+            pagination: PaginationParams::default(),
         })
         .unwrap();
         assert_eq!(stmt.params[0], SqlValue::Text(hex::encode_prefixed(owner)));
@@ -148,9 +105,8 @@ mod tests {
             owner,
             chain_ids: vec![137],
             orderbook_addresses: vec![ob],
-            start_timestamp: None,
-            end_timestamp: None,
-            page: None,
+            time_filter: TimeFilter::default(),
+            pagination: PaginationParams::default(),
         })
         .unwrap();
         assert!(stmt.sql.contains("t.orderbook_address IN"));
@@ -166,9 +122,11 @@ mod tests {
             owner,
             chain_ids: vec![137],
             orderbook_addresses: vec![],
-            start_timestamp: Some(1000),
-            end_timestamp: Some(2000),
-            page: None,
+            time_filter: TimeFilter {
+                start: Some(1000),
+                end: Some(2000),
+            },
+            pagination: PaginationParams::default(),
         })
         .unwrap();
         assert!(stmt.sql.contains("tws.block_timestamp >="));
@@ -184,9 +142,8 @@ mod tests {
             owner,
             chain_ids: vec![],
             orderbook_addresses: vec![],
-            start_timestamp: None,
-            end_timestamp: None,
-            page: None,
+            time_filter: TimeFilter::default(),
+            pagination: PaginationParams::default(),
         })
         .unwrap();
         assert!(!stmt.sql.contains("tws.block_timestamp >="));
@@ -203,17 +160,19 @@ mod tests {
             owner,
             chain_ids: vec![],
             orderbook_addresses: vec![],
-            start_timestamp: None,
-            end_timestamp: None,
-            page: Some(2),
+            time_filter: TimeFilter::default(),
+            pagination: PaginationParams {
+                page: Some(2),
+                page_size: None,
+            },
         })
         .unwrap();
         assert!(stmt.sql.contains("LIMIT"));
         assert!(stmt.sql.contains("OFFSET"));
         assert!(!stmt.sql.contains(PAGINATION_CLAUSE));
         let last_two = &stmt.params[stmt.params.len() - 2..];
-        assert_eq!(last_two[0], SqlValue::U64(PAGE_SIZE as u64));
-        assert_eq!(last_two[1], SqlValue::U64(PAGE_SIZE as u64));
+        assert_eq!(last_two[0], SqlValue::U64(DEFAULT_PAGE_SIZE as u64));
+        assert_eq!(last_two[1], SqlValue::U64(DEFAULT_PAGE_SIZE as u64));
     }
 
     #[test]
@@ -223,9 +182,11 @@ mod tests {
             owner,
             chain_ids: vec![],
             orderbook_addresses: vec![],
-            start_timestamp: Some(2000),
-            end_timestamp: Some(1000),
-            page: None,
+            time_filter: TimeFilter {
+                start: Some(2000),
+                end: Some(1000),
+            },
+            pagination: PaginationParams::default(),
         });
         assert!(result.is_err());
     }
@@ -237,9 +198,8 @@ mod tests {
             owner,
             chain_ids: vec![],
             orderbook_addresses: vec![],
-            start_timestamp: None,
-            end_timestamp: None,
-            page: None,
+            time_filter: TimeFilter::default(),
+            pagination: PaginationParams::default(),
         })
         .unwrap();
         assert!(!stmt.sql.contains("LIMIT"));

--- a/crates/common/src/local_db/query/fetch_owner_trades/mod.rs
+++ b/crates/common/src/local_db/query/fetch_owner_trades/mod.rs
@@ -71,6 +71,12 @@ pub fn build_fetch_owner_trades_stmt(
         orderbooks_iter(),
     )?;
 
+    if let (Some(start), Some(end)) = (args.start_timestamp, args.end_timestamp) {
+        if start > end {
+            return Err(SqlBuildError::new("start_timestamp > end_timestamp"));
+        }
+    }
+
     let start_param = if let Some(v) = args.start_timestamp {
         let i = i64::try_from(v).map_err(|e| {
             SqlBuildError::new(format!(
@@ -208,6 +214,20 @@ mod tests {
         let last_two = &stmt.params[stmt.params.len() - 2..];
         assert_eq!(last_two[0], SqlValue::U64(PAGE_SIZE as u64));
         assert_eq!(last_two[1], SqlValue::U64(PAGE_SIZE as u64));
+    }
+
+    #[test]
+    fn rejects_inverted_timestamp_window() {
+        let owner = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        let result = build_fetch_owner_trades_stmt(&FetchOwnerTradesArgs {
+            owner,
+            chain_ids: vec![],
+            orderbook_addresses: vec![],
+            start_timestamp: Some(2000),
+            end_timestamp: Some(1000),
+            page: None,
+        });
+        assert!(result.is_err());
     }
 
     #[test]

--- a/crates/common/src/local_db/query/fetch_owner_trades/mod.rs
+++ b/crates/common/src/local_db/query/fetch_owner_trades/mod.rs
@@ -1,0 +1,229 @@
+use crate::local_db::query::{SqlBuildError, SqlStatement, SqlValue};
+use alloy::primitives::Address;
+use std::convert::TryFrom;
+
+const QUERY_TEMPLATE: &str = include_str!("query.sql");
+
+const TAKE_ORDERS_CHAIN_IDS_CLAUSE: &str = "/*TAKE_ORDERS_CHAIN_IDS_CLAUSE*/";
+const TAKE_ORDERS_CHAIN_IDS_CLAUSE_BODY: &str = "AND t.chain_id IN ({list})";
+const TAKE_ORDERS_ORDERBOOKS_CLAUSE: &str = "/*TAKE_ORDERS_ORDERBOOKS_CLAUSE*/";
+const TAKE_ORDERS_ORDERBOOKS_CLAUSE_BODY: &str = "AND t.orderbook_address IN ({list})";
+
+const CLEAR_EVENTS_CHAIN_IDS_CLAUSE: &str = "/*CLEAR_EVENTS_CHAIN_IDS_CLAUSE*/";
+const CLEAR_EVENTS_CHAIN_IDS_CLAUSE_BODY: &str = "AND c.chain_id IN ({list})";
+const CLEAR_EVENTS_ORDERBOOKS_CLAUSE: &str = "/*CLEAR_EVENTS_ORDERBOOKS_CLAUSE*/";
+const CLEAR_EVENTS_ORDERBOOKS_CLAUSE_BODY: &str = "AND c.orderbook_address IN ({list})";
+
+const START_TS_CLAUSE: &str = "/*START_TS_CLAUSE*/";
+const START_TS_BODY: &str = "\nAND tws.block_timestamp >= {param}\n";
+const END_TS_CLAUSE: &str = "/*END_TS_CLAUSE*/";
+const END_TS_BODY: &str = "\nAND tws.block_timestamp <= {param}\n";
+const PAGINATION_CLAUSE: &str = "/*PAGINATION_CLAUSE*/";
+
+#[derive(Debug, Clone)]
+pub struct FetchOwnerTradesArgs {
+    pub owner: Address,
+    pub chain_ids: Vec<u32>,
+    pub orderbook_addresses: Vec<Address>,
+    pub start_timestamp: Option<u64>,
+    pub end_timestamp: Option<u64>,
+    pub page: Option<u16>,
+}
+
+pub const PAGE_SIZE: u16 = 100;
+
+pub fn build_fetch_owner_trades_stmt(
+    args: &FetchOwnerTradesArgs,
+) -> Result<SqlStatement, SqlBuildError> {
+    let mut stmt = SqlStatement::new(QUERY_TEMPLATE);
+
+    stmt.push(SqlValue::from(args.owner));
+
+    let mut chain_ids = args.chain_ids.clone();
+    chain_ids.sort_unstable();
+    chain_ids.dedup();
+
+    let mut orderbooks = args.orderbook_addresses.clone();
+    orderbooks.sort();
+    orderbooks.dedup();
+
+    let chain_ids_iter = || chain_ids.iter().cloned().map(SqlValue::from);
+    let orderbooks_iter = || orderbooks.iter().cloned().map(SqlValue::from);
+
+    stmt.bind_list_clause(
+        TAKE_ORDERS_CHAIN_IDS_CLAUSE,
+        TAKE_ORDERS_CHAIN_IDS_CLAUSE_BODY,
+        chain_ids_iter(),
+    )?;
+    stmt.bind_list_clause(
+        CLEAR_EVENTS_CHAIN_IDS_CLAUSE,
+        CLEAR_EVENTS_CHAIN_IDS_CLAUSE_BODY,
+        chain_ids_iter(),
+    )?;
+    stmt.bind_list_clause(
+        TAKE_ORDERS_ORDERBOOKS_CLAUSE,
+        TAKE_ORDERS_ORDERBOOKS_CLAUSE_BODY,
+        orderbooks_iter(),
+    )?;
+    stmt.bind_list_clause(
+        CLEAR_EVENTS_ORDERBOOKS_CLAUSE,
+        CLEAR_EVENTS_ORDERBOOKS_CLAUSE_BODY,
+        orderbooks_iter(),
+    )?;
+
+    let start_param = if let Some(v) = args.start_timestamp {
+        let i = i64::try_from(v).map_err(|e| {
+            SqlBuildError::new(format!(
+                "start_timestamp out of range for i64: {} ({})",
+                v, e
+            ))
+        })?;
+        Some(SqlValue::I64(i))
+    } else {
+        None
+    };
+    stmt.bind_param_clause(START_TS_CLAUSE, START_TS_BODY, start_param)?;
+
+    let end_param = if let Some(v) = args.end_timestamp {
+        let i = i64::try_from(v).map_err(|e| {
+            SqlBuildError::new(format!("end_timestamp out of range for i64: {} ({})", v, e))
+        })?;
+        Some(SqlValue::I64(i))
+    } else {
+        None
+    };
+    stmt.bind_param_clause(END_TS_CLAUSE, END_TS_BODY, end_param)?;
+
+    if let Some(page) = args.page {
+        let page_size = PAGE_SIZE;
+        let offset = (page.saturating_sub(1) as u64) * (page_size as u64);
+        let limit_placeholder = format!("?{}", stmt.params.len() + 1);
+        let offset_placeholder = format!("?{}", stmt.params.len() + 2);
+        let pagination = format!("LIMIT {} OFFSET {}", limit_placeholder, offset_placeholder);
+        stmt.sql = stmt.sql.replace(PAGINATION_CLAUSE, &pagination);
+        stmt.push(SqlValue::U64(page_size as u64));
+        stmt.push(SqlValue::U64(offset));
+    } else {
+        stmt.sql = stmt.sql.replace(PAGINATION_CLAUSE, "");
+    }
+
+    Ok(stmt)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::{hex, primitives::address};
+
+    #[test]
+    fn builds_with_chain_ids_and_owner() {
+        let owner = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        let stmt = build_fetch_owner_trades_stmt(&FetchOwnerTradesArgs {
+            owner,
+            chain_ids: vec![137, 1, 137],
+            orderbook_addresses: vec![],
+            start_timestamp: None,
+            end_timestamp: None,
+            page: None,
+        })
+        .unwrap();
+        assert_eq!(stmt.params[0], SqlValue::Text(hex::encode_prefixed(owner)));
+        assert!(stmt.sql.contains("t.chain_id IN"));
+        assert!(stmt.sql.contains("c.chain_id IN"));
+        assert!(!stmt.sql.contains(TAKE_ORDERS_CHAIN_IDS_CLAUSE));
+        assert!(!stmt.sql.contains(CLEAR_EVENTS_CHAIN_IDS_CLAUSE));
+    }
+
+    #[test]
+    fn builds_with_orderbook_address_filters() {
+        let owner = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        let ob = address!("0x2f209e5b67a33b8fe96e28f24628df6da301c8eb");
+        let stmt = build_fetch_owner_trades_stmt(&FetchOwnerTradesArgs {
+            owner,
+            chain_ids: vec![137],
+            orderbook_addresses: vec![ob],
+            start_timestamp: None,
+            end_timestamp: None,
+            page: None,
+        })
+        .unwrap();
+        assert!(stmt.sql.contains("t.orderbook_address IN"));
+        assert!(stmt.sql.contains("c.orderbook_address IN"));
+        assert!(!stmt.sql.contains(TAKE_ORDERS_ORDERBOOKS_CLAUSE));
+        assert!(!stmt.sql.contains(CLEAR_EVENTS_ORDERBOOKS_CLAUSE));
+    }
+
+    #[test]
+    fn builds_with_time_filters() {
+        let owner = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        let stmt = build_fetch_owner_trades_stmt(&FetchOwnerTradesArgs {
+            owner,
+            chain_ids: vec![137],
+            orderbook_addresses: vec![],
+            start_timestamp: Some(1000),
+            end_timestamp: Some(2000),
+            page: None,
+        })
+        .unwrap();
+        assert!(stmt.sql.contains("tws.block_timestamp >="));
+        assert!(stmt.sql.contains("tws.block_timestamp <="));
+        assert!(!stmt.sql.contains(START_TS_CLAUSE));
+        assert!(!stmt.sql.contains(END_TS_CLAUSE));
+    }
+
+    #[test]
+    fn builds_without_time_filters_when_none() {
+        let owner = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        let stmt = build_fetch_owner_trades_stmt(&FetchOwnerTradesArgs {
+            owner,
+            chain_ids: vec![],
+            orderbook_addresses: vec![],
+            start_timestamp: None,
+            end_timestamp: None,
+            page: None,
+        })
+        .unwrap();
+        assert!(!stmt.sql.contains("tws.block_timestamp >="));
+        assert!(!stmt.sql.contains("tws.block_timestamp <="));
+        assert!(!stmt.sql.contains(START_TS_CLAUSE));
+        assert!(!stmt.sql.contains(END_TS_CLAUSE));
+        assert_eq!(stmt.params.len(), 1);
+    }
+
+    #[test]
+    fn builds_with_pagination() {
+        let owner = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        let stmt = build_fetch_owner_trades_stmt(&FetchOwnerTradesArgs {
+            owner,
+            chain_ids: vec![],
+            orderbook_addresses: vec![],
+            start_timestamp: None,
+            end_timestamp: None,
+            page: Some(2),
+        })
+        .unwrap();
+        assert!(stmt.sql.contains("LIMIT"));
+        assert!(stmt.sql.contains("OFFSET"));
+        assert!(!stmt.sql.contains(PAGINATION_CLAUSE));
+        let last_two = &stmt.params[stmt.params.len() - 2..];
+        assert_eq!(last_two[0], SqlValue::U64(PAGE_SIZE as u64));
+        assert_eq!(last_two[1], SqlValue::U64(PAGE_SIZE as u64));
+    }
+
+    #[test]
+    fn builds_without_pagination_when_none() {
+        let owner = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        let stmt = build_fetch_owner_trades_stmt(&FetchOwnerTradesArgs {
+            owner,
+            chain_ids: vec![],
+            orderbook_addresses: vec![],
+            start_timestamp: None,
+            end_timestamp: None,
+            page: None,
+        })
+        .unwrap();
+        assert!(!stmt.sql.contains("LIMIT"));
+        assert!(!stmt.sql.contains("OFFSET"));
+        assert!(!stmt.sql.contains(PAGINATION_CLAUSE));
+    }
+}

--- a/crates/common/src/local_db/query/fetch_owner_trades/mod.rs
+++ b/crates/common/src/local_db/query/fetch_owner_trades/mod.rs
@@ -1,6 +1,4 @@
-use crate::local_db::query::fetch_owner_trades_common::{
-    bind_common_owner_trade_filters, TAKE_ORDERS_CHAIN_IDS_CLAUSE, TAKE_ORDERS_ORDERBOOKS_CLAUSE,
-};
+use crate::local_db::query::fetch_owner_trades_common::bind_common_owner_trade_filters;
 use crate::local_db::query::{SqlBuildError, SqlStatement, SqlValue};
 use crate::raindex_client::{PaginationParams, TimeFilter};
 use alloy::primitives::Address;
@@ -76,7 +74,9 @@ pub fn build_fetch_owner_trades_stmt(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::local_db::query::fetch_owner_trades_common::{END_TS_CLAUSE, START_TS_CLAUSE};
+    use crate::local_db::query::fetch_owner_trades_common::{
+        END_TS_CLAUSE, START_TS_CLAUSE, TAKE_ORDERS_CHAIN_IDS_CLAUSE, TAKE_ORDERS_ORDERBOOKS_CLAUSE,
+    };
     use alloy::{hex, primitives::address};
 
     #[test]

--- a/crates/common/src/local_db/query/fetch_owner_trades/query.sql
+++ b/crates/common/src/local_db/query/fetch_owner_trades/query.sql
@@ -1,0 +1,387 @@
+WITH
+params AS (
+  SELECT
+    ?1 AS order_owner_filter
+),
+matching_take_orders AS (
+  SELECT
+    'take' AS trade_kind,
+    t.chain_id,
+    t.orderbook_address,
+    t.order_owner,
+    t.order_nonce,
+    t.transaction_hash,
+    t.log_index,
+    t.block_number,
+    t.block_timestamp,
+    t.sender AS transaction_sender,
+    t.input_io_index,
+    t.output_io_index,
+    t.taker_output AS input_delta,
+    FLOAT_NEGATE(t.taker_input) AS output_delta
+  FROM take_orders t
+  JOIN params p
+    ON t.order_owner = p.order_owner_filter
+  WHERE 1 = 1
+  /*TAKE_ORDERS_CHAIN_IDS_CLAUSE*/
+  /*TAKE_ORDERS_ORDERBOOKS_CLAUSE*/
+),
+matching_clears AS (
+  SELECT
+    c.chain_id,
+    c.orderbook_address,
+    c.transaction_hash,
+    c.log_index,
+    c.block_number,
+    c.block_timestamp,
+    c.sender,
+    c.alice_order_hash,
+    c.bob_order_hash,
+    c.alice_input_io_index,
+    c.alice_output_io_index,
+    c.alice_input_vault_id,
+    c.alice_output_vault_id,
+    c.bob_input_io_index,
+    c.bob_output_io_index,
+    c.bob_input_vault_id,
+    c.bob_output_vault_id
+  FROM clear_v3_events c
+  JOIN params p ON 1 = 1
+  JOIN order_events oe
+    ON oe.chain_id = c.chain_id
+   AND oe.orderbook_address = c.orderbook_address
+   AND oe.event_type = 'AddOrderV3'
+   AND oe.order_owner = p.order_owner_filter
+   AND (
+        oe.order_hash = c.alice_order_hash
+     OR oe.order_hash = c.bob_order_hash
+   )
+  WHERE 1 = 1
+  /*CLEAR_EVENTS_CHAIN_IDS_CLAUSE*/
+  /*CLEAR_EVENTS_ORDERBOOKS_CLAUSE*/
+),
+take_trades AS (
+  SELECT
+    mt.trade_kind,
+    mt.chain_id,
+    mt.orderbook_address,
+    oe.order_hash,
+    mt.order_owner,
+    mt.order_nonce,
+    mt.transaction_hash,
+    mt.log_index,
+    mt.block_number,
+    mt.block_timestamp,
+    mt.transaction_sender,
+    io_in.vault_id AS input_vault_id,
+    io_in.token AS input_token,
+    mt.input_delta,
+    io_out.vault_id AS output_vault_id,
+    io_out.token AS output_token,
+    mt.output_delta
+  FROM matching_take_orders mt
+  JOIN order_events oe
+    ON oe.chain_id = mt.chain_id
+   AND oe.orderbook_address = mt.orderbook_address
+   AND oe.order_owner = mt.order_owner
+   AND oe.order_nonce = mt.order_nonce
+   AND oe.event_type = 'AddOrderV3'
+   AND (
+        oe.block_number < mt.block_number
+     OR (oe.block_number = mt.block_number AND oe.log_index <= mt.log_index)
+   )
+   AND NOT EXISTS (
+     SELECT 1
+     FROM order_events newer
+     WHERE newer.chain_id = oe.chain_id
+      AND newer.orderbook_address = oe.orderbook_address
+      AND newer.order_owner = oe.order_owner
+      AND newer.order_nonce = oe.order_nonce
+      AND newer.event_type = 'AddOrderV3'
+       AND (
+            newer.block_number < mt.block_number
+         OR (newer.block_number = mt.block_number AND newer.log_index <= mt.log_index)
+       )
+       AND (
+            newer.block_number > oe.block_number
+         OR (newer.block_number = oe.block_number AND newer.log_index > oe.log_index)
+       )
+   )
+  JOIN order_ios io_in
+    ON io_in.chain_id = oe.chain_id
+   AND io_in.orderbook_address = oe.orderbook_address
+   AND io_in.transaction_hash = oe.transaction_hash
+   AND io_in.log_index = oe.log_index
+   AND io_in.io_index = mt.input_io_index
+   AND io_in.io_type = 'input'
+  JOIN order_ios io_out
+    ON io_out.chain_id = oe.chain_id
+   AND io_out.orderbook_address = oe.orderbook_address
+   AND io_out.transaction_hash = oe.transaction_hash
+   AND io_out.log_index = oe.log_index
+   AND io_out.io_index = mt.output_io_index
+   AND io_out.io_type = 'output'
+),
+clear_alice AS (
+  SELECT DISTINCT
+    'clear' AS trade_kind,
+    mc.chain_id,
+    mc.orderbook_address,
+    oe.order_hash,
+    oe.order_owner,
+    oe.order_nonce,
+    mc.transaction_hash,
+    mc.log_index,
+    mc.block_number,
+    mc.block_timestamp,
+    mc.sender AS transaction_sender,
+    mc.alice_input_vault_id AS input_vault_id,
+    io_in.token AS input_token,
+    a.alice_input AS input_delta,
+    mc.alice_output_vault_id AS output_vault_id,
+    io_out.token AS output_token,
+    FLOAT_NEGATE(a.alice_output) AS output_delta
+  FROM matching_clears mc
+  JOIN params p ON 1 = 1
+  JOIN order_events oe
+    ON oe.chain_id = mc.chain_id
+   AND oe.orderbook_address = mc.orderbook_address
+   AND oe.order_hash = mc.alice_order_hash
+   AND oe.event_type = 'AddOrderV3'
+   AND oe.order_owner = p.order_owner_filter
+   AND (
+        oe.block_number < mc.block_number
+     OR (oe.block_number = mc.block_number AND oe.log_index <= mc.log_index)
+   )
+   AND NOT EXISTS (
+     SELECT 1
+     FROM order_events newer
+     WHERE newer.chain_id = oe.chain_id
+      AND newer.orderbook_address = oe.orderbook_address
+      AND newer.order_hash = oe.order_hash
+      AND newer.event_type = 'AddOrderV3'
+       AND (
+            newer.block_number < mc.block_number
+         OR (newer.block_number = mc.block_number AND newer.log_index <= mc.log_index)
+       )
+       AND (
+            newer.block_number > oe.block_number
+         OR (newer.block_number = oe.block_number AND newer.log_index > oe.log_index)
+       )
+   )
+  JOIN after_clear_v2_events a
+    ON a.chain_id = mc.chain_id
+   AND a.orderbook_address = mc.orderbook_address
+   AND a.transaction_hash = mc.transaction_hash
+   AND a.log_index = (
+       SELECT MIN(ac.log_index)
+       FROM after_clear_v2_events ac
+       WHERE ac.chain_id = mc.chain_id
+         AND ac.orderbook_address = mc.orderbook_address
+         AND ac.transaction_hash = mc.transaction_hash
+         AND ac.log_index > mc.log_index
+   )
+  JOIN order_ios io_in
+    ON io_in.chain_id = oe.chain_id
+   AND io_in.orderbook_address = oe.orderbook_address
+   AND io_in.transaction_hash = oe.transaction_hash
+   AND io_in.log_index = oe.log_index
+   AND io_in.io_index = mc.alice_input_io_index
+   AND io_in.io_type = 'input'
+  JOIN order_ios io_out
+    ON io_out.chain_id = oe.chain_id
+   AND io_out.orderbook_address = oe.orderbook_address
+   AND io_out.transaction_hash = oe.transaction_hash
+   AND io_out.log_index = oe.log_index
+   AND io_out.io_index = mc.alice_output_io_index
+   AND io_out.io_type = 'output'
+),
+clear_bob AS (
+  SELECT DISTINCT
+    'clear' AS trade_kind,
+    mc.chain_id,
+    mc.orderbook_address,
+    oe.order_hash,
+    oe.order_owner,
+    oe.order_nonce,
+    mc.transaction_hash,
+    mc.log_index,
+    mc.block_number,
+    mc.block_timestamp,
+    mc.sender AS transaction_sender,
+    mc.bob_input_vault_id AS input_vault_id,
+    io_in.token AS input_token,
+    a.bob_input AS input_delta,
+    mc.bob_output_vault_id AS output_vault_id,
+    io_out.token AS output_token,
+    FLOAT_NEGATE(a.bob_output) AS output_delta
+  FROM matching_clears mc
+  JOIN params p ON 1 = 1
+  JOIN order_events oe
+    ON oe.chain_id = mc.chain_id
+   AND oe.orderbook_address = mc.orderbook_address
+   AND oe.order_hash = mc.bob_order_hash
+   AND oe.event_type = 'AddOrderV3'
+   AND oe.order_owner = p.order_owner_filter
+   AND (
+        oe.block_number < mc.block_number
+     OR (oe.block_number = mc.block_number AND oe.log_index <= mc.log_index)
+   )
+   AND NOT EXISTS (
+     SELECT 1
+     FROM order_events newer
+     WHERE newer.chain_id = oe.chain_id
+      AND newer.orderbook_address = oe.orderbook_address
+      AND newer.order_hash = oe.order_hash
+      AND newer.event_type = 'AddOrderV3'
+       AND (
+            newer.block_number < mc.block_number
+         OR (newer.block_number = mc.block_number AND newer.log_index <= mc.log_index)
+       )
+       AND (
+            newer.block_number > oe.block_number
+         OR (newer.block_number = oe.block_number AND newer.log_index > oe.log_index)
+       )
+   )
+  JOIN after_clear_v2_events a
+    ON a.chain_id = mc.chain_id
+   AND a.orderbook_address = mc.orderbook_address
+   AND a.transaction_hash = mc.transaction_hash
+   AND a.log_index = (
+       SELECT MIN(ac.log_index)
+       FROM after_clear_v2_events ac
+       WHERE ac.chain_id = mc.chain_id
+         AND ac.orderbook_address = mc.orderbook_address
+         AND ac.transaction_hash = mc.transaction_hash
+         AND ac.log_index > mc.log_index
+   )
+  JOIN order_ios io_in
+    ON io_in.chain_id = oe.chain_id
+   AND io_in.orderbook_address = oe.orderbook_address
+   AND io_in.transaction_hash = oe.transaction_hash
+   AND io_in.log_index = oe.log_index
+   AND io_in.io_index = mc.bob_input_io_index
+   AND io_in.io_type = 'input'
+  JOIN order_ios io_out
+    ON io_out.chain_id = oe.chain_id
+   AND io_out.orderbook_address = oe.orderbook_address
+   AND io_out.transaction_hash = oe.transaction_hash
+   AND io_out.log_index = oe.log_index
+   AND io_out.io_index = mc.bob_output_io_index
+   AND io_out.io_type = 'output'
+),
+clear_trades AS (
+  SELECT * FROM clear_alice
+  UNION ALL
+  SELECT * FROM clear_bob
+),
+unioned_trades AS (
+  SELECT * FROM take_trades
+  UNION ALL
+  SELECT * FROM clear_trades
+),
+trade_rows AS (
+  SELECT
+    ut.trade_kind,
+    ut.chain_id,
+    ut.orderbook_address,
+    ut.order_hash,
+    ut.order_owner,
+    ut.order_nonce,
+    ut.transaction_hash,
+    ut.log_index,
+    ut.block_number,
+    ut.block_timestamp,
+    ut.transaction_sender,
+    ut.input_vault_id,
+    ut.input_token,
+    ut.input_delta,
+    ut.output_vault_id,
+    ut.output_token,
+    ut.output_delta
+  FROM unioned_trades ut
+),
+trade_with_snapshots AS (
+  SELECT
+    tr.*,
+    mvb_in.balance AS input_base_balance,
+    mvb_in.last_block AS input_base_block,
+    mvb_in.last_log_index AS input_base_log_index,
+    mvb_out.balance AS output_base_balance,
+    mvb_out.last_block AS output_base_block,
+    mvb_out.last_log_index AS output_base_log_index
+  FROM trade_rows tr
+  LEFT JOIN running_vault_balances mvb_in
+    ON mvb_in.chain_id = tr.chain_id
+   AND mvb_in.orderbook_address = tr.orderbook_address
+   AND mvb_in.owner = tr.order_owner
+   AND mvb_in.token = tr.input_token
+   AND mvb_in.vault_id = tr.input_vault_id
+  LEFT JOIN running_vault_balances mvb_out
+    ON mvb_out.chain_id = tr.chain_id
+   AND mvb_out.orderbook_address = tr.orderbook_address
+   AND mvb_out.owner = tr.order_owner
+   AND mvb_out.token = tr.output_token
+   AND mvb_out.vault_id = tr.output_vault_id
+)
+SELECT
+  tws.chain_id,
+  tws.trade_kind,
+  tws.orderbook_address AS orderbook,
+  tws.order_hash,
+  tws.order_owner,
+  tws.order_nonce,
+  tws.transaction_hash,
+  tws.log_index,
+  tws.block_number,
+  tws.block_timestamp,
+  tws.transaction_sender,
+  tws.input_vault_id,
+  tws.input_token,
+  tok_in.name AS input_token_name,
+  tok_in.symbol AS input_token_symbol,
+  tok_in.decimals AS input_token_decimals,
+  tws.input_delta,
+  vbc_input.running_balance AS input_running_balance,
+  tws.output_vault_id,
+  tws.output_token,
+  tok_out.name AS output_token_name,
+  tok_out.symbol AS output_token_symbol,
+  tok_out.decimals AS output_token_decimals,
+  tws.output_delta,
+  vbc_output.running_balance AS output_running_balance,
+  (
+    '0x' ||
+    lower(replace(tws.transaction_hash, '0x', '')) ||
+    printf('%016x', tws.log_index)
+  ) AS trade_id
+FROM trade_with_snapshots tws
+LEFT JOIN vault_balance_changes vbc_input
+  ON vbc_input.chain_id = tws.chain_id
+ AND vbc_input.orderbook_address = tws.orderbook_address
+ AND vbc_input.owner = tws.order_owner
+ AND vbc_input.token = tws.input_token
+ AND vbc_input.vault_id = tws.input_vault_id
+ AND vbc_input.block_number = tws.block_number
+ AND vbc_input.log_index = tws.log_index
+LEFT JOIN vault_balance_changes vbc_output
+  ON vbc_output.chain_id = tws.chain_id
+ AND vbc_output.orderbook_address = tws.orderbook_address
+ AND vbc_output.owner = tws.order_owner
+ AND vbc_output.token = tws.output_token
+ AND vbc_output.vault_id = tws.output_vault_id
+ AND vbc_output.block_number = tws.block_number
+ AND vbc_output.log_index = tws.log_index
+LEFT JOIN erc20_tokens tok_in
+  ON tok_in.chain_id = tws.chain_id
+ AND tok_in.orderbook_address = tws.orderbook_address
+ AND tok_in.token_address = tws.input_token
+LEFT JOIN erc20_tokens tok_out
+  ON tok_out.chain_id = tws.chain_id
+ AND tok_out.orderbook_address = tws.orderbook_address
+ AND tok_out.token_address = tws.output_token
+WHERE 1 = 1
+/*START_TS_CLAUSE*/
+/*END_TS_CLAUSE*/
+ORDER BY tws.block_timestamp DESC, tws.block_number DESC, tws.log_index DESC, tws.trade_kind
+/*PAGINATION_CLAUSE*/;

--- a/crates/common/src/local_db/query/fetch_owner_trades_common.rs
+++ b/crates/common/src/local_db/query/fetch_owner_trades_common.rs
@@ -1,0 +1,85 @@
+use crate::local_db::query::{SqlBuildError, SqlStatement, SqlValue};
+use crate::raindex_client::TimeFilter;
+use alloy::primitives::Address;
+use std::convert::TryFrom;
+
+pub(crate) const TAKE_ORDERS_CHAIN_IDS_CLAUSE: &str = "/*TAKE_ORDERS_CHAIN_IDS_CLAUSE*/";
+pub(crate) const TAKE_ORDERS_CHAIN_IDS_CLAUSE_BODY: &str = "AND t.chain_id IN ({list})";
+pub(crate) const TAKE_ORDERS_ORDERBOOKS_CLAUSE: &str = "/*TAKE_ORDERS_ORDERBOOKS_CLAUSE*/";
+pub(crate) const TAKE_ORDERS_ORDERBOOKS_CLAUSE_BODY: &str = "AND t.orderbook_address IN ({list})";
+
+pub(crate) const START_TS_CLAUSE: &str = "/*START_TS_CLAUSE*/";
+pub(crate) const END_TS_CLAUSE: &str = "/*END_TS_CLAUSE*/";
+
+pub(crate) struct PreparedOwnerTradeFilters {
+    pub chain_ids: Vec<u32>,
+    pub orderbooks: Vec<Address>,
+}
+
+pub(crate) fn bind_common_owner_trade_filters(
+    stmt: &mut SqlStatement,
+    owner: Address,
+    chain_ids: &[u32],
+    orderbook_addresses: &[Address],
+    time_filter: &TimeFilter,
+    start_ts_body: &str,
+    end_ts_body: &str,
+) -> Result<PreparedOwnerTradeFilters, SqlBuildError> {
+    stmt.push(SqlValue::from(owner));
+
+    let mut chain_ids = chain_ids.to_vec();
+    chain_ids.sort_unstable();
+    chain_ids.dedup();
+
+    let mut orderbooks = orderbook_addresses.to_vec();
+    orderbooks.sort();
+    orderbooks.dedup();
+
+    let chain_ids_iter = || chain_ids.iter().cloned().map(SqlValue::from);
+    let orderbooks_iter = || orderbooks.iter().cloned().map(SqlValue::from);
+
+    stmt.bind_list_clause(
+        TAKE_ORDERS_CHAIN_IDS_CLAUSE,
+        TAKE_ORDERS_CHAIN_IDS_CLAUSE_BODY,
+        chain_ids_iter(),
+    )?;
+    stmt.bind_list_clause(
+        TAKE_ORDERS_ORDERBOOKS_CLAUSE,
+        TAKE_ORDERS_ORDERBOOKS_CLAUSE_BODY,
+        orderbooks_iter(),
+    )?;
+
+    if let (Some(start), Some(end)) = (time_filter.start, time_filter.end) {
+        if start > end {
+            return Err(SqlBuildError::new("start_timestamp > end_timestamp"));
+        }
+    }
+
+    let start_param = if let Some(v) = time_filter.start {
+        let i = i64::try_from(v).map_err(|e| {
+            SqlBuildError::new(format!(
+                "start_timestamp out of range for i64: {} ({})",
+                v, e
+            ))
+        })?;
+        Some(SqlValue::I64(i))
+    } else {
+        None
+    };
+    stmt.bind_param_clause(START_TS_CLAUSE, start_ts_body, start_param)?;
+
+    let end_param = if let Some(v) = time_filter.end {
+        let i = i64::try_from(v).map_err(|e| {
+            SqlBuildError::new(format!("end_timestamp out of range for i64: {} ({})", v, e))
+        })?;
+        Some(SqlValue::I64(i))
+    } else {
+        None
+    };
+    stmt.bind_param_clause(END_TS_CLAUSE, end_ts_body, end_param)?;
+
+    Ok(PreparedOwnerTradeFilters {
+        chain_ids,
+        orderbooks,
+    })
+}

--- a/crates/common/src/local_db/query/fetch_owner_trades_count/mod.rs
+++ b/crates/common/src/local_db/query/fetch_owner_trades_count/mod.rs
@@ -1,0 +1,182 @@
+use crate::local_db::query::{SqlBuildError, SqlStatement, SqlValue};
+use alloy::primitives::Address;
+use std::convert::TryFrom;
+
+const QUERY_TEMPLATE: &str = include_str!("query.sql");
+
+pub use super::fetch_order_trades_count::LocalDbTradeCountRow;
+
+const TAKE_ORDERS_CHAIN_IDS_CLAUSE: &str = "/*TAKE_ORDERS_CHAIN_IDS_CLAUSE*/";
+const TAKE_ORDERS_CHAIN_IDS_CLAUSE_BODY: &str = "AND t.chain_id IN ({list})";
+const TAKE_ORDERS_ORDERBOOKS_CLAUSE: &str = "/*TAKE_ORDERS_ORDERBOOKS_CLAUSE*/";
+const TAKE_ORDERS_ORDERBOOKS_CLAUSE_BODY: &str = "AND t.orderbook_address IN ({list})";
+
+const CLEAR_ALICE_CHAIN_IDS_CLAUSE: &str = "/*CLEAR_ALICE_CHAIN_IDS_CLAUSE*/";
+const CLEAR_ALICE_CHAIN_IDS_CLAUSE_BODY: &str = "AND c.chain_id IN ({list})";
+const CLEAR_ALICE_ORDERBOOKS_CLAUSE: &str = "/*CLEAR_ALICE_ORDERBOOKS_CLAUSE*/";
+const CLEAR_ALICE_ORDERBOOKS_CLAUSE_BODY: &str = "AND c.orderbook_address IN ({list})";
+
+const CLEAR_BOB_CHAIN_IDS_CLAUSE: &str = "/*CLEAR_BOB_CHAIN_IDS_CLAUSE*/";
+const CLEAR_BOB_CHAIN_IDS_CLAUSE_BODY: &str = "AND c.chain_id IN ({list})";
+const CLEAR_BOB_ORDERBOOKS_CLAUSE: &str = "/*CLEAR_BOB_ORDERBOOKS_CLAUSE*/";
+const CLEAR_BOB_ORDERBOOKS_CLAUSE_BODY: &str = "AND c.orderbook_address IN ({list})";
+
+const START_TS_CLAUSE: &str = "/*START_TS_CLAUSE*/";
+const START_TS_BODY: &str = "\nAND block_timestamp >= {param}\n";
+const END_TS_CLAUSE: &str = "/*END_TS_CLAUSE*/";
+const END_TS_BODY: &str = "\nAND block_timestamp <= {param}\n";
+
+#[derive(Debug, Clone)]
+pub struct FetchOwnerTradesCountArgs {
+    pub owner: Address,
+    pub chain_ids: Vec<u32>,
+    pub orderbook_addresses: Vec<Address>,
+    pub start_timestamp: Option<u64>,
+    pub end_timestamp: Option<u64>,
+}
+
+pub fn build_fetch_owner_trades_count_stmt(
+    args: &FetchOwnerTradesCountArgs,
+) -> Result<SqlStatement, SqlBuildError> {
+    let mut stmt = SqlStatement::new(QUERY_TEMPLATE);
+
+    stmt.push(SqlValue::from(args.owner));
+
+    let mut chain_ids = args.chain_ids.clone();
+    chain_ids.sort_unstable();
+    chain_ids.dedup();
+
+    let mut orderbooks = args.orderbook_addresses.clone();
+    orderbooks.sort();
+    orderbooks.dedup();
+
+    let chain_ids_iter = || chain_ids.iter().cloned().map(SqlValue::from);
+    let orderbooks_iter = || orderbooks.iter().cloned().map(SqlValue::from);
+
+    stmt.bind_list_clause(
+        TAKE_ORDERS_CHAIN_IDS_CLAUSE,
+        TAKE_ORDERS_CHAIN_IDS_CLAUSE_BODY,
+        chain_ids_iter(),
+    )?;
+    stmt.bind_list_clause(
+        TAKE_ORDERS_ORDERBOOKS_CLAUSE,
+        TAKE_ORDERS_ORDERBOOKS_CLAUSE_BODY,
+        orderbooks_iter(),
+    )?;
+    stmt.bind_list_clause(
+        CLEAR_ALICE_CHAIN_IDS_CLAUSE,
+        CLEAR_ALICE_CHAIN_IDS_CLAUSE_BODY,
+        chain_ids_iter(),
+    )?;
+    stmt.bind_list_clause(
+        CLEAR_ALICE_ORDERBOOKS_CLAUSE,
+        CLEAR_ALICE_ORDERBOOKS_CLAUSE_BODY,
+        orderbooks_iter(),
+    )?;
+    stmt.bind_list_clause(
+        CLEAR_BOB_CHAIN_IDS_CLAUSE,
+        CLEAR_BOB_CHAIN_IDS_CLAUSE_BODY,
+        chain_ids_iter(),
+    )?;
+    stmt.bind_list_clause(
+        CLEAR_BOB_ORDERBOOKS_CLAUSE,
+        CLEAR_BOB_ORDERBOOKS_CLAUSE_BODY,
+        orderbooks_iter(),
+    )?;
+
+    if let (Some(start), Some(end)) = (args.start_timestamp, args.end_timestamp) {
+        if start > end {
+            return Err(SqlBuildError::new("start_timestamp > end_timestamp"));
+        }
+    }
+
+    let start_param = if let Some(v) = args.start_timestamp {
+        let i = i64::try_from(v).map_err(|e| {
+            SqlBuildError::new(format!(
+                "start_timestamp out of range for i64: {} ({})",
+                v, e
+            ))
+        })?;
+        Some(SqlValue::I64(i))
+    } else {
+        None
+    };
+    stmt.bind_param_clause(START_TS_CLAUSE, START_TS_BODY, start_param)?;
+
+    let end_param = if let Some(v) = args.end_timestamp {
+        let i = i64::try_from(v).map_err(|e| {
+            SqlBuildError::new(format!("end_timestamp out of range for i64: {} ({})", v, e))
+        })?;
+        Some(SqlValue::I64(i))
+    } else {
+        None
+    };
+    stmt.bind_param_clause(END_TS_CLAUSE, END_TS_BODY, end_param)?;
+
+    Ok(stmt)
+}
+
+pub fn extract_trade_count(rows: &[LocalDbTradeCountRow]) -> u64 {
+    rows.first().map(|row| row.trade_count).unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::primitives::address;
+
+    #[test]
+    fn builds_with_chain_ids() {
+        let owner = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        let stmt = build_fetch_owner_trades_count_stmt(&FetchOwnerTradesCountArgs {
+            owner,
+            chain_ids: vec![137, 1],
+            orderbook_addresses: vec![],
+            start_timestamp: None,
+            end_timestamp: None,
+        })
+        .unwrap();
+        assert!(stmt.sql.contains("t.chain_id IN"));
+        assert!(stmt.sql.contains("c.chain_id IN"));
+        assert!(!stmt.sql.contains(TAKE_ORDERS_CHAIN_IDS_CLAUSE));
+    }
+
+    #[test]
+    fn builds_with_time_filters() {
+        let owner = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        let stmt = build_fetch_owner_trades_count_stmt(&FetchOwnerTradesCountArgs {
+            owner,
+            chain_ids: vec![],
+            orderbook_addresses: vec![],
+            start_timestamp: Some(1000),
+            end_timestamp: Some(2000),
+        })
+        .unwrap();
+        assert!(stmt.sql.contains("block_timestamp >="));
+        assert!(stmt.sql.contains("block_timestamp <="));
+    }
+
+    #[test]
+    fn builds_without_filters() {
+        let owner = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        let stmt = build_fetch_owner_trades_count_stmt(&FetchOwnerTradesCountArgs {
+            owner,
+            chain_ids: vec![],
+            orderbook_addresses: vec![],
+            start_timestamp: None,
+            end_timestamp: None,
+        })
+        .unwrap();
+        assert!(!stmt.sql.contains("block_timestamp >="));
+        assert!(!stmt.sql.contains("block_timestamp <="));
+        assert_eq!(stmt.params.len(), 1);
+    }
+
+    #[test]
+    fn extract_trade_count_works() {
+        let rows = vec![LocalDbTradeCountRow { trade_count: 42 }];
+        assert_eq!(extract_trade_count(&rows), 42);
+        let empty: Vec<LocalDbTradeCountRow> = vec![];
+        assert_eq!(extract_trade_count(&empty), 0);
+    }
+}

--- a/crates/common/src/local_db/query/fetch_owner_trades_count/mod.rs
+++ b/crates/common/src/local_db/query/fetch_owner_trades_count/mod.rs
@@ -1,15 +1,16 @@
+use crate::local_db::query::fetch_owner_trades_common::{
+    bind_common_owner_trade_filters, TAKE_ORDERS_CHAIN_IDS_CLAUSE,
+};
 use crate::local_db::query::{SqlBuildError, SqlStatement, SqlValue};
+use crate::raindex_client::TimeFilter;
 use alloy::primitives::Address;
-use std::convert::TryFrom;
 
 const QUERY_TEMPLATE: &str = include_str!("query.sql");
 
 pub use super::fetch_order_trades_count::LocalDbTradeCountRow;
 
-const TAKE_ORDERS_CHAIN_IDS_CLAUSE: &str = "/*TAKE_ORDERS_CHAIN_IDS_CLAUSE*/";
-const TAKE_ORDERS_CHAIN_IDS_CLAUSE_BODY: &str = "AND t.chain_id IN ({list})";
-const TAKE_ORDERS_ORDERBOOKS_CLAUSE: &str = "/*TAKE_ORDERS_ORDERBOOKS_CLAUSE*/";
-const TAKE_ORDERS_ORDERBOOKS_CLAUSE_BODY: &str = "AND t.orderbook_address IN ({list})";
+const START_TS_BODY: &str = "\nAND block_timestamp >= {param}\n";
+const END_TS_BODY: &str = "\nAND block_timestamp <= {param}\n";
 
 const CLEAR_ALICE_CHAIN_IDS_CLAUSE: &str = "/*CLEAR_ALICE_CHAIN_IDS_CLAUSE*/";
 const CLEAR_ALICE_CHAIN_IDS_CLAUSE_BODY: &str = "AND c.chain_id IN ({list})";
@@ -21,18 +22,12 @@ const CLEAR_BOB_CHAIN_IDS_CLAUSE_BODY: &str = "AND c.chain_id IN ({list})";
 const CLEAR_BOB_ORDERBOOKS_CLAUSE: &str = "/*CLEAR_BOB_ORDERBOOKS_CLAUSE*/";
 const CLEAR_BOB_ORDERBOOKS_CLAUSE_BODY: &str = "AND c.orderbook_address IN ({list})";
 
-const START_TS_CLAUSE: &str = "/*START_TS_CLAUSE*/";
-const START_TS_BODY: &str = "\nAND block_timestamp >= {param}\n";
-const END_TS_CLAUSE: &str = "/*END_TS_CLAUSE*/";
-const END_TS_BODY: &str = "\nAND block_timestamp <= {param}\n";
-
 #[derive(Debug, Clone)]
 pub struct FetchOwnerTradesCountArgs {
     pub owner: Address,
     pub chain_ids: Vec<u32>,
     pub orderbook_addresses: Vec<Address>,
-    pub start_timestamp: Option<u64>,
-    pub end_timestamp: Option<u64>,
+    pub time_filter: TimeFilter,
 }
 
 pub fn build_fetch_owner_trades_count_stmt(
@@ -40,29 +35,19 @@ pub fn build_fetch_owner_trades_count_stmt(
 ) -> Result<SqlStatement, SqlBuildError> {
     let mut stmt = SqlStatement::new(QUERY_TEMPLATE);
 
-    stmt.push(SqlValue::from(args.owner));
-
-    let mut chain_ids = args.chain_ids.clone();
-    chain_ids.sort_unstable();
-    chain_ids.dedup();
-
-    let mut orderbooks = args.orderbook_addresses.clone();
-    orderbooks.sort();
-    orderbooks.dedup();
-
-    let chain_ids_iter = || chain_ids.iter().cloned().map(SqlValue::from);
-    let orderbooks_iter = || orderbooks.iter().cloned().map(SqlValue::from);
-
-    stmt.bind_list_clause(
-        TAKE_ORDERS_CHAIN_IDS_CLAUSE,
-        TAKE_ORDERS_CHAIN_IDS_CLAUSE_BODY,
-        chain_ids_iter(),
+    let filters = bind_common_owner_trade_filters(
+        &mut stmt,
+        args.owner,
+        &args.chain_ids,
+        &args.orderbook_addresses,
+        &args.time_filter,
+        START_TS_BODY,
+        END_TS_BODY,
     )?;
-    stmt.bind_list_clause(
-        TAKE_ORDERS_ORDERBOOKS_CLAUSE,
-        TAKE_ORDERS_ORDERBOOKS_CLAUSE_BODY,
-        orderbooks_iter(),
-    )?;
+
+    let chain_ids_iter = || filters.chain_ids.iter().cloned().map(SqlValue::from);
+    let orderbooks_iter = || filters.orderbooks.iter().cloned().map(SqlValue::from);
+
     stmt.bind_list_clause(
         CLEAR_ALICE_CHAIN_IDS_CLAUSE,
         CLEAR_ALICE_CHAIN_IDS_CLAUSE_BODY,
@@ -84,35 +69,6 @@ pub fn build_fetch_owner_trades_count_stmt(
         orderbooks_iter(),
     )?;
 
-    if let (Some(start), Some(end)) = (args.start_timestamp, args.end_timestamp) {
-        if start > end {
-            return Err(SqlBuildError::new("start_timestamp > end_timestamp"));
-        }
-    }
-
-    let start_param = if let Some(v) = args.start_timestamp {
-        let i = i64::try_from(v).map_err(|e| {
-            SqlBuildError::new(format!(
-                "start_timestamp out of range for i64: {} ({})",
-                v, e
-            ))
-        })?;
-        Some(SqlValue::I64(i))
-    } else {
-        None
-    };
-    stmt.bind_param_clause(START_TS_CLAUSE, START_TS_BODY, start_param)?;
-
-    let end_param = if let Some(v) = args.end_timestamp {
-        let i = i64::try_from(v).map_err(|e| {
-            SqlBuildError::new(format!("end_timestamp out of range for i64: {} ({})", v, e))
-        })?;
-        Some(SqlValue::I64(i))
-    } else {
-        None
-    };
-    stmt.bind_param_clause(END_TS_CLAUSE, END_TS_BODY, end_param)?;
-
     Ok(stmt)
 }
 
@@ -123,6 +79,7 @@ pub fn extract_trade_count(rows: &[LocalDbTradeCountRow]) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::local_db::query::fetch_owner_trades_common::{END_TS_CLAUSE, START_TS_CLAUSE};
     use alloy::primitives::address;
 
     #[test]
@@ -132,8 +89,7 @@ mod tests {
             owner,
             chain_ids: vec![137, 1],
             orderbook_addresses: vec![],
-            start_timestamp: None,
-            end_timestamp: None,
+            time_filter: TimeFilter::default(),
         })
         .unwrap();
         assert!(stmt.sql.contains("t.chain_id IN"));
@@ -148,12 +104,16 @@ mod tests {
             owner,
             chain_ids: vec![],
             orderbook_addresses: vec![],
-            start_timestamp: Some(1000),
-            end_timestamp: Some(2000),
+            time_filter: TimeFilter {
+                start: Some(1000),
+                end: Some(2000),
+            },
         })
         .unwrap();
         assert!(stmt.sql.contains("block_timestamp >="));
         assert!(stmt.sql.contains("block_timestamp <="));
+        assert!(!stmt.sql.contains(START_TS_CLAUSE));
+        assert!(!stmt.sql.contains(END_TS_CLAUSE));
     }
 
     #[test]
@@ -163,8 +123,7 @@ mod tests {
             owner,
             chain_ids: vec![],
             orderbook_addresses: vec![],
-            start_timestamp: None,
-            end_timestamp: None,
+            time_filter: TimeFilter::default(),
         })
         .unwrap();
         assert!(!stmt.sql.contains("block_timestamp >="));

--- a/crates/common/src/local_db/query/fetch_owner_trades_count/mod.rs
+++ b/crates/common/src/local_db/query/fetch_owner_trades_count/mod.rs
@@ -1,6 +1,4 @@
-use crate::local_db::query::fetch_owner_trades_common::{
-    bind_common_owner_trade_filters, TAKE_ORDERS_CHAIN_IDS_CLAUSE,
-};
+use crate::local_db::query::fetch_owner_trades_common::bind_common_owner_trade_filters;
 use crate::local_db::query::{SqlBuildError, SqlStatement, SqlValue};
 use crate::raindex_client::TimeFilter;
 use alloy::primitives::Address;
@@ -79,7 +77,9 @@ pub fn extract_trade_count(rows: &[LocalDbTradeCountRow]) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::local_db::query::fetch_owner_trades_common::{END_TS_CLAUSE, START_TS_CLAUSE};
+    use crate::local_db::query::fetch_owner_trades_common::{
+        END_TS_CLAUSE, START_TS_CLAUSE, TAKE_ORDERS_CHAIN_IDS_CLAUSE,
+    };
     use alloy::primitives::address;
 
     #[test]

--- a/crates/common/src/local_db/query/fetch_owner_trades_count/query.sql
+++ b/crates/common/src/local_db/query/fetch_owner_trades_count/query.sql
@@ -1,0 +1,107 @@
+SELECT COUNT(*) AS trade_count
+FROM (
+  SELECT t.transaction_hash, t.log_index, t.block_timestamp
+  FROM take_orders t
+  JOIN order_events oe
+    ON oe.chain_id = t.chain_id
+   AND oe.orderbook_address = t.orderbook_address
+   AND oe.event_type = 'AddOrderV3'
+   AND oe.order_owner = t.order_owner
+   AND oe.order_nonce = t.order_nonce
+   AND oe.order_owner = ?1
+   AND (
+        oe.block_number < t.block_number
+     OR (oe.block_number = t.block_number AND oe.log_index <= t.log_index)
+   )
+   AND NOT EXISTS (
+     SELECT 1
+     FROM order_events oe2
+    WHERE oe2.chain_id = oe.chain_id
+      AND oe2.orderbook_address = oe.orderbook_address
+      AND oe2.event_type = 'AddOrderV3'
+      AND oe2.order_owner = t.order_owner
+      AND oe2.order_nonce = t.order_nonce
+       AND (
+            oe2.block_number < t.block_number
+         OR (oe2.block_number = t.block_number AND oe2.log_index <= t.log_index)
+       )
+       AND (
+            oe2.block_number > oe.block_number
+         OR (oe2.block_number = oe.block_number AND oe2.log_index > oe.log_index)
+       )
+   )
+  WHERE t.order_owner = ?1
+  /*TAKE_ORDERS_CHAIN_IDS_CLAUSE*/
+  /*TAKE_ORDERS_ORDERBOOKS_CLAUSE*/
+
+  UNION ALL
+
+  SELECT c.transaction_hash, c.log_index, c.block_timestamp
+  FROM clear_v3_events c
+  JOIN order_events oe
+    ON oe.chain_id = c.chain_id
+   AND oe.orderbook_address = c.orderbook_address
+   AND oe.order_hash = c.alice_order_hash
+   AND oe.event_type = 'AddOrderV3'
+   AND oe.order_owner = ?1
+   AND (
+        oe.block_number < c.block_number
+     OR (oe.block_number = c.block_number AND oe.log_index <= c.log_index)
+   )
+   AND NOT EXISTS (
+     SELECT 1
+     FROM order_events oe2
+    WHERE oe2.chain_id = oe.chain_id
+      AND oe2.orderbook_address = oe.orderbook_address
+      AND oe2.order_hash = c.alice_order_hash
+      AND oe2.event_type = 'AddOrderV3'
+       AND (
+            oe2.block_number < c.block_number
+         OR (oe2.block_number = c.block_number AND oe2.log_index <= c.log_index)
+       )
+       AND (
+            oe2.block_number > oe.block_number
+         OR (oe2.block_number = oe.block_number AND oe2.log_index > oe.log_index)
+       )
+   )
+  WHERE 1 = 1
+  /*CLEAR_ALICE_CHAIN_IDS_CLAUSE*/
+  /*CLEAR_ALICE_ORDERBOOKS_CLAUSE*/
+
+  UNION ALL
+
+  SELECT c.transaction_hash, c.log_index, c.block_timestamp
+  FROM clear_v3_events c
+  JOIN order_events oe
+    ON oe.chain_id = c.chain_id
+   AND oe.orderbook_address = c.orderbook_address
+   AND oe.order_hash = c.bob_order_hash
+   AND oe.event_type = 'AddOrderV3'
+   AND oe.order_owner = ?1
+   AND (
+        oe.block_number < c.block_number
+     OR (oe.block_number = c.block_number AND oe.log_index <= c.log_index)
+   )
+   AND NOT EXISTS (
+     SELECT 1
+     FROM order_events oe2
+    WHERE oe2.chain_id = oe.chain_id
+      AND oe2.orderbook_address = oe.orderbook_address
+      AND oe2.order_hash = c.bob_order_hash
+      AND oe2.event_type = 'AddOrderV3'
+       AND (
+            oe2.block_number < c.block_number
+         OR (oe2.block_number = c.block_number AND oe2.log_index <= c.log_index)
+       )
+       AND (
+            oe2.block_number > oe.block_number
+         OR (oe2.block_number = oe.block_number AND oe2.log_index > oe.log_index)
+       )
+   )
+  WHERE 1 = 1
+  /*CLEAR_BOB_CHAIN_IDS_CLAUSE*/
+  /*CLEAR_BOB_ORDERBOOKS_CLAUSE*/
+) AS combined_trades
+WHERE 1=1
+/*START_TS_CLAUSE*/
+/*END_TS_CLAUSE*/;

--- a/crates/common/src/local_db/query/mod.rs
+++ b/crates/common/src/local_db/query/mod.rs
@@ -14,6 +14,7 @@ pub mod fetch_orders;
 pub(crate) mod fetch_orders_common;
 pub mod fetch_orders_count;
 pub mod fetch_owner_trades;
+pub(crate) mod fetch_owner_trades_common;
 pub mod fetch_owner_trades_count;
 pub mod fetch_store_addresses;
 pub mod fetch_tables;

--- a/crates/common/src/local_db/query/mod.rs
+++ b/crates/common/src/local_db/query/mod.rs
@@ -13,6 +13,8 @@ pub mod fetch_order_vaults_volume;
 pub mod fetch_orders;
 pub(crate) mod fetch_orders_common;
 pub mod fetch_orders_count;
+pub mod fetch_owner_trades;
+pub mod fetch_owner_trades_count;
 pub mod fetch_store_addresses;
 pub mod fetch_tables;
 pub mod fetch_target_watermark;

--- a/crates/common/src/raindex_client/local_db/query/fetch_owner_trades.rs
+++ b/crates/common/src/raindex_client/local_db/query/fetch_owner_trades.rs
@@ -30,9 +30,8 @@ mod wasm_tests {
             owner,
             chain_ids: vec![137, 42161],
             orderbook_addresses: vec![],
-            start_timestamp: None,
-            end_timestamp: None,
-            page: None,
+            time_filter: Default::default(),
+            pagination: Default::default(),
         };
 
         let expected_stmt = build_fetch_owner_trades_stmt(&args).unwrap();

--- a/crates/common/src/raindex_client/local_db/query/fetch_owner_trades.rs
+++ b/crates/common/src/raindex_client/local_db/query/fetch_owner_trades.rs
@@ -1,0 +1,53 @@
+use crate::local_db::query::fetch_order_trades::LocalDbOrderTrade;
+use crate::local_db::query::fetch_owner_trades::{
+    build_fetch_owner_trades_stmt, FetchOwnerTradesArgs,
+};
+use crate::local_db::query::{LocalDbQueryError, LocalDbQueryExecutor};
+
+pub async fn fetch_owner_trades<E: LocalDbQueryExecutor + ?Sized>(
+    exec: &E,
+    args: FetchOwnerTradesArgs,
+) -> Result<Vec<LocalDbOrderTrade>, LocalDbQueryError> {
+    let stmt = build_fetch_owner_trades_stmt(&args)?;
+    exec.query_json(&stmt).await
+}
+
+#[cfg(all(test, target_family = "wasm"))]
+mod wasm_tests {
+    use super::*;
+    use crate::raindex_client::local_db::executor::tests::create_sql_capturing_callback;
+    use crate::raindex_client::local_db::executor::JsCallbackExecutor;
+    use alloy::primitives::address;
+    use std::cell::RefCell;
+    use std::rc::Rc;
+    use wasm_bindgen_test::*;
+    use wasm_bindgen_utils::prelude::*;
+
+    #[wasm_bindgen_test]
+    async fn wrapper_uses_builder_sql_exactly() {
+        let owner = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        let args = FetchOwnerTradesArgs {
+            owner,
+            chain_ids: vec![137, 42161],
+            orderbook_addresses: vec![],
+            start_timestamp: None,
+            end_timestamp: None,
+            page: None,
+        };
+
+        let expected_stmt = build_fetch_owner_trades_stmt(&args).unwrap();
+
+        let store = Rc::new(RefCell::new((
+            String::new(),
+            wasm_bindgen::JsValue::UNDEFINED,
+        )));
+        let callback = create_sql_capturing_callback("[]", store.clone());
+        let exec = JsCallbackExecutor::from_ref(&callback);
+
+        let res = fetch_owner_trades(&exec, args).await;
+        assert!(res.is_ok());
+
+        let captured = store.borrow().clone();
+        assert_eq!(captured.0, expected_stmt.sql);
+    }
+}

--- a/crates/common/src/raindex_client/local_db/query/fetch_owner_trades_count.rs
+++ b/crates/common/src/raindex_client/local_db/query/fetch_owner_trades_count.rs
@@ -1,0 +1,51 @@
+use crate::local_db::query::fetch_owner_trades_count::{
+    build_fetch_owner_trades_count_stmt, FetchOwnerTradesCountArgs, LocalDbTradeCountRow,
+};
+use crate::local_db::query::{LocalDbQueryError, LocalDbQueryExecutor};
+
+pub async fn fetch_owner_trades_count<E: LocalDbQueryExecutor + ?Sized>(
+    exec: &E,
+    args: FetchOwnerTradesCountArgs,
+) -> Result<Vec<LocalDbTradeCountRow>, LocalDbQueryError> {
+    let stmt = build_fetch_owner_trades_count_stmt(&args)?;
+    exec.query_json(&stmt).await
+}
+
+#[cfg(all(test, target_family = "wasm"))]
+mod wasm_tests {
+    use super::*;
+    use crate::raindex_client::local_db::executor::tests::create_sql_capturing_callback;
+    use crate::raindex_client::local_db::executor::JsCallbackExecutor;
+    use alloy::primitives::address;
+    use std::cell::RefCell;
+    use std::rc::Rc;
+    use wasm_bindgen_test::*;
+    use wasm_bindgen_utils::prelude::*;
+
+    #[wasm_bindgen_test]
+    async fn wrapper_uses_builder_sql_exactly() {
+        let owner = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        let args = FetchOwnerTradesCountArgs {
+            owner,
+            chain_ids: vec![137],
+            orderbook_addresses: vec![],
+            start_timestamp: None,
+            end_timestamp: None,
+        };
+
+        let expected_stmt = build_fetch_owner_trades_count_stmt(&args).unwrap();
+
+        let store = Rc::new(RefCell::new((
+            String::new(),
+            wasm_bindgen::JsValue::UNDEFINED,
+        )));
+        let callback = create_sql_capturing_callback("[]", store.clone());
+        let exec = JsCallbackExecutor::from_ref(&callback);
+
+        let res = fetch_owner_trades_count(&exec, args).await;
+        assert!(res.is_ok());
+
+        let captured = store.borrow().clone();
+        assert_eq!(captured.0, expected_stmt.sql);
+    }
+}

--- a/crates/common/src/raindex_client/local_db/query/fetch_owner_trades_count.rs
+++ b/crates/common/src/raindex_client/local_db/query/fetch_owner_trades_count.rs
@@ -29,8 +29,7 @@ mod wasm_tests {
             owner,
             chain_ids: vec![137],
             orderbook_addresses: vec![],
-            start_timestamp: None,
-            end_timestamp: None,
+            time_filter: Default::default(),
         };
 
         let expected_stmt = build_fetch_owner_trades_count_stmt(&args).unwrap();

--- a/crates/common/src/raindex_client/local_db/query/mod.rs
+++ b/crates/common/src/raindex_client/local_db/query/mod.rs
@@ -8,6 +8,8 @@ pub mod fetch_order_trades_count;
 pub mod fetch_order_vaults_volume;
 pub mod fetch_orders;
 pub mod fetch_orders_count;
+pub mod fetch_owner_trades;
+pub mod fetch_owner_trades_count;
 pub mod fetch_store_addresses;
 pub mod fetch_tables;
 pub mod fetch_trades_by_tx;

--- a/crates/common/src/raindex_client/mod.rs
+++ b/crates/common/src/raindex_client/mod.rs
@@ -69,6 +69,22 @@ pub mod vaults_list;
 pub struct ChainIds(#[tsify(type = "number[]")] pub Vec<u32>);
 impl_wasm_traits!(ChainIds);
 
+#[derive(Serialize, Deserialize, Debug, Clone, Default, Tsify)]
+#[serde(rename_all = "camelCase")]
+pub struct TimeFilter {
+    pub start: Option<u64>,
+    pub end: Option<u64>,
+}
+impl_wasm_traits!(TimeFilter);
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default, Tsify)]
+#[serde(rename_all = "camelCase")]
+pub struct PaginationParams {
+    pub page: Option<u16>,
+    pub page_size: Option<u16>,
+}
+impl_wasm_traits!(PaginationParams);
+
 /// RaindexClient provides a simplified interface for querying orderbook data across
 /// multiple networks with automatic configuration management.
 ///

--- a/crates/common/src/raindex_client/mod.rs
+++ b/crates/common/src/raindex_client/mod.rs
@@ -48,9 +48,8 @@ pub(crate) type ClientRef = std::rc::Rc<RaindexClient>;
 pub(crate) type ClientRef = std::sync::Arc<RaindexClient>;
 
 use thiserror::Error;
-use tsify::Tsify;
 use url::Url;
-use wasm_bindgen_utils::{impl_wasm_traits, prelude::*, wasm_export};
+use wasm_bindgen_utils::{prelude::*, wasm_export};
 
 pub mod add_orders;
 pub mod local_db;
@@ -62,28 +61,11 @@ pub mod remove_orders;
 pub mod take_orders;
 pub mod trades;
 pub mod transactions;
+pub mod types;
 pub mod vaults;
 pub mod vaults_list;
 
-#[derive(Serialize, Deserialize, Debug, Clone, Tsify)]
-pub struct ChainIds(#[tsify(type = "number[]")] pub Vec<u32>);
-impl_wasm_traits!(ChainIds);
-
-#[derive(Serialize, Deserialize, Debug, Clone, Default, Tsify)]
-#[serde(rename_all = "camelCase")]
-pub struct TimeFilter {
-    pub start: Option<u64>,
-    pub end: Option<u64>,
-}
-impl_wasm_traits!(TimeFilter);
-
-#[derive(Serialize, Deserialize, Debug, Clone, Default, Tsify)]
-#[serde(rename_all = "camelCase")]
-pub struct PaginationParams {
-    pub page: Option<u16>,
-    pub page_size: Option<u16>,
-}
-impl_wasm_traits!(PaginationParams);
+pub use types::*;
 
 /// RaindexClient provides a simplified interface for querying orderbook data across
 /// multiple networks with automatic configuration management.

--- a/crates/common/src/raindex_client/order_quotes.rs
+++ b/crates/common/src/raindex_client/order_quotes.rs
@@ -10,6 +10,7 @@ use rain_orderbook_quote::{
 };
 use rain_orderbook_subgraph_client::utils::float::{F0, F1};
 use std::ops::{Div, Mul};
+use wasm_bindgen_utils::impl_wasm_traits;
 
 #[derive(Serialize, Deserialize, Debug, Clone, Tsify)]
 #[serde(rename_all = "camelCase")]

--- a/crates/common/src/raindex_client/orders.rs
+++ b/crates/common/src/raindex_client/orders.rs
@@ -47,6 +47,7 @@ use rain_orderbook_subgraph_client::{
 use serde::{Deserialize, Serialize};
 use std::{collections::HashSet, io::Cursor, str::FromStr};
 use tsify::Tsify;
+use wasm_bindgen_utils::impl_wasm_traits;
 #[cfg(target_family = "wasm")]
 use wasm_bindgen_utils::prelude::js_sys::BigInt;
 

--- a/crates/common/src/raindex_client/trades/get_by_owner.rs
+++ b/crates/common/src/raindex_client/trades/get_by_owner.rs
@@ -204,9 +204,9 @@ mod tests {
             let owner = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
 
             let callback = make_local_db_trades_callback(
-                vec![fixture.order.clone()],
-                vec![fixture.input_vault.clone(), fixture.output_vault.clone()],
-                vec![fixture.trade.clone()],
+                vec![fixture.order],
+                vec![fixture.input_vault, fixture.output_vault],
+                vec![fixture.trade],
                 4,
             );
             let client = new_test_client_with_db_callback(
@@ -235,9 +235,9 @@ mod tests {
             let owner = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
 
             let callback = make_local_db_trades_callback(
-                vec![fixture.order.clone()],
-                vec![fixture.input_vault.clone(), fixture.output_vault.clone()],
-                vec![fixture.trade.clone()],
+                vec![fixture.order],
+                vec![fixture.input_vault, fixture.output_vault],
+                vec![fixture.trade],
                 4,
             );
             let client = new_test_client_with_db_callback(
@@ -267,102 +267,12 @@ mod tests {
     #[cfg(not(target_family = "wasm"))]
     mod non_wasm {
         use crate::raindex_client::tests::get_test_yaml;
+        use crate::raindex_client::trades::test_helpers::get_sg_trade_json;
         use crate::raindex_client::{ChainIds, RaindexClient};
         use alloy::primitives::{address, Bytes};
         use httpmock::MockServer;
-        use rain_orderbook_subgraph_client::utils::float::*;
         use serde_json::json;
         use std::str::FromStr;
-
-        fn get_trade_json() -> serde_json::Value {
-            json!({
-                "id": "0x0123",
-                "tradeEvent": {
-                    "transaction": {
-                        "id": "0x0000000000000000000000000000000000000000000000000000000000000abc",
-                        "from": "0x0000000000000000000000000000000000000000",
-                        "blockNumber": "100",
-                        "timestamp": "1700000000"
-                    },
-                    "sender": "0xsender1"
-                },
-                "outputVaultBalanceChange": {
-                    "id": "0xovbc1",
-                    "__typename": "TradeVaultBalanceChange",
-                    "amount": NEG2,
-                    "newVaultBalance": F0,
-                    "oldVaultBalance": F2,
-                    "vault": {
-                        "id": "0xvault_out",
-                        "vaultId": "0x01",
-                        "token": {
-                            "id": "0x12e605bc104e93b45e1ad99f9e555f659051c2bb",
-                            "address": "0x12e605bc104e93b45e1ad99f9e555f659051c2bb",
-                            "name": "Staked FLR",
-                            "symbol": "sFLR",
-                            "decimals": "18"
-                        }
-                    },
-                    "timestamp": "1700000000",
-                    "transaction": {
-                        "id": "0x0000000000000000000000000000000000000000000000000000000000000abc",
-                        "from": "0x0000000000000000000000000000000000000000",
-                        "blockNumber": "100",
-                        "timestamp": "1700000000"
-                    },
-                    "orderbook": {
-                        "id": "0x1234567890123456789012345678901234567890"
-                    },
-                    "trade": {
-                        "tradeEvent": {
-                            "__typename": "TakeOrder"
-                        }
-                    }
-                },
-                "order": {
-                    "id": "0x0123",
-                    "orderHash": "0x0000000000000000000000000000000000000000000000000000000000000123",
-                    "owner": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-                },
-                "inputVaultBalanceChange": {
-                    "id": "0xivbc1",
-                    "__typename": "TradeVaultBalanceChange",
-                    "amount": F1,
-                    "newVaultBalance": F1,
-                    "oldVaultBalance": F0,
-                    "vault": {
-                        "id": "0xvault_in",
-                        "vaultId": "0x02",
-                        "token": {
-                            "id": "0x1d80c49bbbcd1c0911346656b529df9e5c2f783d",
-                            "address": "0x1d80c49bbbcd1c0911346656b529df9e5c2f783d",
-                            "name": "Wrapped Flare",
-                            "symbol": "WFLR",
-                            "decimals": "18"
-                        }
-                    },
-                    "timestamp": "1700000000",
-                    "transaction": {
-                        "id": "0x0000000000000000000000000000000000000000000000000000000000000abc",
-                        "from": "0x0000000000000000000000000000000000000000",
-                        "blockNumber": "100",
-                        "timestamp": "1700000000"
-                    },
-                    "orderbook": {
-                        "id": "0x1234567890123456789012345678901234567890"
-                    },
-                    "trade": {
-                        "tradeEvent": {
-                            "__typename": "TakeOrder"
-                        }
-                    }
-                },
-                "timestamp": "1700000000",
-                "orderbook": {
-                    "id": "0x1234567890123456789012345678901234567890"
-                }
-            })
-        }
 
         #[tokio::test]
         async fn test_returns_trades() {
@@ -370,7 +280,7 @@ mod tests {
             sg_server.mock(|when, then| {
                 when.path("/sg").body_contains("SgOwnerTradesListQuery");
                 then.status(200).json_body_obj(&json!({
-                    "data": { "trades": [get_trade_json()] }
+                    "data": { "trades": [get_sg_trade_json("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")] }
                 }));
             });
 
@@ -441,7 +351,7 @@ mod tests {
             sg_server.mock(|when, then| {
                 when.path("/sg").body_contains("SgOwnerTradesListQuery");
                 then.status(200).json_body_obj(&json!({
-                    "data": { "trades": [get_trade_json()] }
+                    "data": { "trades": [get_sg_trade_json("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")] }
                 }));
             });
 

--- a/crates/common/src/raindex_client/trades/get_by_owner.rs
+++ b/crates/common/src/raindex_client/trades/get_by_owner.rs
@@ -1,0 +1,183 @@
+use super::*;
+use crate::local_db::query::fetch_owner_trades::FetchOwnerTradesArgs;
+use crate::local_db::query::fetch_owner_trades_count::{
+    extract_trade_count, FetchOwnerTradesCountArgs,
+};
+use crate::raindex_client::local_db::query::fetch_owner_trades::fetch_owner_trades;
+use crate::raindex_client::local_db::query::fetch_owner_trades_count::fetch_owner_trades_count;
+use alloy::primitives::Address;
+use rain_orderbook_subgraph_client::MultiOrderbookSubgraphClient;
+use std::str::FromStr;
+
+#[wasm_export]
+impl RaindexClient {
+    #[wasm_export(
+        js_name = "getTradesForOwner",
+        return_description = "Trades list result with total count and per-pair summary",
+        unchecked_return_type = "RaindexTradesListResult",
+        preserve_js_class
+    )]
+    pub async fn get_trades_for_owner_wasm_binding(
+        &self,
+        #[wasm_export(
+            js_name = "chainIds",
+            param_description = "Optional chain IDs to filter networks (queries all if not specified)"
+        )]
+        chain_ids: Option<ChainIds>,
+        #[wasm_export(
+            js_name = "orderbookAddresses",
+            param_description = "Optional orderbook addresses to filter results"
+        )]
+        orderbook_addresses: Option<Vec<String>>,
+        #[wasm_export(
+            js_name = "owner",
+            param_description = "Owner address",
+            unchecked_param_type = "Address"
+        )]
+        owner: String,
+        #[wasm_export(
+            js_name = "startTimestamp",
+            param_description = "Optional start time filter (Unix timestamp in seconds)"
+        )]
+        start_timestamp: Option<u64>,
+        #[wasm_export(
+            js_name = "endTimestamp",
+            param_description = "Optional end time filter (Unix timestamp in seconds)"
+        )]
+        end_timestamp: Option<u64>,
+        #[wasm_export(
+            js_name = "page",
+            param_description = "Optional page number (defaults to all results)"
+        )]
+        page: Option<u16>,
+    ) -> Result<RaindexTradesListResult, RaindexError> {
+        let owner = Address::from_str(&owner)?;
+        let orderbook_addresses = orderbook_addresses
+            .map(|addresses| {
+                addresses
+                    .into_iter()
+                    .map(|address| Address::from_str(&address))
+                    .collect::<Result<Vec<_>, _>>()
+            })
+            .transpose()?;
+        self.get_trades_for_owner(
+            chain_ids,
+            orderbook_addresses,
+            owner,
+            start_timestamp,
+            end_timestamp,
+            page,
+        )
+        .await
+    }
+}
+impl RaindexClient {
+    pub async fn get_trades_for_owner(
+        &self,
+        chain_ids: Option<ChainIds>,
+        orderbook_addresses: Option<Vec<Address>>,
+        owner: Address,
+        start_timestamp: Option<u64>,
+        end_timestamp: Option<u64>,
+        page: Option<u16>,
+    ) -> Result<RaindexTradesListResult, RaindexError> {
+        let ids = chain_ids.map(|ChainIds(ids)| ids);
+        let (local_db, local_ids, sg_ids) = self.classify_chains(ids)?;
+        let orderbook_addresses_for_local_db = orderbook_addresses.clone().unwrap_or_default();
+
+        let mut all_trades = Vec::new();
+        let mut total_count: Option<u64> = None;
+
+        if let Some(db) = local_db.filter(|_| !local_ids.is_empty()) {
+            let trades = fetch_owner_trades(
+                &db,
+                FetchOwnerTradesArgs {
+                    owner,
+                    chain_ids: local_ids.clone(),
+                    orderbook_addresses: orderbook_addresses_for_local_db.clone(),
+                    start_timestamp,
+                    end_timestamp,
+                    page,
+                },
+            )
+            .await?;
+            let raindex_trades: Vec<RaindexTrade> = trades
+                .into_iter()
+                .map(RaindexTrade::try_from_local_db_trade)
+                .collect::<Result<_, _>>()?;
+
+            if page.is_some() {
+                let count_rows = fetch_owner_trades_count(
+                    &db,
+                    FetchOwnerTradesCountArgs {
+                        owner,
+                        chain_ids: local_ids,
+                        orderbook_addresses: orderbook_addresses_for_local_db,
+                        start_timestamp,
+                        end_timestamp,
+                    },
+                )
+                .await?;
+                total_count = Some(extract_trade_count(&count_rows));
+            }
+
+            all_trades.extend(raindex_trades);
+        }
+
+        if !sg_ids.is_empty() {
+            let multi_subgraph_args = self.get_multi_subgraph_args(Some(sg_ids))?;
+            let orderbook_in = orderbook_addresses
+                .as_deref()
+                .filter(|addresses| !addresses.is_empty())
+                .map(|addresses| {
+                    addresses
+                        .iter()
+                        .map(|address| address.to_string().to_lowercase())
+                        .collect::<Vec<_>>()
+                });
+            if !multi_subgraph_args.is_empty() {
+                let name_to_chain_id: std::collections::HashMap<&str, u32> = multi_subgraph_args
+                    .iter()
+                    .flat_map(|(chain_id, args)| {
+                        args.iter().map(|arg| (arg.name.as_str(), *chain_id))
+                    })
+                    .collect();
+                let client = MultiOrderbookSubgraphClient::new(
+                    multi_subgraph_args.values().flatten().cloned().collect(),
+                );
+                let sg_trades = client
+                    .trades_by_owner(
+                        owner.to_string().to_lowercase(),
+                        start_timestamp,
+                        end_timestamp,
+                        orderbook_in,
+                    )
+                    .await;
+                for trade_with_name in sg_trades {
+                    let chain_id = name_to_chain_id
+                        .get(trade_with_name.subgraph_name.as_str())
+                        .copied()
+                        .ok_or(RaindexError::SubgraphNotFound(
+                            trade_with_name.subgraph_name.clone(),
+                            trade_with_name.trade.id.0.clone(),
+                        ))?;
+                    let trade = RaindexTrade::try_from_sg_trade(chain_id, trade_with_name.trade)?;
+                    all_trades.push(trade);
+                }
+            }
+        }
+
+        let final_total_count = total_count.unwrap_or(all_trades.len() as u64);
+        let summary = if page.is_some() {
+            None
+        } else {
+            Some(RaindexPairSummary::from_trades(&all_trades)?)
+        };
+
+        Ok(RaindexTradesListResult {
+            trades: all_trades,
+            total_count: final_total_count,
+            summary,
+        })
+    }
+}

--- a/crates/common/src/raindex_client/trades/get_by_owner.rs
+++ b/crates/common/src/raindex_client/trades/get_by_owner.rs
@@ -37,17 +37,17 @@ impl RaindexClient {
         )]
         owner: String,
         #[wasm_export(
-            js_name = "timeFilter",
-            param_description = "Optional time filter with start/end Unix timestamps in seconds",
-            unchecked_param_type = "TimeFilter"
-        )]
-        time_filter: Option<TimeFilter>,
-        #[wasm_export(
             js_name = "pagination",
             param_description = "Optional pagination with page number and page size",
             unchecked_param_type = "PaginationParams"
         )]
         pagination: Option<PaginationParams>,
+        #[wasm_export(
+            js_name = "timeFilter",
+            param_description = "Optional time filter with start/end Unix timestamps in seconds",
+            unchecked_param_type = "TimeFilter"
+        )]
+        time_filter: Option<TimeFilter>,
     ) -> Result<RaindexTradesListResult, RaindexError> {
         let owner = Address::from_str(&owner)?;
         let orderbook_addresses = orderbook_addresses
@@ -62,8 +62,8 @@ impl RaindexClient {
             chain_ids,
             orderbook_addresses,
             owner,
-            time_filter.unwrap_or_default(),
             pagination.unwrap_or_default(),
+            time_filter.unwrap_or_default(),
         )
         .await
     }
@@ -74,8 +74,8 @@ impl RaindexClient {
         chain_ids: Option<ChainIds>,
         orderbook_addresses: Option<Vec<Address>>,
         owner: Address,
-        time_filter: TimeFilter,
         pagination: PaginationParams,
+        time_filter: TimeFilter,
     ) -> Result<RaindexTradesListResult, RaindexError> {
         let ids = chain_ids.map(|ChainIds(ids)| ids);
         let (local_db, local_ids, sg_ids) = self.classify_chains(ids)?;
@@ -251,11 +251,11 @@ mod tests {
                     Some(ChainIds(vec![42161])),
                     None,
                     owner,
-                    Default::default(),
                     PaginationParams {
                         page: Some(1),
                         page_size: None,
                     },
+                    Default::default(),
                 )
                 .await
                 .unwrap();
@@ -388,11 +388,11 @@ mod tests {
                     Some(ChainIds(vec![1])),
                     None,
                     owner,
-                    Default::default(),
                     PaginationParams {
                         page: Some(1),
                         page_size: None,
                     },
+                    Default::default(),
                 )
                 .await
                 .unwrap();

--- a/crates/common/src/raindex_client/trades/get_by_owner.rs
+++ b/crates/common/src/raindex_client/trades/get_by_owner.rs
@@ -5,6 +5,7 @@ use crate::local_db::query::fetch_owner_trades_count::{
 };
 use crate::raindex_client::local_db::query::fetch_owner_trades::fetch_owner_trades;
 use crate::raindex_client::local_db::query::fetch_owner_trades_count::fetch_owner_trades_count;
+use crate::raindex_client::{PaginationParams, TimeFilter};
 use alloy::primitives::Address;
 use rain_orderbook_subgraph_client::MultiOrderbookSubgraphClient;
 use std::str::FromStr;
@@ -36,20 +37,17 @@ impl RaindexClient {
         )]
         owner: String,
         #[wasm_export(
-            js_name = "startTimestamp",
-            param_description = "Optional start time filter (Unix timestamp in seconds)"
+            js_name = "timeFilter",
+            param_description = "Optional time filter with start/end Unix timestamps in seconds",
+            unchecked_param_type = "TimeFilter"
         )]
-        start_timestamp: Option<u64>,
+        time_filter: Option<TimeFilter>,
         #[wasm_export(
-            js_name = "endTimestamp",
-            param_description = "Optional end time filter (Unix timestamp in seconds)"
+            js_name = "pagination",
+            param_description = "Optional pagination with page number and page size",
+            unchecked_param_type = "PaginationParams"
         )]
-        end_timestamp: Option<u64>,
-        #[wasm_export(
-            js_name = "page",
-            param_description = "Optional page number (defaults to all results)"
-        )]
-        page: Option<u16>,
+        pagination: Option<PaginationParams>,
     ) -> Result<RaindexTradesListResult, RaindexError> {
         let owner = Address::from_str(&owner)?;
         let orderbook_addresses = orderbook_addresses
@@ -64,9 +62,8 @@ impl RaindexClient {
             chain_ids,
             orderbook_addresses,
             owner,
-            start_timestamp,
-            end_timestamp,
-            page,
+            time_filter.unwrap_or_default(),
+            pagination.unwrap_or_default(),
         )
         .await
     }
@@ -77,9 +74,8 @@ impl RaindexClient {
         chain_ids: Option<ChainIds>,
         orderbook_addresses: Option<Vec<Address>>,
         owner: Address,
-        start_timestamp: Option<u64>,
-        end_timestamp: Option<u64>,
-        page: Option<u16>,
+        time_filter: TimeFilter,
+        pagination: PaginationParams,
     ) -> Result<RaindexTradesListResult, RaindexError> {
         let ids = chain_ids.map(|ChainIds(ids)| ids);
         let (local_db, local_ids, sg_ids) = self.classify_chains(ids)?;
@@ -95,9 +91,8 @@ impl RaindexClient {
                     owner,
                     chain_ids: local_ids.clone(),
                     orderbook_addresses: orderbook_addresses_for_local_db.clone(),
-                    start_timestamp,
-                    end_timestamp,
-                    page,
+                    time_filter: time_filter.clone(),
+                    pagination: pagination.clone(),
                 },
             )
             .await?;
@@ -106,15 +101,14 @@ impl RaindexClient {
                 .map(RaindexTrade::try_from_local_db_trade)
                 .collect::<Result<_, _>>()?;
 
-            if page.is_some() {
+            if pagination.page.is_some() {
                 let count_rows = fetch_owner_trades_count(
                     &db,
                     FetchOwnerTradesCountArgs {
                         owner,
                         chain_ids: local_ids,
                         orderbook_addresses: orderbook_addresses_for_local_db,
-                        start_timestamp,
-                        end_timestamp,
+                        time_filter: time_filter.clone(),
                     },
                 )
                 .await?;
@@ -148,8 +142,8 @@ impl RaindexClient {
                 let sg_trades = client
                     .trades_by_owner(
                         owner.to_string().to_lowercase(),
-                        start_timestamp,
-                        end_timestamp,
+                        time_filter.start,
+                        time_filter.end,
                         orderbook_in,
                     )
                     .await;
@@ -168,7 +162,7 @@ impl RaindexClient {
         }
 
         let final_total_count = total_count.unwrap_or(all_trades.len() as u64);
-        let summary = if page.is_some() {
+        let summary = if pagination.page.is_some() {
             None
         } else {
             Some(RaindexPairSummary::from_trades(&all_trades)?)
@@ -192,7 +186,7 @@ mod tests {
         use crate::raindex_client::trades::test_helpers::{
             build_local_trade_fixture, make_local_db_trades_callback,
         };
-        use crate::raindex_client::ChainIds;
+        use crate::raindex_client::{ChainIds, PaginationParams};
         use alloy::primitives::{address, b256};
         use wasm_bindgen_test::wasm_bindgen_test;
 
@@ -216,7 +210,13 @@ mod tests {
             );
 
             let result = client
-                .get_trades_for_owner(Some(ChainIds(vec![42161])), None, owner, None, None, None)
+                .get_trades_for_owner(
+                    Some(ChainIds(vec![42161])),
+                    None,
+                    owner,
+                    Default::default(),
+                    Default::default(),
+                )
                 .await
                 .unwrap();
 
@@ -251,9 +251,11 @@ mod tests {
                     Some(ChainIds(vec![42161])),
                     None,
                     owner,
-                    None,
-                    None,
-                    Some(1),
+                    Default::default(),
+                    PaginationParams {
+                        page: Some(1),
+                        page_size: None,
+                    },
                 )
                 .await
                 .unwrap();
@@ -268,7 +270,7 @@ mod tests {
     mod non_wasm {
         use crate::raindex_client::tests::get_test_yaml;
         use crate::raindex_client::trades::test_helpers::get_sg_trade_json;
-        use crate::raindex_client::{ChainIds, RaindexClient};
+        use crate::raindex_client::{ChainIds, PaginationParams, RaindexClient};
         use alloy::primitives::{address, Bytes};
         use httpmock::MockServer;
         use serde_json::json;
@@ -299,7 +301,13 @@ mod tests {
             .unwrap();
 
             let result = client
-                .get_trades_for_owner(Some(ChainIds(vec![1])), None, owner, None, None, None)
+                .get_trades_for_owner(
+                    Some(ChainIds(vec![1])),
+                    None,
+                    owner,
+                    Default::default(),
+                    Default::default(),
+                )
                 .await
                 .unwrap();
 
@@ -336,7 +344,13 @@ mod tests {
             .unwrap();
 
             let result = client
-                .get_trades_for_owner(Some(ChainIds(vec![1])), None, owner, None, None, None)
+                .get_trades_for_owner(
+                    Some(ChainIds(vec![1])),
+                    None,
+                    owner,
+                    Default::default(),
+                    Default::default(),
+                )
                 .await
                 .unwrap();
 
@@ -370,7 +384,16 @@ mod tests {
             .unwrap();
 
             let result = client
-                .get_trades_for_owner(Some(ChainIds(vec![1])), None, owner, None, None, Some(1))
+                .get_trades_for_owner(
+                    Some(ChainIds(vec![1])),
+                    None,
+                    owner,
+                    Default::default(),
+                    PaginationParams {
+                        page: Some(1),
+                        page_size: None,
+                    },
+                )
                 .await
                 .unwrap();
 

--- a/crates/common/src/raindex_client/trades/get_by_owner.rs
+++ b/crates/common/src/raindex_client/trades/get_by_owner.rs
@@ -181,3 +181,291 @@ impl RaindexClient {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_family = "wasm")]
+    mod wasm {
+        use crate::raindex_client::tests::{
+            get_local_db_test_yaml, new_test_client_with_db_callback,
+        };
+        use crate::raindex_client::trades::test_helpers::{
+            build_local_trade_fixture, make_local_db_trades_callback,
+        };
+        use crate::raindex_client::ChainIds;
+        use alloy::primitives::{address, b256};
+        use wasm_bindgen_test::wasm_bindgen_test;
+
+        #[wasm_bindgen_test]
+        async fn test_local_db_path() {
+            let tx_hash =
+                b256!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+            let fixture = build_local_trade_fixture(tx_hash, 1, 4);
+            let owner = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+
+            let callback = make_local_db_trades_callback(
+                vec![fixture.order.clone()],
+                vec![fixture.input_vault.clone(), fixture.output_vault.clone()],
+                vec![fixture.trade.clone()],
+                4,
+            );
+            let client = new_test_client_with_db_callback(
+                vec![get_local_db_test_yaml()],
+                callback,
+                vec![42161],
+            );
+
+            let result = client
+                .get_trades_for_owner(Some(ChainIds(vec![42161])), None, owner, None, None, None)
+                .await
+                .unwrap();
+
+            assert_eq!(result.total_count(), 1);
+            assert!(result.summary().is_some());
+            let trades = result.trades();
+            assert_eq!(trades.len(), 1);
+            assert_eq!(trades[0].chain_id(), 42161);
+        }
+
+        #[wasm_bindgen_test]
+        async fn test_local_db_with_pagination() {
+            let tx_hash =
+                b256!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+            let fixture = build_local_trade_fixture(tx_hash, 1, 4);
+            let owner = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+
+            let callback = make_local_db_trades_callback(
+                vec![fixture.order.clone()],
+                vec![fixture.input_vault.clone(), fixture.output_vault.clone()],
+                vec![fixture.trade.clone()],
+                4,
+            );
+            let client = new_test_client_with_db_callback(
+                vec![get_local_db_test_yaml()],
+                callback,
+                vec![42161],
+            );
+
+            let result = client
+                .get_trades_for_owner(
+                    Some(ChainIds(vec![42161])),
+                    None,
+                    owner,
+                    None,
+                    None,
+                    Some(1),
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(result.total_count(), 4);
+            assert!(result.summary().is_none());
+            assert_eq!(result.trades().len(), 1);
+        }
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    mod non_wasm {
+        use crate::raindex_client::tests::get_test_yaml;
+        use crate::raindex_client::{ChainIds, RaindexClient};
+        use alloy::primitives::{address, Bytes};
+        use httpmock::MockServer;
+        use rain_orderbook_subgraph_client::utils::float::*;
+        use serde_json::json;
+        use std::str::FromStr;
+
+        fn get_trade_json() -> serde_json::Value {
+            json!({
+                "id": "0x0123",
+                "tradeEvent": {
+                    "transaction": {
+                        "id": "0x0000000000000000000000000000000000000000000000000000000000000abc",
+                        "from": "0x0000000000000000000000000000000000000000",
+                        "blockNumber": "100",
+                        "timestamp": "1700000000"
+                    },
+                    "sender": "0xsender1"
+                },
+                "outputVaultBalanceChange": {
+                    "id": "0xovbc1",
+                    "__typename": "TradeVaultBalanceChange",
+                    "amount": NEG2,
+                    "newVaultBalance": F0,
+                    "oldVaultBalance": F2,
+                    "vault": {
+                        "id": "0xvault_out",
+                        "vaultId": "0x01",
+                        "token": {
+                            "id": "0x12e605bc104e93b45e1ad99f9e555f659051c2bb",
+                            "address": "0x12e605bc104e93b45e1ad99f9e555f659051c2bb",
+                            "name": "Staked FLR",
+                            "symbol": "sFLR",
+                            "decimals": "18"
+                        }
+                    },
+                    "timestamp": "1700000000",
+                    "transaction": {
+                        "id": "0x0000000000000000000000000000000000000000000000000000000000000abc",
+                        "from": "0x0000000000000000000000000000000000000000",
+                        "blockNumber": "100",
+                        "timestamp": "1700000000"
+                    },
+                    "orderbook": {
+                        "id": "0x1234567890123456789012345678901234567890"
+                    },
+                    "trade": {
+                        "tradeEvent": {
+                            "__typename": "TakeOrder"
+                        }
+                    }
+                },
+                "order": {
+                    "id": "0x0123",
+                    "orderHash": "0x0000000000000000000000000000000000000000000000000000000000000123",
+                    "owner": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                },
+                "inputVaultBalanceChange": {
+                    "id": "0xivbc1",
+                    "__typename": "TradeVaultBalanceChange",
+                    "amount": F1,
+                    "newVaultBalance": F1,
+                    "oldVaultBalance": F0,
+                    "vault": {
+                        "id": "0xvault_in",
+                        "vaultId": "0x02",
+                        "token": {
+                            "id": "0x1d80c49bbbcd1c0911346656b529df9e5c2f783d",
+                            "address": "0x1d80c49bbbcd1c0911346656b529df9e5c2f783d",
+                            "name": "Wrapped Flare",
+                            "symbol": "WFLR",
+                            "decimals": "18"
+                        }
+                    },
+                    "timestamp": "1700000000",
+                    "transaction": {
+                        "id": "0x0000000000000000000000000000000000000000000000000000000000000abc",
+                        "from": "0x0000000000000000000000000000000000000000",
+                        "blockNumber": "100",
+                        "timestamp": "1700000000"
+                    },
+                    "orderbook": {
+                        "id": "0x1234567890123456789012345678901234567890"
+                    },
+                    "trade": {
+                        "tradeEvent": {
+                            "__typename": "TakeOrder"
+                        }
+                    }
+                },
+                "timestamp": "1700000000",
+                "orderbook": {
+                    "id": "0x1234567890123456789012345678901234567890"
+                }
+            })
+        }
+
+        #[tokio::test]
+        async fn test_returns_trades() {
+            let sg_server = MockServer::start_async().await;
+            sg_server.mock(|when, then| {
+                when.path("/sg").body_contains("SgOwnerTradesListQuery");
+                then.status(200).json_body_obj(&json!({
+                    "data": { "trades": [get_trade_json()] }
+                }));
+            });
+
+            let owner = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+            let client = RaindexClient::new(
+                vec![get_test_yaml(
+                    &sg_server.url("/sg"),
+                    &sg_server.url("/sg"),
+                    "http://localhost:3000",
+                    "http://localhost:3000",
+                )],
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+            let result = client
+                .get_trades_for_owner(Some(ChainIds(vec![1])), None, owner, None, None, None)
+                .await
+                .unwrap();
+
+            assert_eq!(result.total_count(), 1);
+            assert!(result.summary().is_some());
+            let trades = result.trades();
+            assert_eq!(trades.len(), 1);
+            assert_eq!(trades[0].id(), Bytes::from_str("0x0123").unwrap());
+            assert_eq!(trades[0].chain_id(), 1);
+        }
+
+        #[tokio::test]
+        async fn test_empty_result() {
+            let sg_server = MockServer::start_async().await;
+            sg_server.mock(|when, then| {
+                when.path("/sg").body_contains("SgOwnerTradesListQuery");
+                then.status(200).json_body_obj(&json!({
+                    "data": { "trades": [] }
+                }));
+            });
+
+            let owner = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+            let client = RaindexClient::new(
+                vec![get_test_yaml(
+                    &sg_server.url("/sg"),
+                    &sg_server.url("/sg"),
+                    "http://localhost:3000",
+                    "http://localhost:3000",
+                )],
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+            let result = client
+                .get_trades_for_owner(Some(ChainIds(vec![1])), None, owner, None, None, None)
+                .await
+                .unwrap();
+
+            assert_eq!(result.total_count(), 0);
+            assert!(result.trades().is_empty());
+            assert!(result.summary().is_some());
+        }
+
+        #[tokio::test]
+        async fn test_with_pagination_skips_summary() {
+            let sg_server = MockServer::start_async().await;
+            sg_server.mock(|when, then| {
+                when.path("/sg").body_contains("SgOwnerTradesListQuery");
+                then.status(200).json_body_obj(&json!({
+                    "data": { "trades": [get_trade_json()] }
+                }));
+            });
+
+            let owner = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+            let client = RaindexClient::new(
+                vec![get_test_yaml(
+                    &sg_server.url("/sg"),
+                    &sg_server.url("/sg"),
+                    "http://localhost:3000",
+                    "http://localhost:3000",
+                )],
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+            let result = client
+                .get_trades_for_owner(Some(ChainIds(vec![1])), None, owner, None, None, Some(1))
+                .await
+                .unwrap();
+
+            assert!(!result.trades().is_empty());
+            assert!(result.summary().is_none());
+        }
+    }
+}

--- a/crates/common/src/raindex_client/trades/get_by_tx.rs
+++ b/crates/common/src/raindex_client/trades/get_by_tx.rs
@@ -147,9 +147,9 @@ mod tests {
             let trade_id = fixture.trade.trade_id.clone();
 
             let callback = make_local_db_trades_callback(
-                vec![fixture.order.clone()],
-                vec![fixture.input_vault.clone(), fixture.output_vault.clone()],
-                vec![fixture.trade.clone()],
+                vec![fixture.order],
+                vec![fixture.input_vault, fixture.output_vault],
+                vec![fixture.trade],
                 4,
             );
             let client = new_test_client_with_db_callback(
@@ -182,102 +182,12 @@ mod tests {
     #[cfg(not(target_family = "wasm"))]
     mod non_wasm {
         use crate::raindex_client::tests::get_test_yaml;
+        use crate::raindex_client::trades::test_helpers::get_sg_trade_json;
         use crate::raindex_client::{ChainIds, RaindexClient};
         use alloy::primitives::{b256, Address, Bytes};
         use httpmock::MockServer;
-        use rain_orderbook_subgraph_client::utils::float::*;
         use serde_json::json;
         use std::str::FromStr;
-
-        fn get_trade_json() -> serde_json::Value {
-            json!({
-                "id": "0x0123",
-                "tradeEvent": {
-                    "transaction": {
-                        "id": "0x0000000000000000000000000000000000000000000000000000000000000abc",
-                        "from": "0x0000000000000000000000000000000000000000",
-                        "blockNumber": "100",
-                        "timestamp": "1700000000"
-                    },
-                    "sender": "0xsender1"
-                },
-                "outputVaultBalanceChange": {
-                    "id": "0xovbc1",
-                    "__typename": "TradeVaultBalanceChange",
-                    "amount": NEG2,
-                    "newVaultBalance": F0,
-                    "oldVaultBalance": F2,
-                    "vault": {
-                        "id": "0xvault_out",
-                        "vaultId": "0x01",
-                        "token": {
-                            "id": "0x12e605bc104e93b45e1ad99f9e555f659051c2bb",
-                            "address": "0x12e605bc104e93b45e1ad99f9e555f659051c2bb",
-                            "name": "Staked FLR",
-                            "symbol": "sFLR",
-                            "decimals": "18"
-                        }
-                    },
-                    "timestamp": "1700000000",
-                    "transaction": {
-                        "id": "0x0000000000000000000000000000000000000000000000000000000000000abc",
-                        "from": "0x0000000000000000000000000000000000000000",
-                        "blockNumber": "100",
-                        "timestamp": "1700000000"
-                    },
-                    "orderbook": {
-                        "id": "0x1234567890123456789012345678901234567890"
-                    },
-                    "trade": {
-                        "tradeEvent": {
-                            "__typename": "TakeOrder"
-                        }
-                    }
-                },
-                "order": {
-                    "id": "0x0123",
-                    "orderHash": "0x0000000000000000000000000000000000000000000000000000000000000123",
-                    "owner": "0x0000000000000000000000000000000000000000"
-                },
-                "inputVaultBalanceChange": {
-                    "id": "0xivbc1",
-                    "__typename": "TradeVaultBalanceChange",
-                    "amount": F1,
-                    "newVaultBalance": F1,
-                    "oldVaultBalance": F0,
-                    "vault": {
-                        "id": "0xvault_in",
-                        "vaultId": "0x02",
-                        "token": {
-                            "id": "0x1d80c49bbbcd1c0911346656b529df9e5c2f783d",
-                            "address": "0x1d80c49bbbcd1c0911346656b529df9e5c2f783d",
-                            "name": "Wrapped Flare",
-                            "symbol": "WFLR",
-                            "decimals": "18"
-                        }
-                    },
-                    "timestamp": "1700000000",
-                    "transaction": {
-                        "id": "0x0000000000000000000000000000000000000000000000000000000000000abc",
-                        "from": "0x0000000000000000000000000000000000000000",
-                        "blockNumber": "100",
-                        "timestamp": "1700000000"
-                    },
-                    "orderbook": {
-                        "id": "0x1234567890123456789012345678901234567890"
-                    },
-                    "trade": {
-                        "tradeEvent": {
-                            "__typename": "TakeOrder"
-                        }
-                    }
-                },
-                "timestamp": "1700000000",
-                "orderbook": {
-                    "id": "0x1234567890123456789012345678901234567890"
-                }
-            })
-        }
 
         #[tokio::test]
         async fn test_returns_trades() {
@@ -285,7 +195,7 @@ mod tests {
             sg_server.mock(|when, then| {
                 when.path("/sg").body_contains("SgTransactionTradesQuery");
                 then.status(200).json_body_obj(&json!({
-                    "data": { "trades": [get_trade_json()] }
+                    "data": { "trades": [get_sg_trade_json("0x0000000000000000000000000000000000000000")] }
                 }));
             });
 
@@ -362,7 +272,7 @@ mod tests {
             sg_server.mock(|when, then| {
                 when.path("/sg").body_contains("SgTransactionTradesQuery");
                 then.status(200).json_body_obj(&json!({
-                    "data": { "trades": [get_trade_json()] }
+                    "data": { "trades": [get_sg_trade_json("0x0000000000000000000000000000000000000000")] }
                 }));
             });
 

--- a/crates/common/src/raindex_client/trades/get_by_tx.rs
+++ b/crates/common/src/raindex_client/trades/get_by_tx.rs
@@ -123,3 +123,274 @@ impl RaindexClient {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_family = "wasm")]
+    mod wasm {
+        use crate::raindex_client::tests::{
+            get_local_db_test_yaml, new_test_client_with_db_callback,
+        };
+        use crate::raindex_client::trades::test_helpers::{
+            build_local_trade_fixture, make_local_db_trades_callback,
+        };
+        use crate::raindex_client::ChainIds;
+        use alloy::primitives::b256;
+        use wasm_bindgen_test::wasm_bindgen_test;
+
+        #[wasm_bindgen_test]
+        async fn test_local_db_path() {
+            let trade_log_index = 1u64;
+            let tx_hash =
+                b256!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+            let fixture = build_local_trade_fixture(tx_hash, trade_log_index, 4);
+            let trade_id = fixture.trade.trade_id.clone();
+
+            let callback = make_local_db_trades_callback(
+                vec![fixture.order.clone()],
+                vec![fixture.input_vault.clone(), fixture.output_vault.clone()],
+                vec![fixture.trade.clone()],
+                4,
+            );
+            let client = new_test_client_with_db_callback(
+                vec![get_local_db_test_yaml()],
+                callback,
+                vec![42161],
+            );
+
+            let result = client
+                .get_trades_for_transaction(Some(ChainIds(vec![42161])), None, tx_hash)
+                .await
+                .unwrap();
+
+            assert_eq!(result.total_count(), 1);
+            assert!(result.summary().is_some());
+            let trades = result.trades();
+            assert_eq!(trades.len(), 1);
+
+            let trade = trades.first().unwrap();
+            assert_eq!(trade.id(), trade_id);
+            assert_eq!(trade.chain_id(), 42161);
+            assert_eq!(trade.order_hash(), fixture.order_hash.to_string());
+            assert_eq!(
+                trade.orderbook().to_lowercase(),
+                fixture.orderbook_address.to_string().to_lowercase()
+            );
+        }
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    mod non_wasm {
+        use crate::raindex_client::tests::get_test_yaml;
+        use crate::raindex_client::{ChainIds, RaindexClient};
+        use alloy::primitives::{b256, Address, Bytes};
+        use httpmock::MockServer;
+        use rain_orderbook_subgraph_client::utils::float::*;
+        use serde_json::json;
+        use std::str::FromStr;
+
+        fn get_trade_json() -> serde_json::Value {
+            json!({
+                "id": "0x0123",
+                "tradeEvent": {
+                    "transaction": {
+                        "id": "0x0000000000000000000000000000000000000000000000000000000000000abc",
+                        "from": "0x0000000000000000000000000000000000000000",
+                        "blockNumber": "100",
+                        "timestamp": "1700000000"
+                    },
+                    "sender": "0xsender1"
+                },
+                "outputVaultBalanceChange": {
+                    "id": "0xovbc1",
+                    "__typename": "TradeVaultBalanceChange",
+                    "amount": NEG2,
+                    "newVaultBalance": F0,
+                    "oldVaultBalance": F2,
+                    "vault": {
+                        "id": "0xvault_out",
+                        "vaultId": "0x01",
+                        "token": {
+                            "id": "0x12e605bc104e93b45e1ad99f9e555f659051c2bb",
+                            "address": "0x12e605bc104e93b45e1ad99f9e555f659051c2bb",
+                            "name": "Staked FLR",
+                            "symbol": "sFLR",
+                            "decimals": "18"
+                        }
+                    },
+                    "timestamp": "1700000000",
+                    "transaction": {
+                        "id": "0x0000000000000000000000000000000000000000000000000000000000000abc",
+                        "from": "0x0000000000000000000000000000000000000000",
+                        "blockNumber": "100",
+                        "timestamp": "1700000000"
+                    },
+                    "orderbook": {
+                        "id": "0x1234567890123456789012345678901234567890"
+                    },
+                    "trade": {
+                        "tradeEvent": {
+                            "__typename": "TakeOrder"
+                        }
+                    }
+                },
+                "order": {
+                    "id": "0x0123",
+                    "orderHash": "0x0000000000000000000000000000000000000000000000000000000000000123",
+                    "owner": "0x0000000000000000000000000000000000000000"
+                },
+                "inputVaultBalanceChange": {
+                    "id": "0xivbc1",
+                    "__typename": "TradeVaultBalanceChange",
+                    "amount": F1,
+                    "newVaultBalance": F1,
+                    "oldVaultBalance": F0,
+                    "vault": {
+                        "id": "0xvault_in",
+                        "vaultId": "0x02",
+                        "token": {
+                            "id": "0x1d80c49bbbcd1c0911346656b529df9e5c2f783d",
+                            "address": "0x1d80c49bbbcd1c0911346656b529df9e5c2f783d",
+                            "name": "Wrapped Flare",
+                            "symbol": "WFLR",
+                            "decimals": "18"
+                        }
+                    },
+                    "timestamp": "1700000000",
+                    "transaction": {
+                        "id": "0x0000000000000000000000000000000000000000000000000000000000000abc",
+                        "from": "0x0000000000000000000000000000000000000000",
+                        "blockNumber": "100",
+                        "timestamp": "1700000000"
+                    },
+                    "orderbook": {
+                        "id": "0x1234567890123456789012345678901234567890"
+                    },
+                    "trade": {
+                        "tradeEvent": {
+                            "__typename": "TakeOrder"
+                        }
+                    }
+                },
+                "timestamp": "1700000000",
+                "orderbook": {
+                    "id": "0x1234567890123456789012345678901234567890"
+                }
+            })
+        }
+
+        #[tokio::test]
+        async fn test_returns_trades() {
+            let sg_server = MockServer::start_async().await;
+            sg_server.mock(|when, then| {
+                when.path("/sg").body_contains("SgTransactionTradesQuery");
+                then.status(200).json_body_obj(&json!({
+                    "data": { "trades": [get_trade_json()] }
+                }));
+            });
+
+            let client = RaindexClient::new(
+                vec![get_test_yaml(
+                    &sg_server.url("/sg"),
+                    &sg_server.url("/sg"),
+                    "http://localhost:3000",
+                    "http://localhost:3000",
+                )],
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+            let tx_hash =
+                b256!("0x0000000000000000000000000000000000000000000000000000000000000abc");
+            let result = client
+                .get_trades_for_transaction(Some(ChainIds(vec![1])), None, tx_hash)
+                .await
+                .unwrap();
+
+            assert_eq!(result.total_count(), 1);
+            assert!(result.summary().is_some());
+            let trades = result.trades();
+            assert_eq!(trades.len(), 1);
+            assert_eq!(trades[0].id(), Bytes::from_str("0x0123").unwrap());
+            assert_eq!(trades[0].chain_id(), 1);
+            assert_eq!(
+                trades[0].orderbook(),
+                Address::from_str("0x1234567890123456789012345678901234567890").unwrap()
+            );
+        }
+
+        #[tokio::test]
+        async fn test_empty_result() {
+            let sg_server = MockServer::start_async().await;
+            sg_server.mock(|when, then| {
+                when.path("/sg").body_contains("SgTransactionTradesQuery");
+                then.status(200).json_body_obj(&json!({
+                    "data": { "trades": [] }
+                }));
+            });
+
+            let client = RaindexClient::new(
+                vec![get_test_yaml(
+                    &sg_server.url("/sg"),
+                    &sg_server.url("/sg"),
+                    "http://localhost:3000",
+                    "http://localhost:3000",
+                )],
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+            let tx_hash =
+                b256!("0x0000000000000000000000000000000000000000000000000000000000000abc");
+            let result = client
+                .get_trades_for_transaction(Some(ChainIds(vec![1])), None, tx_hash)
+                .await
+                .unwrap();
+
+            assert_eq!(result.total_count(), 0);
+            assert!(result.trades().is_empty());
+            assert!(result.summary().is_some());
+        }
+
+        #[tokio::test]
+        async fn test_with_chain_filter() {
+            let sg_server = MockServer::start_async().await;
+            sg_server.mock(|when, then| {
+                when.path("/sg").body_contains("SgTransactionTradesQuery");
+                then.status(200).json_body_obj(&json!({
+                    "data": { "trades": [get_trade_json()] }
+                }));
+            });
+
+            let client = RaindexClient::new(
+                vec![get_test_yaml(
+                    &sg_server.url("/sg"),
+                    &sg_server.url("/sg"),
+                    "http://localhost:3000",
+                    "http://localhost:3000",
+                )],
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+            let tx_hash =
+                b256!("0x0000000000000000000000000000000000000000000000000000000000000abc");
+            let result = client
+                .get_trades_for_transaction(Some(ChainIds(vec![137])), None, tx_hash)
+                .await
+                .unwrap();
+
+            assert!(result.total_count() > 0);
+            let trades = result.trades();
+            for trade in trades {
+                assert_eq!(trade.chain_id(), 137);
+            }
+        }
+    }
+}

--- a/crates/common/src/raindex_client/trades/get_by_tx.rs
+++ b/crates/common/src/raindex_client/trades/get_by_tx.rs
@@ -1,0 +1,125 @@
+use super::*;
+use crate::local_db::query::fetch_trades_by_tx::FetchTradesByTxArgs;
+use crate::raindex_client::local_db::query::fetch_trades_by_tx::fetch_trades_by_tx;
+use alloy::primitives::{Address, B256};
+use rain_orderbook_subgraph_client::MultiOrderbookSubgraphClient;
+use std::str::FromStr;
+
+#[wasm_export]
+impl RaindexClient {
+    #[wasm_export(
+        js_name = "getTradesForTransaction",
+        return_description = "Trades list result with total count and per-pair summary",
+        unchecked_return_type = "RaindexTradesListResult",
+        preserve_js_class
+    )]
+    pub async fn get_trades_for_transaction_wasm_binding(
+        &self,
+        #[wasm_export(
+            js_name = "chainIds",
+            param_description = "Optional chain IDs to filter networks (queries all if not specified)"
+        )]
+        chain_ids: Option<ChainIds>,
+        #[wasm_export(
+            js_name = "orderbookAddresses",
+            param_description = "Optional orderbook addresses to filter results"
+        )]
+        orderbook_addresses: Option<Vec<String>>,
+        #[wasm_export(
+            js_name = "txHash",
+            param_description = "Transaction hash",
+            unchecked_param_type = "Hex"
+        )]
+        tx_hash: String,
+    ) -> Result<RaindexTradesListResult, RaindexError> {
+        let tx_hash = B256::from_str(&tx_hash)?;
+        let orderbook_addresses = orderbook_addresses
+            .map(|addresses| {
+                addresses
+                    .into_iter()
+                    .map(|address| Address::from_str(&address))
+                    .collect::<Result<Vec<_>, _>>()
+            })
+            .transpose()?;
+        self.get_trades_for_transaction(chain_ids, orderbook_addresses, tx_hash)
+            .await
+    }
+}
+impl RaindexClient {
+    pub async fn get_trades_for_transaction(
+        &self,
+        chain_ids: Option<ChainIds>,
+        orderbook_addresses: Option<Vec<Address>>,
+        tx_hash: B256,
+    ) -> Result<RaindexTradesListResult, RaindexError> {
+        let ids = chain_ids.map(|ChainIds(ids)| ids);
+        let (local_db, local_ids, sg_ids) = self.classify_chains(ids)?;
+        let orderbook_addresses_for_local_db = orderbook_addresses.clone().unwrap_or_default();
+
+        let mut all_trades = Vec::new();
+
+        if let Some(db) = local_db.filter(|_| !local_ids.is_empty()) {
+            let trades = fetch_trades_by_tx(
+                &db,
+                FetchTradesByTxArgs {
+                    chain_ids: local_ids,
+                    orderbook_addresses: orderbook_addresses_for_local_db,
+                    tx_hash,
+                },
+            )
+            .await?;
+            let raindex_trades: Vec<RaindexTrade> = trades
+                .into_iter()
+                .map(RaindexTrade::try_from_local_db_trade)
+                .collect::<Result<_, _>>()?;
+            all_trades.extend(raindex_trades);
+        }
+
+        if !sg_ids.is_empty() {
+            let multi_subgraph_args = self.get_multi_subgraph_args(Some(sg_ids))?;
+            let orderbook_in = orderbook_addresses
+                .as_deref()
+                .filter(|addresses| !addresses.is_empty())
+                .map(|addresses| {
+                    addresses
+                        .iter()
+                        .map(|address| address.to_string().to_lowercase())
+                        .collect::<Vec<_>>()
+                });
+            if !multi_subgraph_args.is_empty() {
+                let name_to_chain_id: std::collections::HashMap<&str, u32> = multi_subgraph_args
+                    .iter()
+                    .flat_map(|(chain_id, args)| {
+                        args.iter().map(|arg| (arg.name.as_str(), *chain_id))
+                    })
+                    .collect();
+                let client = MultiOrderbookSubgraphClient::new(
+                    multi_subgraph_args.values().flatten().cloned().collect(),
+                );
+                let sg_trades = client
+                    .trades_by_transaction(tx_hash.to_string(), orderbook_in)
+                    .await?;
+                for trade_with_name in sg_trades {
+                    let chain_id = name_to_chain_id
+                        .get(trade_with_name.subgraph_name.as_str())
+                        .copied()
+                        .ok_or(RaindexError::SubgraphNotFound(
+                            trade_with_name.subgraph_name.clone(),
+                            trade_with_name.trade.id.0.clone(),
+                        ))?;
+                    let trade = RaindexTrade::try_from_sg_trade(chain_id, trade_with_name.trade)?;
+                    all_trades.push(trade);
+                }
+            }
+        }
+
+        let total_count = all_trades.len() as u64;
+        let summary = RaindexPairSummary::from_trades(&all_trades)?;
+
+        Ok(RaindexTradesListResult {
+            trades: all_trades,
+            total_count,
+            summary: Some(summary),
+        })
+    }
+}

--- a/crates/common/src/raindex_client/trades/mod.rs
+++ b/crates/common/src/raindex_client/trades/mod.rs
@@ -588,10 +588,275 @@ impl RaindexTradesListResult {
 
 #[cfg(test)]
 mod test_helpers {
+    use super::*;
+
     #[cfg(target_family = "wasm")]
-    use super::*;
-    #[cfg(not(target_family = "wasm"))]
-    use super::*;
+    use crate::local_db::query::{
+        fetch_order_trades::LocalDbOrderTrade, fetch_orders::LocalDbOrder,
+        fetch_vaults::LocalDbVault,
+    };
+    #[cfg(target_family = "wasm")]
+    use alloy::primitives::{address, b256, bytes, Address, Bytes, B256, U256};
+    #[cfg(target_family = "wasm")]
+    use js_sys::Array;
+    #[cfg(target_family = "wasm")]
+    use serde_json::{self, json};
+    #[cfg(target_family = "wasm")]
+    use std::collections::HashMap;
+    #[cfg(target_family = "wasm")]
+    use std::str::FromStr;
+    #[cfg(target_family = "wasm")]
+    use wasm_bindgen::{prelude::Closure, JsCast, JsValue};
+    #[cfg(target_family = "wasm")]
+    use wasm_bindgen_utils::prelude::WasmEncodedResult;
+
+    #[cfg(target_family = "wasm")]
+    #[derive(Clone)]
+    pub(super) struct LocalTradeFixture {
+        pub(super) order: LocalDbOrder,
+        pub(super) input_vault: LocalDbVault,
+        pub(super) output_vault: LocalDbVault,
+        pub(super) trade: LocalDbOrderTrade,
+        pub(super) orderbook_address: Address,
+        pub(super) order_hash: B256,
+        pub(super) input_token: Address,
+        pub(super) output_token: Address,
+    }
+
+    #[cfg(target_family = "wasm")]
+    pub(super) fn build_local_trade_fixture(
+        tx_hash: B256,
+        trade_log_index: u64,
+        trade_count: u64,
+    ) -> LocalTradeFixture {
+        const CHAIN_ID: u32 = 42161;
+        let orderbook_address = address!("0x2f209e5b67a33b8fe96e28f24628df6da301c8eb");
+        let order_hash =
+            b256!("0x0000000000000000000000000000000000000000000000000000000000000abc");
+        let owner = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        let input_vault_id = U256::from_str("0x01").unwrap();
+        let output_vault_id = U256::from_str("0x02").unwrap();
+        let input_token = address!("0x00000000000000000000000000000000000000aa");
+        let output_token = address!("0x00000000000000000000000000000000000000bb");
+        const INPUT_DELTA_HEX: &str =
+            "0x0000000000000000000000000000000000000000000000000000000000000001";
+        const INPUT_RUNNING_HEX: &str =
+            "0x0000000000000000000000000000000000000000000000000000000000000003";
+        const OUTPUT_DELTA_HEX: &str =
+            "0x00000000fffffffffffffffffffffffffffffffffffffffffffffffffffffffe";
+        const OUTPUT_RUNNING_HEX: &str =
+            "0x0000000000000000000000000000000000000000000000000000000000000001";
+
+        let tx_hash_hex = format!("{tx_hash:#x}");
+        let trade_id = format!(
+            "0x{}{:016x}",
+            tx_hash_hex.trim_start_matches("0x"),
+            trade_log_index
+        )
+        .to_lowercase();
+
+        let order_bytes =
+            bytes!("0x00000000000000000000000000000000000000000000000000000000000000ff");
+        let transaction_hash = tx_hash;
+        let transaction_sender = address!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+
+        let input_vault = LocalDbVault {
+            chain_id: 42161,
+            vault_id: input_vault_id,
+            token: input_token,
+            owner,
+            orderbook_address,
+            token_name: "Token A".to_string(),
+            token_symbol: "TKNA".to_string(),
+            token_decimals: 18,
+            balance: INPUT_RUNNING_HEX.to_string(),
+            input_orders: Some(format!("0x01:{}:0", order_hash)),
+            output_orders: None,
+        };
+
+        let output_vault = LocalDbVault {
+            chain_id: 42161,
+            vault_id: output_vault_id,
+            token: output_token,
+            owner,
+            orderbook_address,
+            token_name: "Token B".to_string(),
+            token_symbol: "TKNB".to_string(),
+            token_decimals: 6,
+            balance: OUTPUT_RUNNING_HEX.to_string(),
+            input_orders: None,
+            output_orders: Some(format!("0x01:{}:0", order_hash)),
+        };
+
+        let order_inputs_payload = serde_json::to_string(&vec![json!({
+            "ioIndex": 0,
+            "vault": input_vault.clone()
+        })])
+        .unwrap();
+
+        let order_outputs_payload = serde_json::to_string(&vec![json!({
+            "ioIndex": 0,
+            "vault": output_vault.clone()
+        })])
+        .unwrap();
+
+        let order = LocalDbOrder {
+            chain_id: CHAIN_ID,
+            order_hash: order_hash.clone(),
+            owner,
+            block_timestamp: 1_700_000_010,
+            block_number: 123_456,
+            orderbook_address,
+            order_bytes: order_bytes.clone(),
+            transaction_hash,
+            inputs: Some(order_inputs_payload),
+            outputs: Some(order_outputs_payload),
+            trade_count,
+            active: true,
+            meta: Some(Bytes::from_str("0x1234").unwrap()),
+        };
+
+        let trade = LocalDbOrderTrade {
+            chain_id: CHAIN_ID,
+            trade_kind: "take".into(),
+            orderbook: orderbook_address,
+            order_hash: order_hash.clone(),
+            order_owner: owner,
+            order_nonce: "0".into(),
+            transaction_hash,
+            log_index: trade_log_index,
+            block_number: 123_460,
+            block_timestamp: 1_700_000_000,
+            transaction_sender,
+            input_vault_id,
+            input_token,
+            input_token_name: Some("Token A".into()),
+            input_token_symbol: Some("TKNA".into()),
+            input_token_decimals: Some(18),
+            input_delta: INPUT_DELTA_HEX.into(),
+            input_running_balance: Some(INPUT_RUNNING_HEX.into()),
+            output_vault_id,
+            output_token,
+            output_token_name: Some("Token B".into()),
+            output_token_symbol: Some("TKNB".into()),
+            output_token_decimals: Some(6),
+            output_delta: OUTPUT_DELTA_HEX.into(),
+            output_running_balance: Some(OUTPUT_RUNNING_HEX.into()),
+            trade_id,
+        };
+
+        LocalTradeFixture {
+            order,
+            input_vault,
+            output_vault,
+            trade,
+            orderbook_address,
+            order_hash,
+            input_token,
+            output_token,
+        }
+    }
+
+    #[cfg(target_family = "wasm")]
+    pub(super) fn make_local_db_trades_callback(
+        orders: Vec<LocalDbOrder>,
+        vaults: Vec<LocalDbVault>,
+        trades: Vec<LocalDbOrderTrade>,
+        trade_count: u64,
+    ) -> js_sys::Function {
+        let orders_json = serde_json::to_string(&orders).unwrap();
+        let orders_result = WasmEncodedResult::Success::<String> {
+            value: orders_json,
+            error: None,
+        };
+        let orders_payload =
+            js_sys::JSON::stringify(&serde_wasm_bindgen::to_value(&orders_result).unwrap())
+                .unwrap()
+                .as_string()
+                .unwrap();
+
+        let trades_json = serde_json::to_string(&trades).unwrap();
+        let trades_result = WasmEncodedResult::Success::<String> {
+            value: trades_json,
+            error: None,
+        };
+        let trades_payload =
+            js_sys::JSON::stringify(&serde_wasm_bindgen::to_value(&trades_result).unwrap())
+                .unwrap()
+                .as_string()
+                .unwrap();
+
+        let trade_count_rows =
+            serde_json::to_string(&vec![json!({ "trade_count": trade_count })]).unwrap();
+        let trade_count_result = WasmEncodedResult::Success::<String> {
+            value: trade_count_rows,
+            error: None,
+        };
+        let trade_count_payload =
+            js_sys::JSON::stringify(&serde_wasm_bindgen::to_value(&trade_count_result).unwrap())
+                .unwrap()
+                .as_string()
+                .unwrap();
+
+        let empty_result = WasmEncodedResult::Success::<String> {
+            value: "[]".to_string(),
+            error: None,
+        };
+        let empty_payload =
+            js_sys::JSON::stringify(&serde_wasm_bindgen::to_value(&empty_result).unwrap())
+                .unwrap()
+                .as_string()
+                .unwrap();
+
+        let mut vault_payloads = HashMap::new();
+        for vault in vaults.into_iter() {
+            let lookup = format!("{:#x}", vault.vault_id).to_ascii_lowercase();
+            let json = serde_json::to_string(&vec![vault]).unwrap();
+            let result = WasmEncodedResult::Success::<String> {
+                value: json,
+                error: None,
+            };
+            let payload = js_sys::JSON::stringify(&serde_wasm_bindgen::to_value(&result).unwrap())
+                .unwrap()
+                .as_string()
+                .unwrap();
+            vault_payloads.insert(lookup, payload);
+        }
+
+        let callback = Closure::wrap(Box::new(move |sql: String, params: JsValue| -> JsValue {
+            if sql.contains("FROM order_events")
+                && (sql.contains("json_group_array") || sql.contains("GROUP_CONCAT("))
+                && (sql.contains("ios.io_type = 'input'")
+                    || sql.contains("lower(ios.io_type) = 'input'"))
+            {
+                return js_sys::JSON::parse(&orders_payload).unwrap();
+            }
+
+            if sql.contains("SELECT COUNT(*) AS trade_count") {
+                return js_sys::JSON::parse(&trade_count_payload).unwrap();
+            }
+
+            if sql.contains(" AS trade_kind") {
+                return js_sys::JSON::parse(&trades_payload).unwrap();
+            }
+
+            if sql.contains("?3 AS vault_id") {
+                if !params.is_undefined() && !params.is_null() {
+                    let params_array = Array::from(&params);
+                    if let Some(vault_id_val) = params_array.get(2).as_string() {
+                        let vault_id = vault_id_val.to_ascii_lowercase();
+                        if let Some(payload) = vault_payloads.get(&vault_id) {
+                            return js_sys::JSON::parse(payload).unwrap();
+                        }
+                    }
+                }
+            }
+
+            js_sys::JSON::parse(&empty_payload).unwrap()
+        }) as Box<dyn FnMut(String, JsValue) -> JsValue>);
+
+        callback.into_js_value().dyn_into().unwrap()
+    }
 
     #[cfg(not(target_family = "wasm"))]
     mod native_tests {
@@ -611,270 +876,11 @@ mod test_helpers {
     #[cfg(target_family = "wasm")]
     mod wasm_tests {
         use super::*;
-        use crate::local_db::query::{
-            fetch_order_trades::LocalDbOrderTrade, fetch_orders::LocalDbOrder,
-            fetch_vaults::LocalDbVault,
-        };
         use crate::raindex_client::tests::{
             get_local_db_test_yaml, new_test_client_with_db_callback,
         };
-        use alloy::primitives::{address, b256, bytes, Address, Bytes, B256, U256};
-        use js_sys::Array;
         use rain_orderbook_subgraph_client::utils::float::{F1, F2, F3, NEG2};
-        use serde_json::{self, json};
-        use std::collections::HashMap;
-        use std::str::FromStr;
-        use wasm_bindgen::{prelude::Closure, JsCast, JsValue};
         use wasm_bindgen_test::wasm_bindgen_test;
-        use wasm_bindgen_utils::prelude::WasmEncodedResult;
-
-        #[derive(Clone)]
-        struct LocalTradeFixture {
-            order: LocalDbOrder,
-            input_vault: LocalDbVault,
-            output_vault: LocalDbVault,
-            trade: LocalDbOrderTrade,
-            orderbook_address: Address,
-            order_hash: B256,
-            input_token: Address,
-            output_token: Address,
-        }
-
-        fn build_local_trade_fixture(
-            tx_hash: B256,
-            trade_log_index: u64,
-            trade_count: u64,
-        ) -> LocalTradeFixture {
-            const CHAIN_ID: u32 = 42161;
-            let orderbook_address = address!("0x2f209e5b67a33b8fe96e28f24628df6da301c8eb");
-            let order_hash =
-                b256!("0x0000000000000000000000000000000000000000000000000000000000000abc");
-            let owner = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
-            let input_vault_id = U256::from_str("0x01").unwrap();
-            let output_vault_id = U256::from_str("0x02").unwrap();
-            let input_token = address!("0x00000000000000000000000000000000000000aa");
-            let output_token = address!("0x00000000000000000000000000000000000000bb");
-            const INPUT_DELTA_HEX: &str =
-                "0x0000000000000000000000000000000000000000000000000000000000000001";
-            const INPUT_RUNNING_HEX: &str =
-                "0x0000000000000000000000000000000000000000000000000000000000000003";
-            const OUTPUT_DELTA_HEX: &str =
-                "0x00000000fffffffffffffffffffffffffffffffffffffffffffffffffffffffe";
-            const OUTPUT_RUNNING_HEX: &str =
-                "0x0000000000000000000000000000000000000000000000000000000000000001";
-
-            let tx_hash_hex = format!("{tx_hash:#x}");
-            let trade_id = format!(
-                "0x{}{:016x}",
-                tx_hash_hex.trim_start_matches("0x"),
-                trade_log_index
-            )
-            .to_lowercase();
-
-            let order_bytes =
-                bytes!("0x00000000000000000000000000000000000000000000000000000000000000ff");
-            let transaction_hash = tx_hash;
-            let transaction_sender = address!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
-
-            let input_vault = LocalDbVault {
-                chain_id: 42161,
-                vault_id: input_vault_id,
-                token: input_token,
-                owner,
-                orderbook_address,
-                token_name: "Token A".to_string(),
-                token_symbol: "TKNA".to_string(),
-                token_decimals: 18,
-                balance: INPUT_RUNNING_HEX.to_string(),
-                input_orders: Some(format!("0x01:{}:0", order_hash)),
-                output_orders: None,
-            };
-
-            let output_vault = LocalDbVault {
-                chain_id: 42161,
-                vault_id: output_vault_id,
-                token: output_token,
-                owner,
-                orderbook_address,
-                token_name: "Token B".to_string(),
-                token_symbol: "TKNB".to_string(),
-                token_decimals: 6,
-                balance: OUTPUT_RUNNING_HEX.to_string(),
-                input_orders: None,
-                output_orders: Some(format!("0x01:{}:0", order_hash)),
-            };
-
-            let order_inputs_payload = serde_json::to_string(&vec![json!({
-                "ioIndex": 0,
-                "vault": input_vault.clone()
-            })])
-            .unwrap();
-
-            let order_outputs_payload = serde_json::to_string(&vec![json!({
-                "ioIndex": 0,
-                "vault": output_vault.clone()
-            })])
-            .unwrap();
-
-            let order = LocalDbOrder {
-                chain_id: CHAIN_ID,
-                order_hash: order_hash.clone(),
-                owner,
-                block_timestamp: 1_700_000_010,
-                block_number: 123_456,
-                orderbook_address,
-                order_bytes: order_bytes.clone(),
-                transaction_hash,
-                inputs: Some(order_inputs_payload),
-                outputs: Some(order_outputs_payload),
-                trade_count,
-                active: true,
-                meta: Some(Bytes::from_str("0x1234").unwrap()),
-            };
-
-            let trade = LocalDbOrderTrade {
-                chain_id: CHAIN_ID,
-                trade_kind: "take".into(),
-                orderbook: orderbook_address,
-                order_hash: order_hash.clone(),
-                order_owner: owner,
-                order_nonce: "0".into(),
-                transaction_hash,
-                log_index: trade_log_index,
-                block_number: 123_460,
-                block_timestamp: 1_700_000_000,
-                transaction_sender,
-                input_vault_id,
-                input_token,
-                input_token_name: Some("Token A".into()),
-                input_token_symbol: Some("TKNA".into()),
-                input_token_decimals: Some(18),
-                input_delta: INPUT_DELTA_HEX.into(),
-                input_running_balance: Some(INPUT_RUNNING_HEX.into()),
-                output_vault_id,
-                output_token,
-                output_token_name: Some("Token B".into()),
-                output_token_symbol: Some("TKNB".into()),
-                output_token_decimals: Some(6),
-                output_delta: OUTPUT_DELTA_HEX.into(),
-                output_running_balance: Some(OUTPUT_RUNNING_HEX.into()),
-                trade_id,
-            };
-
-            LocalTradeFixture {
-                order,
-                input_vault,
-                output_vault,
-                trade,
-                orderbook_address,
-                order_hash,
-                input_token,
-                output_token,
-            }
-        }
-
-        fn make_local_db_trades_callback(
-            orders: Vec<LocalDbOrder>,
-            vaults: Vec<LocalDbVault>,
-            trades: Vec<LocalDbOrderTrade>,
-            trade_count: u64,
-        ) -> js_sys::Function {
-            let orders_json = serde_json::to_string(&orders).unwrap();
-            let orders_result = WasmEncodedResult::Success::<String> {
-                value: orders_json,
-                error: None,
-            };
-            let orders_payload =
-                js_sys::JSON::stringify(&serde_wasm_bindgen::to_value(&orders_result).unwrap())
-                    .unwrap()
-                    .as_string()
-                    .unwrap();
-
-            let trades_json = serde_json::to_string(&trades).unwrap();
-            let trades_result = WasmEncodedResult::Success::<String> {
-                value: trades_json,
-                error: None,
-            };
-            let trades_payload =
-                js_sys::JSON::stringify(&serde_wasm_bindgen::to_value(&trades_result).unwrap())
-                    .unwrap()
-                    .as_string()
-                    .unwrap();
-
-            let trade_count_rows =
-                serde_json::to_string(&vec![json!({ "trade_count": trade_count })]).unwrap();
-            let trade_count_result = WasmEncodedResult::Success::<String> {
-                value: trade_count_rows,
-                error: None,
-            };
-            let trade_count_payload = js_sys::JSON::stringify(
-                &serde_wasm_bindgen::to_value(&trade_count_result).unwrap(),
-            )
-            .unwrap()
-            .as_string()
-            .unwrap();
-
-            let empty_result = WasmEncodedResult::Success::<String> {
-                value: "[]".to_string(),
-                error: None,
-            };
-            let empty_payload =
-                js_sys::JSON::stringify(&serde_wasm_bindgen::to_value(&empty_result).unwrap())
-                    .unwrap()
-                    .as_string()
-                    .unwrap();
-
-            let mut vault_payloads = HashMap::new();
-            for vault in vaults.into_iter() {
-                let lookup = format!("{:#x}", vault.vault_id).to_ascii_lowercase();
-                let json = serde_json::to_string(&vec![vault]).unwrap();
-                let result = WasmEncodedResult::Success::<String> {
-                    value: json,
-                    error: None,
-                };
-                let payload =
-                    js_sys::JSON::stringify(&serde_wasm_bindgen::to_value(&result).unwrap())
-                        .unwrap()
-                        .as_string()
-                        .unwrap();
-                vault_payloads.insert(lookup, payload);
-            }
-
-            let callback = Closure::wrap(Box::new(move |sql: String, params: JsValue| -> JsValue {
-                if sql.contains("FROM order_events")
-                    && (sql.contains("json_group_array") || sql.contains("GROUP_CONCAT("))
-                    && (sql.contains("ios.io_type = 'input'")
-                        || sql.contains("lower(ios.io_type) = 'input'"))
-                {
-                    return js_sys::JSON::parse(&orders_payload).unwrap();
-                }
-
-                if sql.contains("SELECT COUNT(*) AS trade_count") {
-                    return js_sys::JSON::parse(&trade_count_payload).unwrap();
-                }
-
-                if sql.contains(" AS trade_kind") {
-                    return js_sys::JSON::parse(&trades_payload).unwrap();
-                }
-
-                if sql.contains("?3 AS vault_id") {
-                    if !params.is_undefined() && !params.is_null() {
-                        let params_array = Array::from(&params);
-                        if let Some(vault_id_val) = params_array.get(2).as_string() {
-                            let vault_id = vault_id_val.to_ascii_lowercase();
-                            if let Some(payload) = vault_payloads.get(&vault_id) {
-                                return js_sys::JSON::parse(payload).unwrap();
-                            }
-                        }
-                    }
-                }
-
-                js_sys::JSON::parse(&empty_payload).unwrap()
-            })
-                as Box<dyn FnMut(String, JsValue) -> JsValue>);
-
-            callback.into_js_value().dyn_into().unwrap()
-        }
 
         #[wasm_bindgen_test]
         async fn test_get_trades_list_local_db_path() {

--- a/crates/common/src/raindex_client/trades/mod.rs
+++ b/crates/common/src/raindex_client/trades/mod.rs
@@ -859,7 +859,6 @@ mod test_helpers {
     }
 
     #[cfg(not(target_family = "wasm"))]
-<<<<<<< HEAD
     mod native_tests {
         use super::*;
         use rain_orderbook_subgraph_client::utils::float::F1;
@@ -872,7 +871,9 @@ mod test_helpers {
             assert!(ratio.eq(Float::zero().unwrap()).unwrap());
             assert_eq!(formatted_ratio, "0");
         }
-=======
+    }
+
+    #[cfg(not(target_family = "wasm"))]
     pub(super) fn get_sg_trade_json(owner: &str) -> serde_json::Value {
         use rain_orderbook_subgraph_client::utils::float::*;
         serde_json::json!({
@@ -962,7 +963,6 @@ mod test_helpers {
                 "id": "0x1234567890123456789012345678901234567890"
             }
         })
->>>>>>> 1e57fd471 (refactor: deduplicate trade test fixtures and remove unnecessary clones)
     }
 
     #[cfg(target_family = "wasm")]

--- a/crates/common/src/raindex_client/trades/mod.rs
+++ b/crates/common/src/raindex_client/trades/mod.rs
@@ -1,11 +1,12 @@
+mod get_by_owner;
+mod get_by_tx;
+
 use super::local_db::orders::LocalDbOrders;
 use super::orders::{OrdersDataSource, SubgraphOrders};
 use super::ClientRef;
 use super::*;
 use crate::local_db::query::fetch_order_trades::LocalDbOrderTrade;
-use crate::local_db::query::fetch_trades_by_tx::FetchTradesByTxArgs;
 use crate::local_db::OrderbookIdentifier;
-use crate::raindex_client::local_db::query::fetch_trades_by_tx::fetch_trades_by_tx;
 use crate::raindex_client::{
     orders::RaindexOrder,
     transactions::RaindexTransaction,
@@ -13,10 +14,7 @@ use crate::raindex_client::{
 };
 use alloy::primitives::{Address, Bytes, B256, U256};
 use rain_math_float::Float;
-use rain_orderbook_subgraph_client::{
-    types::{common::SgTrade, Id},
-    MultiOrderbookSubgraphClient,
-};
+use rain_orderbook_subgraph_client::types::{common::SgTrade, Id};
 use std::ops::{Add, Div, Sub};
 use std::str::FromStr;
 #[cfg(target_family = "wasm")]
@@ -121,144 +119,6 @@ impl RaindexTrade {
     }
     pub fn formatted_io_ratio(&self) -> &str {
         &self.formatted_io_ratio
-    }
-}
-
-#[wasm_export]
-impl RaindexClient {
-    /// Fetches all trades from a specific transaction
-    ///
-    /// Queries either local DB or subgraph based on the configured data source
-    /// for each chain, using the classify_chains pattern.
-    ///
-    /// ## Examples
-    ///
-    /// ```javascript
-    /// const result = await client.getTradesForTransaction(
-    ///   undefined,
-    ///   undefined,
-    ///   "0xabcdef..."
-    /// );
-    /// if (result.error) {
-    ///   console.error("Error:", result.error.readableMsg);
-    ///   return;
-    /// }
-    /// const { trades, totalCount, summary } = result.value;
-    /// ```
-    #[wasm_export(
-        js_name = "getTradesForTransaction",
-        return_description = "Trades list result with total count and per-pair summary",
-        unchecked_return_type = "RaindexTradesListResult",
-        preserve_js_class
-    )]
-    pub async fn get_trades_for_transaction_wasm_binding(
-        &self,
-        #[wasm_export(
-            js_name = "chainIds",
-            param_description = "Optional chain IDs to filter networks (queries all if not specified)"
-        )]
-        chain_ids: Option<ChainIds>,
-        #[wasm_export(
-            js_name = "orderbookAddresses",
-            param_description = "Optional orderbook addresses to filter results"
-        )]
-        orderbook_addresses: Option<Vec<String>>,
-        #[wasm_export(
-            js_name = "txHash",
-            param_description = "Transaction hash",
-            unchecked_param_type = "Hex"
-        )]
-        tx_hash: String,
-    ) -> Result<RaindexTradesListResult, RaindexError> {
-        let tx_hash = B256::from_str(&tx_hash)?;
-        let orderbook_addresses = orderbook_addresses
-            .map(|addresses| {
-                addresses
-                    .into_iter()
-                    .map(|address| Address::from_str(&address))
-                    .collect::<Result<Vec<_>, _>>()
-            })
-            .transpose()?;
-        self.get_trades_for_transaction(chain_ids, orderbook_addresses, tx_hash)
-            .await
-    }
-}
-impl RaindexClient {
-    pub async fn get_trades_for_transaction(
-        &self,
-        chain_ids: Option<ChainIds>,
-        orderbook_addresses: Option<Vec<Address>>,
-        tx_hash: B256,
-    ) -> Result<RaindexTradesListResult, RaindexError> {
-        let ids = chain_ids.map(|ChainIds(ids)| ids);
-        let (local_db, local_ids, sg_ids) = self.classify_chains(ids)?;
-        let orderbook_addresses_for_local_db = orderbook_addresses.clone().unwrap_or_default();
-
-        let mut all_trades = Vec::new();
-
-        if let Some(db) = local_db.filter(|_| !local_ids.is_empty()) {
-            let trades = fetch_trades_by_tx(
-                &db,
-                FetchTradesByTxArgs {
-                    chain_ids: local_ids,
-                    orderbook_addresses: orderbook_addresses_for_local_db,
-                    tx_hash,
-                },
-            )
-            .await?;
-            let raindex_trades: Vec<RaindexTrade> = trades
-                .into_iter()
-                .map(RaindexTrade::try_from_local_db_trade)
-                .collect::<Result<_, _>>()?;
-            all_trades.extend(raindex_trades);
-        }
-
-        if !sg_ids.is_empty() {
-            let multi_subgraph_args = self.get_multi_subgraph_args(Some(sg_ids))?;
-            let orderbook_in = orderbook_addresses
-                .as_deref()
-                .filter(|addresses| !addresses.is_empty())
-                .map(|addresses| {
-                    addresses
-                        .iter()
-                        .map(|address| address.to_string().to_lowercase())
-                        .collect::<Vec<_>>()
-                });
-            if !multi_subgraph_args.is_empty() {
-                let name_to_chain_id: std::collections::HashMap<&str, u32> = multi_subgraph_args
-                    .iter()
-                    .flat_map(|(chain_id, args)| {
-                        args.iter().map(|arg| (arg.name.as_str(), *chain_id))
-                    })
-                    .collect();
-                let client = MultiOrderbookSubgraphClient::new(
-                    multi_subgraph_args.values().flatten().cloned().collect(),
-                );
-                let sg_trades = client
-                    .trades_by_transaction(tx_hash.to_string(), orderbook_in)
-                    .await?;
-                for trade_with_name in sg_trades {
-                    let chain_id = name_to_chain_id
-                        .get(trade_with_name.subgraph_name.as_str())
-                        .copied()
-                        .ok_or(RaindexError::SubgraphNotFound(
-                            trade_with_name.subgraph_name.clone(),
-                            trade_with_name.trade.id.0.clone(),
-                        ))?;
-                    let trade = RaindexTrade::try_from_sg_trade(chain_id, trade_with_name.trade)?;
-                    all_trades.push(trade);
-                }
-            }
-        }
-
-        let total_count = all_trades.len() as u64;
-        let summary = RaindexPairSummary::from_trades(&all_trades)?;
-
-        Ok(RaindexTradesListResult {
-            trades: all_trades,
-            total_count,
-            summary: Some(summary),
-        })
     }
 }
 

--- a/crates/common/src/raindex_client/trades/mod.rs
+++ b/crates/common/src/raindex_client/trades/mod.rs
@@ -859,6 +859,7 @@ mod test_helpers {
     }
 
     #[cfg(not(target_family = "wasm"))]
+<<<<<<< HEAD
     mod native_tests {
         use super::*;
         use rain_orderbook_subgraph_client::utils::float::F1;
@@ -871,6 +872,97 @@ mod test_helpers {
             assert!(ratio.eq(Float::zero().unwrap()).unwrap());
             assert_eq!(formatted_ratio, "0");
         }
+=======
+    pub(super) fn get_sg_trade_json(owner: &str) -> serde_json::Value {
+        use rain_orderbook_subgraph_client::utils::float::*;
+        serde_json::json!({
+            "id": "0x0123",
+            "tradeEvent": {
+                "transaction": {
+                    "id": "0x0000000000000000000000000000000000000000000000000000000000000abc",
+                    "from": "0x0000000000000000000000000000000000000000",
+                    "blockNumber": "100",
+                    "timestamp": "1700000000"
+                },
+                "sender": "0xsender1"
+            },
+            "outputVaultBalanceChange": {
+                "id": "0xovbc1",
+                "__typename": "TradeVaultBalanceChange",
+                "amount": NEG2,
+                "newVaultBalance": F0,
+                "oldVaultBalance": F2,
+                "vault": {
+                    "id": "0xvault_out",
+                    "vaultId": "0x01",
+                    "token": {
+                        "id": "0x12e605bc104e93b45e1ad99f9e555f659051c2bb",
+                        "address": "0x12e605bc104e93b45e1ad99f9e555f659051c2bb",
+                        "name": "Staked FLR",
+                        "symbol": "sFLR",
+                        "decimals": "18"
+                    }
+                },
+                "timestamp": "1700000000",
+                "transaction": {
+                    "id": "0x0000000000000000000000000000000000000000000000000000000000000abc",
+                    "from": "0x0000000000000000000000000000000000000000",
+                    "blockNumber": "100",
+                    "timestamp": "1700000000"
+                },
+                "orderbook": {
+                    "id": "0x1234567890123456789012345678901234567890"
+                },
+                "trade": {
+                    "tradeEvent": {
+                        "__typename": "TakeOrder"
+                    }
+                }
+            },
+            "order": {
+                "id": "0x0123",
+                "orderHash": "0x0000000000000000000000000000000000000000000000000000000000000123",
+                "owner": owner
+            },
+            "inputVaultBalanceChange": {
+                "id": "0xivbc1",
+                "__typename": "TradeVaultBalanceChange",
+                "amount": F1,
+                "newVaultBalance": F1,
+                "oldVaultBalance": F0,
+                "vault": {
+                    "id": "0xvault_in",
+                    "vaultId": "0x02",
+                    "token": {
+                        "id": "0x1d80c49bbbcd1c0911346656b529df9e5c2f783d",
+                        "address": "0x1d80c49bbbcd1c0911346656b529df9e5c2f783d",
+                        "name": "Wrapped Flare",
+                        "symbol": "WFLR",
+                        "decimals": "18"
+                    }
+                },
+                "timestamp": "1700000000",
+                "transaction": {
+                    "id": "0x0000000000000000000000000000000000000000000000000000000000000abc",
+                    "from": "0x0000000000000000000000000000000000000000",
+                    "blockNumber": "100",
+                    "timestamp": "1700000000"
+                },
+                "orderbook": {
+                    "id": "0x1234567890123456789012345678901234567890"
+                },
+                "trade": {
+                    "tradeEvent": {
+                        "__typename": "TakeOrder"
+                    }
+                }
+            },
+            "timestamp": "1700000000",
+            "orderbook": {
+                "id": "0x1234567890123456789012345678901234567890"
+            }
+        })
+>>>>>>> 1e57fd471 (refactor: deduplicate trade test fixtures and remove unnecessary clones)
     }
 
     #[cfg(target_family = "wasm")]

--- a/crates/common/src/raindex_client/types.rs
+++ b/crates/common/src/raindex_client/types.rs
@@ -1,0 +1,23 @@
+use serde::{Deserialize, Serialize};
+use tsify::Tsify;
+use wasm_bindgen_utils::{impl_wasm_traits, prelude::*};
+
+#[derive(Serialize, Deserialize, Debug, Clone, Tsify)]
+pub struct ChainIds(#[tsify(type = "number[]")] pub Vec<u32>);
+impl_wasm_traits!(ChainIds);
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default, Tsify)]
+#[serde(rename_all = "camelCase")]
+pub struct TimeFilter {
+    pub start: Option<u64>,
+    pub end: Option<u64>,
+}
+impl_wasm_traits!(TimeFilter);
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default, Tsify)]
+#[serde(rename_all = "camelCase")]
+pub struct PaginationParams {
+    pub page: Option<u16>,
+    pub page_size: Option<u16>,
+}
+impl_wasm_traits!(PaginationParams);

--- a/crates/common/src/raindex_client/vaults.rs
+++ b/crates/common/src/raindex_client/vaults.rs
@@ -39,6 +39,7 @@ use rain_orderbook_subgraph_client::{
     SgPaginationArgs,
 };
 use std::str::FromStr;
+use wasm_bindgen_utils::impl_wasm_traits;
 #[cfg(target_family = "wasm")]
 use wasm_bindgen_utils::prelude::js_sys::BigInt;
 

--- a/crates/subgraph/src/multi_orderbook_client.rs
+++ b/crates/subgraph/src/multi_orderbook_client.rs
@@ -1445,4 +1445,248 @@ mod tests {
             .await;
         assert!(result.is_err());
     }
+
+    #[tokio::test]
+    async fn test_trades_by_owner_no_subgraphs() {
+        let client = MultiOrderbookSubgraphClient::new(vec![]);
+        let result = client
+            .trades_by_owner("0xowner".to_string(), None, None, None)
+            .await;
+        assert!(result.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_trades_by_owner_one_subgraph_returns_trades() {
+        let server = MockServer::start_async().await;
+        let sg_url = Url::parse(&server.url("")).unwrap();
+        let sg_name = "sg_owner";
+        let owner = "0xowner_abc";
+
+        let trade1 = default_sg_trade();
+        server.mock(|when, then| {
+            when.method(POST).path("/").body_contains(owner);
+            then.status(200)
+                .json_body(json!({"data": {"trades": [trade1]}}));
+        });
+        server.mock(|when, then| {
+            when.method(POST).path("/").body_contains(owner);
+            then.status(200).json_body(json!({"data": {"trades": []}}));
+        });
+
+        let client = MultiOrderbookSubgraphClient::new(vec![MultiSubgraphArgs {
+            url: sg_url,
+            name: sg_name.to_string(),
+        }]);
+
+        let trades = client
+            .trades_by_owner(owner.to_string(), None, None, None)
+            .await;
+        assert_eq!(trades.len(), 1);
+        assert_eq!(trades[0].trade.id, trade1.id);
+        assert_eq!(trades[0].subgraph_name, sg_name);
+    }
+
+    #[tokio::test]
+    async fn test_trades_by_owner_multiple_subgraphs_merge() {
+        let server1 = MockServer::start_async().await;
+        let sg1_url = Url::parse(&server1.url("")).unwrap();
+        let sg1_name = "sg_one";
+
+        let server2 = MockServer::start_async().await;
+        let sg2_url = Url::parse(&server2.url("")).unwrap();
+        let sg2_name = "sg_two";
+
+        let owner = "0xowner_multi";
+        let trade_s1 = default_sg_trade();
+        let trade_s2 = default_sg_trade();
+
+        server1.mock(|when, then| {
+            when.method(POST).path("/").body_contains(owner);
+            then.status(200)
+                .json_body(json!({"data": {"trades": [trade_s1]}}));
+        });
+        server1.mock(|when, then| {
+            when.method(POST).path("/").body_contains(owner);
+            then.status(200).json_body(json!({"data": {"trades": []}}));
+        });
+        server2.mock(|when, then| {
+            when.method(POST).path("/").body_contains(owner);
+            then.status(200)
+                .json_body(json!({"data": {"trades": [trade_s2]}}));
+        });
+        server2.mock(|when, then| {
+            when.method(POST).path("/").body_contains(owner);
+            then.status(200).json_body(json!({"data": {"trades": []}}));
+        });
+
+        let client = MultiOrderbookSubgraphClient::new(vec![
+            MultiSubgraphArgs {
+                url: sg1_url,
+                name: sg1_name.to_string(),
+            },
+            MultiSubgraphArgs {
+                url: sg2_url,
+                name: sg2_name.to_string(),
+            },
+        ]);
+
+        let trades = client
+            .trades_by_owner(owner.to_string(), None, None, None)
+            .await;
+        assert_eq!(trades.len(), 2);
+
+        let names: std::collections::HashSet<_> =
+            trades.iter().map(|t| t.subgraph_name.clone()).collect();
+        assert!(names.contains(sg1_name));
+        assert!(names.contains(sg2_name));
+    }
+
+    #[tokio::test]
+    async fn test_trades_by_owner_with_time_filters() {
+        let server = MockServer::start_async().await;
+        let sg_url = Url::parse(&server.url("")).unwrap();
+        let sg_name = "sg_time";
+        let owner = "0xowner_time";
+
+        let trade1 = default_sg_trade();
+        server.mock(|when, then| {
+            when.method(POST).path("/").body_contains(owner);
+            then.status(200)
+                .json_body(json!({"data": {"trades": [trade1]}}));
+        });
+        server.mock(|when, then| {
+            when.method(POST).path("/").body_contains(owner);
+            then.status(200).json_body(json!({"data": {"trades": []}}));
+        });
+
+        let client = MultiOrderbookSubgraphClient::new(vec![MultiSubgraphArgs {
+            url: sg_url,
+            name: sg_name.to_string(),
+        }]);
+
+        let trades = client
+            .trades_by_owner(owner.to_string(), Some(1000), Some(2000), None)
+            .await;
+        assert_eq!(trades.len(), 1);
+        assert_eq!(trades[0].trade.id, trade1.id);
+    }
+
+    #[tokio::test]
+    async fn test_trades_by_owner_with_orderbook_filter() {
+        let server = MockServer::start_async().await;
+        let sg_url = Url::parse(&server.url("")).unwrap();
+        let sg_name = "sg_ob_filter";
+        let owner = "0xowner_ob";
+        let orderbook_addr = "0x1234567890abcdef1234567890abcdef12345678";
+
+        let trade1 = default_sg_trade();
+        server.mock(|when, then| {
+            when.method(POST)
+                .path("/")
+                .body_contains(owner)
+                .body_contains(orderbook_addr);
+            then.status(200)
+                .json_body(json!({"data": {"trades": [trade1]}}));
+        });
+        server.mock(|when, then| {
+            when.method(POST)
+                .path("/")
+                .body_contains(owner)
+                .body_contains(orderbook_addr);
+            then.status(200).json_body(json!({"data": {"trades": []}}));
+        });
+
+        let client = MultiOrderbookSubgraphClient::new(vec![MultiSubgraphArgs {
+            url: sg_url,
+            name: sg_name.to_string(),
+        }]);
+
+        let trades = client
+            .trades_by_owner(
+                owner.to_string(),
+                None,
+                None,
+                Some(vec![orderbook_addr.to_string()]),
+            )
+            .await;
+        assert_eq!(trades.len(), 1);
+        assert_eq!(trades[0].trade.id, trade1.id);
+    }
+
+    #[tokio::test]
+    async fn test_trades_by_owner_one_subgraph_errors_others_succeed() {
+        let server1 = MockServer::start_async().await;
+        let sg1_url = Url::parse(&server1.url("")).unwrap();
+        let sg1_name = "sg_one_ok";
+
+        let server2 = MockServer::start_async().await;
+        let sg2_url = Url::parse(&server2.url("")).unwrap();
+        let sg2_name = "sg_two_error";
+
+        let owner = "0xowner_partial";
+        let trade_s1 = default_sg_trade();
+        server1.mock(|when, then| {
+            when.method(POST).path("/");
+            then.status(200)
+                .json_body(json!({"data": {"trades": [trade_s1]}}));
+        });
+        server1.mock(|when, then| {
+            when.method(POST).path("/");
+            then.status(200).json_body(json!({"data": {"trades": []}}));
+        });
+        server2.mock(|when, then| {
+            when.method(POST).path("/");
+            then.status(500);
+        });
+
+        let client = MultiOrderbookSubgraphClient::new(vec![
+            MultiSubgraphArgs {
+                url: sg1_url,
+                name: sg1_name.to_string(),
+            },
+            MultiSubgraphArgs {
+                url: sg2_url,
+                name: sg2_name.to_string(),
+            },
+        ]);
+        let trades = client
+            .trades_by_owner(owner.to_string(), None, None, None)
+            .await;
+        assert_eq!(trades.len(), 1);
+        assert_eq!(trades[0].trade.id, trade_s1.id);
+        assert_eq!(trades[0].subgraph_name, sg1_name);
+    }
+
+    #[tokio::test]
+    async fn test_trades_by_owner_all_subgraphs_error() {
+        let server1 = MockServer::start_async().await;
+        let sg1_url = Url::parse(&server1.url("")).unwrap();
+
+        let server2 = MockServer::start_async().await;
+        let sg2_url = Url::parse(&server2.url("")).unwrap();
+
+        server1.mock(|when, then| {
+            when.method(POST).path("/");
+            then.status(500);
+        });
+        server2.mock(|when, then| {
+            when.method(POST).path("/");
+            then.status(500);
+        });
+
+        let client = MultiOrderbookSubgraphClient::new(vec![
+            MultiSubgraphArgs {
+                url: sg1_url,
+                name: "sg_one_err".to_string(),
+            },
+            MultiSubgraphArgs {
+                url: sg2_url,
+                name: "sg_two_err".to_string(),
+            },
+        ]);
+        let trades = client
+            .trades_by_owner("0xowner_all_err".to_string(), None, None, None)
+            .await;
+        assert!(trades.is_empty());
+    }
 }

--- a/crates/subgraph/src/multi_orderbook_client.rs
+++ b/crates/subgraph/src/multi_orderbook_client.rs
@@ -201,6 +201,42 @@ impl MultiOrderbookSubgraphClient {
         Ok(all_trades)
     }
 
+    pub async fn trades_by_owner(
+        &self,
+        owner: String,
+        start_timestamp: Option<u64>,
+        end_timestamp: Option<u64>,
+        orderbook_in: Option<Vec<String>>,
+    ) -> Vec<SgTradeWithSubgraphName> {
+        let futures = self.subgraphs.iter().map(|subgraph| {
+            let url = subgraph.url.clone();
+            let owner = owner.clone();
+            let orderbook_in = orderbook_in.clone();
+            async move {
+                let client = self.get_orderbook_subgraph_client(url);
+                let trades = client
+                    .trades_by_owner_all(owner, start_timestamp, end_timestamp, orderbook_in)
+                    .await?;
+                let wrapped_trades: Vec<SgTradeWithSubgraphName> = trades
+                    .into_iter()
+                    .map(|trade| SgTradeWithSubgraphName {
+                        trade,
+                        subgraph_name: subgraph.name.clone(),
+                    })
+                    .collect();
+                Ok::<_, OrderbookSubgraphClientError>(wrapped_trades)
+            }
+        });
+
+        let results = join_all(futures).await;
+
+        results
+            .into_iter()
+            .filter_map(Result::ok)
+            .flatten()
+            .collect()
+    }
+
     pub async fn tokens_list(
         &self,
     ) -> Result<Vec<SgErc20WithSubgraphName>, OrderbookSubgraphClientError> {

--- a/crates/subgraph/src/orderbook_client/mod.rs
+++ b/crates/subgraph/src/orderbook_client/mod.rs
@@ -7,7 +7,8 @@ use crate::types::order::{
     SgOrderDetailByHashQueryVariables, SgOrderDetailByIdQuery, SgOrderIdList, SgOrdersListQuery,
 };
 use crate::types::order_trade::{
-    SgOrderTradeDetailQuery, SgOrderTradesListQuery, SgTransactionTradesQuery,
+    SgOrderTradeDetailQuery, SgOrderTradesListQuery, SgOwnerTradesListQuery,
+    SgTransactionTradesQuery,
 };
 use crate::types::remove_order::{
     SgTransactionRemoveOrdersQuery, TransactionRemoveOrdersVariables,

--- a/crates/subgraph/src/orderbook_client/order_trade.rs
+++ b/crates/subgraph/src/orderbook_client/order_trade.rs
@@ -85,6 +85,70 @@ impl OrderbookSubgraphClient {
         Ok(all_trades)
     }
 
+    pub async fn trades_by_owner(
+        &self,
+        owner: String,
+        start_timestamp: Option<u64>,
+        end_timestamp: Option<u64>,
+        orderbook_in: Option<Vec<String>>,
+        pagination_args: SgPaginationArgs,
+    ) -> Result<Vec<SgTrade>, OrderbookSubgraphClientError> {
+        let pagination_variables = Self::parse_pagination_args(pagination_args);
+        let data = self
+            .query::<SgOwnerTradesListQuery, SgOwnerTradesQueryVariables>(
+                SgOwnerTradesQueryVariables {
+                    owner: SgBytes(owner),
+                    first: pagination_variables.first,
+                    skip: pagination_variables.skip,
+                    timestamp_gte: Some(
+                        start_timestamp
+                            .map_or(SgBigInt("0".to_string()), |v| SgBigInt(v.to_string())),
+                    ),
+                    timestamp_lte: Some(
+                        end_timestamp
+                            .map_or(SgBigInt(u64::MAX.to_string()), |v| SgBigInt(v.to_string())),
+                    ),
+                    orderbook_in,
+                },
+            )
+            .await?;
+
+        Ok(data.trades)
+    }
+
+    pub async fn trades_by_owner_all(
+        &self,
+        owner: String,
+        start_timestamp: Option<u64>,
+        end_timestamp: Option<u64>,
+        orderbook_in: Option<Vec<String>>,
+    ) -> Result<Vec<SgTrade>, OrderbookSubgraphClientError> {
+        let mut all_trades = vec![];
+        let mut page = 1;
+
+        loop {
+            let page_data = self
+                .trades_by_owner(
+                    owner.clone(),
+                    start_timestamp,
+                    end_timestamp,
+                    orderbook_in.clone(),
+                    SgPaginationArgs {
+                        page,
+                        page_size: ALL_PAGES_QUERY_PAGE_SIZE,
+                    },
+                )
+                .await?;
+            let page_len = page_data.len();
+            all_trades.extend(page_data);
+            if page_len < ALL_PAGES_QUERY_PAGE_SIZE as usize {
+                break;
+            }
+            page += 1;
+        }
+        Ok(all_trades)
+    }
+
     /// Fetch all pages of order_takes_list query
     pub async fn order_trades_list_all(
         &self,
@@ -705,6 +769,148 @@ mod tests {
         });
 
         let result = client.order_trades_list_all(order_id, None, None).await;
+        assert!(matches!(
+            result,
+            Err(OrderbookSubgraphClientError::CynicClientError(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_trades_by_owner_found() {
+        let sg_server = MockServer::start_async().await;
+        let client = setup_client(&sg_server);
+        let owner = "0xowner_abc123".to_string();
+        let expected_trades = vec![default_sg_trade(), default_sg_trade()];
+        let pagination_args = SgPaginationArgs {
+            page: 1,
+            page_size: 10,
+        };
+
+        sg_server.mock(|when, then| {
+            when.method(POST).path("/");
+            then.status(200)
+                .json_body(json!({"data": {"trades": expected_trades}}));
+        });
+
+        let result = client
+            .trades_by_owner(owner, None, None, None, pagination_args)
+            .await;
+        assert!(result.is_ok());
+        let trades = result.unwrap();
+        assert_eq!(trades.len(), expected_trades.len());
+        for (actual, expected) in trades.iter().zip(expected_trades.iter()) {
+            assert_sg_trade_eq(actual, expected);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_trades_by_owner_empty() {
+        let sg_server = MockServer::start_async().await;
+        let client = setup_client(&sg_server);
+        let owner = "0xowner_empty".to_string();
+        let pagination_args = SgPaginationArgs {
+            page: 1,
+            page_size: 10,
+        };
+
+        sg_server.mock(|when, then| {
+            when.method(POST).path("/");
+            then.status(200).json_body(json!({"data": {"trades": []}}));
+        });
+
+        let result = client
+            .trades_by_owner(owner, None, None, None, pagination_args)
+            .await;
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_trades_by_owner_with_orderbook_filter() {
+        let sg_server = MockServer::start_async().await;
+        let client = setup_client(&sg_server);
+        let owner = "0xowner_filtered".to_string();
+        let orderbook = "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef".to_string();
+        let pagination_args = SgPaginationArgs {
+            page: 1,
+            page_size: 10,
+        };
+
+        sg_server.mock(|when, then| {
+            when.method(POST)
+                .path("/")
+                .body_contains(format!("\"orderbookIn\":[\"{}\"]", orderbook));
+            then.status(200).json_body(json!({"data": {"trades": []}}));
+        });
+
+        let result = client
+            .trades_by_owner(owner, None, None, Some(vec![orderbook]), pagination_args)
+            .await;
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_trades_by_owner_all_multiple_pages() {
+        let sg_server = MockServer::start_async().await;
+        let client = setup_client(&sg_server);
+        let owner = "0xowner_multi_page".to_string();
+        let trades_page1: Vec<SgTrade> = (0..ALL_PAGES_QUERY_PAGE_SIZE)
+            .map(|_| default_sg_trade())
+            .collect();
+        let trades_page2: Vec<SgTrade> = (0..50).map(|_| default_sg_trade()).collect();
+
+        sg_server.mock(|when, then| {
+            when.method(POST)
+                .path("/")
+                .body_contains(format!("\"first\":{}", ALL_PAGES_QUERY_PAGE_SIZE))
+                .body_contains("\"skip\":0");
+            then.status(200)
+                .json_body(json!({"data": {"trades": trades_page1}}));
+        });
+        sg_server.mock(|when, then| {
+            when.method(POST)
+                .path("/")
+                .body_contains(format!("\"first\":{}", ALL_PAGES_QUERY_PAGE_SIZE))
+                .body_contains(format!("\"skip\":{}", ALL_PAGES_QUERY_PAGE_SIZE));
+            then.status(200)
+                .json_body(json!({"data": {"trades": trades_page2}}));
+        });
+        sg_server.mock(|when, then| {
+            when.method(POST)
+                .path("/")
+                .body_contains(format!("\"first\":{}", ALL_PAGES_QUERY_PAGE_SIZE))
+                .body_contains(format!("\"skip\":{}", ALL_PAGES_QUERY_PAGE_SIZE * 2));
+            then.status(200).json_body(json!({"data": {"trades": []}}));
+        });
+
+        let result = client.trades_by_owner_all(owner, None, None, None).await;
+        assert!(result.is_ok());
+        let trades = result.unwrap();
+        assert_eq!(
+            trades.len(),
+            ALL_PAGES_QUERY_PAGE_SIZE as usize + trades_page2.len()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_trades_by_owner_network_error() {
+        let sg_server = MockServer::start_async().await;
+        let client = setup_client(&sg_server);
+        let owner = "0xowner_error".to_string();
+        let pagination_args = SgPaginationArgs {
+            page: 1,
+            page_size: 10,
+        };
+
+        sg_server.mock(|when, then| {
+            when.method(POST).path("/");
+            then.status(500);
+        });
+
+        let result = client
+            .trades_by_owner(owner, None, None, None, pagination_args)
+            .await;
         assert!(matches!(
             result,
             Err(OrderbookSubgraphClientError::CynicClientError(_))

--- a/crates/subgraph/src/types/common.rs
+++ b/crates/subgraph/src/types/common.rs
@@ -114,6 +114,21 @@ pub struct SgPaginationWithTxIdQueryVariables {
     pub orderbook_in: Option<Vec<String>>,
 }
 
+#[derive(cynic::QueryVariables, Debug, Clone, Tsify)]
+pub struct SgOwnerTradesQueryVariables {
+    #[cfg_attr(target_family = "wasm", tsify(optional))]
+    pub first: Option<i32>,
+    #[cfg_attr(target_family = "wasm", tsify(optional))]
+    pub skip: Option<i32>,
+    pub owner: SgBytes,
+    #[cfg_attr(target_family = "wasm", tsify(optional))]
+    pub timestamp_gte: Option<SgBigInt>,
+    #[cfg_attr(target_family = "wasm", tsify(optional))]
+    pub timestamp_lte: Option<SgBigInt>,
+    #[cfg_attr(target_family = "wasm", tsify(optional))]
+    pub orderbook_in: Option<Vec<String>>,
+}
+
 #[derive(cynic::QueryFragment, Debug, Serialize, Clone, Tsify)]
 #[cynic(graphql_type = "Orderbook")]
 pub struct SgOrderbook {

--- a/crates/subgraph/src/types/order_trade.rs
+++ b/crates/subgraph/src/types/order_trade.rs
@@ -35,6 +35,25 @@ pub struct SgOrderTradeDetailQuery {
 }
 
 #[derive(cynic::QueryFragment, Debug, Clone, Serialize)]
+#[cynic(graphql_type = "Query", variables = "SgOwnerTradesQueryVariables")]
+#[cfg_attr(target_family = "wasm", derive(Tsify))]
+pub struct SgOwnerTradesListQuery {
+    #[arguments(
+        skip: $skip,
+        first: $first,
+        orderBy: "timestamp",
+        orderDirection: "desc",
+        where: {
+            order_: { owner: $owner },
+            timestamp_gte: $timestamp_gte,
+            timestamp_lte: $timestamp_lte,
+            orderbook_in: $orderbook_in
+        }
+    )]
+    pub trades: Vec<SgTrade>,
+}
+
+#[derive(cynic::QueryFragment, Debug, Clone, Serialize)]
 #[cynic(
     graphql_type = "Query",
     variables = "SgPaginationWithTxIdQueryVariables"


### PR DESCRIPTION
## Chained PRs
- https://github.com/rainlanguage/rain.orderbook/pull/2497

## Motivation

The parent PR added improved trade structs and trades-by-transaction support. This PR extends the trades API to support fetching trades by owner address, enabling the frontend to display all trades for a given wallet across all orderbooks and chains.

## Solution

- **Refactor trades module**: Split `trades.rs` into a `trades/` directory with `mod.rs`, `get_by_tx.rs`, and `get_by_owner.rs` for better code organization
- **Local DB queries**: Add `fetch_owner_trades` and `fetch_owner_trades_count` SQL query modules that filter trades by owner address, with support for chain ID, orderbook, time range, and pagination filters
- **Subgraph queries**: Add `SgOwnerTradesQueryVariables` and `SgOwnerTradesListQuery` types, plus `trades_by_owner` / `trades_by_owner_all` methods on both single and multi-orderbook subgraph clients
- **RaindexClient API**: Add `get_trades_for_owner` using the `classify_chains` pattern to query both local DB and subgraph sources, merge results, and return `RaindexTradesListResult` with total count and optional pair summary
- **Tests**: Comprehensive test coverage including SQL builder unit tests, subgraph client tests, multi-client tests, and RaindexClient-level integration tests for both wasm and non-wasm targets

## Checks

By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fetch trades by owner with chain, orderbook and timestamp filters (supports pagination).
  * Fetch trades by transaction hash with optional filters.
  * Combined local DB + subgraph aggregation for fuller trade results.
  * New typed API inputs: ChainIds, TimeFilter, PaginationParams for wasm/TS.

* **Bug Fixes / Behavior**
  * Timestamp range validation (invalid ranges rejected).
  * Summary omitted when pagination is used; total_count available when paginating.

* **Tests**
  * Added tests for filters, pagination, counts, and multi-source aggregation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->