### PR TITLE
Update repository metadata for raindex rename

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 edition = "2021"
 license = "LicenseRef-DCL-1.0"
 version = "0.0.0-alpha.0"
-homepage = "https://github.com/rainprotocol/rain.orderbook"
+homepage = "https://github.com/rainlanguage/raindex"
 
 [workspace.dependencies]
 foundry-block-explorers = "0.2.6"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# rain.orderbook
+# raindex
 
 Rain Orderbook (also known as Raindex) is an open source, permissionless orderbook system with no fees or admin keys.
 

--- a/package.json
+++ b/package.json
@@ -5,13 +5,13 @@
     "private": true,
     "repository": {
         "type": "git",
-        "url": "https://github.com/rainlanguage/rain.orderbook.git"
+        "url": "https://github.com/rainlanguage/raindex.git"
     },
     "keywords": [],
     "bugs": {
-        "url": "https://github.com/rainlanguage/rain.orderbook/issues"
+        "url": "https://github.com/rainlanguage/raindex/issues"
     },
-    "homepage": "https://github.com/rainlanguage/rain.orderbook#readme",
+    "homepage": "https://github.com/rainlanguage/raindex#readme",
     "engines": {
         "node": ">=18"
     },

--- a/packages/orderbook/README.md
+++ b/packages/orderbook/README.md
@@ -752,4 +752,4 @@ console.log(result.value);
 
 ## Contributing
 
-This SDK is part of the Rain Language ecosystem. For contributions and issues, please visit the [GitHub repository](https://github.com/rainlanguage/rain.orderbook).
+This SDK is part of the Rain Language ecosystem. For contributions and issues, please visit the [GitHub repository](https://github.com/rainlanguage/raindex).

--- a/packages/orderbook/package.json
+++ b/packages/orderbook/package.json
@@ -6,13 +6,13 @@
     "author": "Rain Open Source Software Ltd",
     "repository": {
         "type": "git",
-        "url": "https://github.com/rainlanguage/rain.orderbook.git"
+        "url": "https://github.com/rainlanguage/raindex.git"
     },
     "keywords": [],
     "bugs": {
-        "url": "https://github.com/rainlanguage/rain.orderbook/issues"
+        "url": "https://github.com/rainlanguage/raindex/issues"
     },
-    "homepage": "https://github.com/rainlanguage/rain.orderbook#readme",
+    "homepage": "https://github.com/rainlanguage/raindex#readme",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.js",
     "browser": {

--- a/packages/orderbook/typedoc.json
+++ b/packages/orderbook/typedoc.json
@@ -14,7 +14,7 @@
   "hideGenerator": true,
   "theme": "default",
   "navigationLinks": {
-    "GitHub": "https://github.com/rainlanguage/rain.orderbook",
+    "GitHub": "https://github.com/rainlanguage/raindex",
     "NPM": "https://www.npmjs.com/package/@rainlanguage/orderbook"
   },
   "kindSortOrder": [

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -6,7 +6,7 @@
 	"author": "Rain Open Source Software Ltd",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/rainlanguage/rain.orderbook.git"
+		"url": "https://github.com/rainlanguage/raindex.git"
 	},
 	"main": "dist/index.js",
 	"module": "dist/index.js",


### PR DESCRIPTION
## Motivation

The repository was renamed from `rain.orderbook` to `raindex`, but several metadata fields still pointed at the old GitHub repository.

This breaks the npm release workflow because it verifies that the Git remote matches the `repository.url` in the published package manifests before attempting OIDC publish.

## Solution

- Updated root `package.json` repository metadata:
  - `repository.url`
  - `bugs.url`
  - `homepage`
- Updated `packages/orderbook/package.json` repository metadata:
  - `repository.url`
  - `bugs.url`
  - `homepage`
- Updated `packages/ui-components/package.json` `repository.url`
- Updated `packages/orderbook/typedoc.json` GitHub navigation link
- Updated `packages/orderbook/README.md` contributing link to the renamed repository
- Updated root `README.md` heading from `rain.orderbook` to `raindex`
- Updated workspace `Cargo.toml` homepage URL from the old repository to `https://github.com/rainlanguage/raindex`

Closes RAI-192.

## Checks

By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [ ] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)

Note: I did not run builds, tests, Cargo commands, or module initialization in this workspace per the local constraints.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project name and repository references across documentation and configuration files to align with new project location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->