### PR TITLE
feat: SignedContextInjector trait for caller-supplied signed contexts

### DIFF
--- a/crates/common/src/raindex_client/mod.rs
+++ b/crates/common/src/raindex_client/mod.rs
@@ -462,6 +462,8 @@ pub enum RaindexError {
     QuoteDataMissing,
     #[error("Invalid input index: {0}")]
     InvalidInputIndex(u32),
+    #[error("Invalid output index: {0}")]
+    InvalidOutputIndex(u32),
     #[error("Cannot parse metadata: {0}")]
     ParseMetaError(#[from] rain_metadata::Error),
     #[error("No metaboards configured for any chain")]
@@ -654,6 +656,12 @@ impl RaindexError {
             RaindexError::InvalidInputIndex(index) => {
                 format!(
                     "Invalid input index: {}. The order does not have an input at this index.",
+                    index
+                )
+            }
+            RaindexError::InvalidOutputIndex(index) => {
+                format!(
+                    "Invalid output index: {}. The order does not have an output at this index.",
                     index
                 )
             }

--- a/crates/common/src/raindex_client/order_quotes.rs
+++ b/crates/common/src/raindex_client/order_quotes.rs
@@ -1,9 +1,13 @@
 use super::*;
 use crate::raindex_client::orders::RaindexOrder;
 use crate::raindex_client::orders_list::RaindexOrders;
+use alloy::primitives::Address;
 use rain_math_float::Float;
-use rain_orderbook_bindings::IRaindexV6::OrderV4;
-use rain_orderbook_quote::{get_order_quotes, BatchOrderQuotesResponse, OrderQuoteValue, Pair};
+use rain_orderbook_bindings::IRaindexV6::{OrderV4, SignedContextV1};
+use rain_orderbook_quote::{
+    get_order_quotes, BatchOrderQuotesResponse, NoopInjector, OrderQuoteValue, Pair,
+    SignedContextInjector,
+};
 use rain_orderbook_subgraph_client::utils::float::{F0, F1};
 use std::ops::{Div, Mul};
 
@@ -17,6 +21,12 @@ pub struct RaindexOrderQuote {
     pub success: bool,
     #[tsify(optional)]
     pub error: Option<String>,
+    /// Composed signed context that was attached to the quote RPC: oracle
+    /// entries first, then any injector-contributed entries. Propagated so
+    /// the candidate builder can reuse the same context the quote saw.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[tsify(optional)]
+    pub signed_context: Vec<SignedContextV1>,
 }
 impl_wasm_traits!(RaindexOrderQuote);
 impl RaindexOrderQuote {
@@ -32,6 +42,7 @@ impl RaindexOrderQuote {
                 .transpose()?,
             success: value.success,
             error: value.error,
+            signed_context: value.signed_context,
         })
     }
 }
@@ -129,6 +140,44 @@ impl RaindexOrder {
             block_number,
             rpcs.iter().map(|s| s.to_string()).collect(),
             chunk_size.map(|v| v as usize),
+            Address::ZERO,
+            &NoopInjector,
+        )
+        .await?;
+
+        let mut result_order_quotes = vec![];
+        for order_quote in order_quotes {
+            let data = RaindexOrderQuote::try_from_batch_order_quotes_response(order_quote)?;
+            result_order_quotes.push(data);
+        }
+        Ok(result_order_quotes)
+    }
+}
+
+impl RaindexOrder {
+    /// Non-wasm variant of [`Self::get_quotes`] that threads a `counterparty`
+    /// address and a caller-supplied [`SignedContextInjector`] through to the
+    /// quote RPC. Used by single-take flows that need to populate signed
+    /// context for gated orders whose `calculate-io` asserts on `signer<0>()`
+    /// or similar. The resulting `RaindexOrderQuote.signed_context` carries
+    /// the composed `[oracle..., injected...]` list that the multicall saw.
+    pub async fn get_quotes_with_injector(
+        &self,
+        block_number: Option<u64>,
+        chunk_size: Option<u32>,
+        counterparty: Address,
+        injector: &dyn SignedContextInjector,
+    ) -> Result<Vec<RaindexOrderQuote>, RaindexError> {
+        let rpcs = self.get_rpc_urls()?;
+        let sg_order = self.clone().into_sg_order()?;
+
+        let order_quotes = get_order_quotes(
+            vec![sg_order],
+            block_number,
+            rpcs.iter().map(|s| s.to_string()).collect(),
+            chunk_size.map(|v| v as usize),
+            counterparty,
+            injector,
         )
         .await?;
 
@@ -195,6 +244,30 @@ pub async fn get_order_quotes_batch(
     block_number: Option<u64>,
     chunk_size: Option<u32>,
 ) -> Result<Vec<Vec<RaindexOrderQuote>>, RaindexError> {
+    get_order_quotes_batch_with_injector(
+        orders,
+        block_number,
+        chunk_size,
+        Address::ZERO,
+        &NoopInjector,
+    )
+    .await
+}
+
+/// Batch variant of [`get_order_quotes_batch`] that threads a
+/// `counterparty` address and a caller-supplied [`SignedContextInjector`]
+/// through to the quote RPC. Oracle-fetched contexts come first, followed by
+/// entries produced by the injector; the composed list is attached to each
+/// `QuoteV2.signedContext` before the multicall and is therefore visible to
+/// any `calculate-io` execution run during quoting (e.g. gated orders that
+/// assert on `signer<0>()`).
+pub async fn get_order_quotes_batch_with_injector(
+    orders: &[RaindexOrder],
+    block_number: Option<u64>,
+    chunk_size: Option<u32>,
+    counterparty: Address,
+    injector: &dyn SignedContextInjector,
+) -> Result<Vec<Vec<RaindexOrderQuote>>, RaindexError> {
     if orders.is_empty() {
         return Ok(vec![]);
     }
@@ -242,6 +315,8 @@ pub async fn get_order_quotes_batch(
         block_number,
         rpcs,
         chunk_size.map(|v| v as usize),
+        counterparty,
+        injector,
     )
     .await?;
 

--- a/crates/common/src/raindex_client/orders.rs
+++ b/crates/common/src/raindex_client/orders.rs
@@ -696,6 +696,10 @@ impl RaindexOrder {
         #[cfg(target_family = "wasm")]
         let sell_token = Address::from_str(&sell_token)?;
 
+        if (output_index as usize) >= self.outputs.len() {
+            return Err(RaindexError::InvalidOutputIndex(output_index));
+        }
+
         let rpc_urls = self.get_rpc_urls()?;
 
         let rpc_client = RpcClient::new_with_urls(rpc_urls.clone())?;
@@ -716,7 +720,6 @@ impl RaindexOrder {
             price_cap: parsed_price_cap,
             taker: taker_addr,
             sell_token,
-            oracle_url: self.oracle_url(),
         };
         let rpc_context = RpcContext {
             rpc_urls: &rpc_urls,
@@ -746,6 +749,86 @@ impl RaindexOrder {
         let amount_float = Float::parse(amount)?;
 
         estimate_take_order(data.max_output, data.ratio, is_buy, amount_float)
+    }
+}
+
+impl RaindexOrder {
+    /// Non-wasm variant of [`Self::get_take_calldata`] that threads a
+    /// caller-supplied [`SignedContextInjector`] through the quote pipeline.
+    ///
+    /// Mirrors the shape of [`RaindexClient::get_take_orders_calldata_with_injector`]:
+    /// any injector-contributed `SignedContextV1` entries are appended after
+    /// any oracle-fetched context on each `QuoteV2` before the quote multicall
+    /// (composition order: `[oracle..., injected...]`). The candidate inherits
+    /// that exact composed list, so `takeOrders4` executes with the same
+    /// signed context the quote saw — required for gated orders whose
+    /// `calculate-io` asserts on `signer<0>()` or similar.
+    ///
+    /// The injector is only needed at the quote stage; once the candidate is
+    /// built with the correct `signed_context`, [`execute_single_take`] is
+    /// sufficient without any injector parameter.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn get_take_calldata_with_injector(
+        &self,
+        input_index: u32,
+        output_index: u32,
+        taker: String,
+        mode: TakeOrdersMode,
+        amount: String,
+        price_cap: String,
+        injector: &dyn rain_orderbook_quote::SignedContextInjector,
+    ) -> Result<TakeOrdersCalldataResult, RaindexError> {
+        let taker_addr = Address::from_str(&taker)?;
+        let parsed_mode = ParsedTakeOrdersMode::parse(mode, &amount)?;
+        let parsed_price_cap = Float::parse(price_cap)?;
+
+        let zero = Float::zero()?;
+        if parsed_price_cap.lt(zero)? {
+            return Err(RaindexError::NegativePriceCap);
+        }
+
+        let sell_token = self
+            .inputs
+            .get(input_index as usize)
+            .ok_or(RaindexError::InvalidInputIndex(input_index))?
+            .token()
+            .address();
+        #[cfg(target_family = "wasm")]
+        let sell_token = Address::from_str(&sell_token)?;
+
+        if (output_index as usize) >= self.outputs.len() {
+            return Err(RaindexError::InvalidOutputIndex(output_index));
+        }
+
+        let rpc_urls = self.get_rpc_urls()?;
+
+        let rpc_client = RpcClient::new_with_urls(rpc_urls.clone())?;
+        let block_number = rpc_client.get_latest_block_number().await?;
+
+        let fresh_quotes = self
+            .get_quotes_with_injector(Some(block_number), None, taker_addr, injector)
+            .await?;
+
+        let fresh_quote = fresh_quotes
+            .into_iter()
+            .find(|q| q.pair.input_index == input_index && q.pair.output_index == output_index)
+            .ok_or(RaindexError::NoLiquidity)?;
+
+        let candidate =
+            build_candidate_from_quote(self, &fresh_quote)?.ok_or(RaindexError::NoLiquidity)?;
+
+        let execution_params = TakeOrderExecutionParams {
+            mode: parsed_mode,
+            price_cap: parsed_price_cap,
+            taker: taker_addr,
+            sell_token,
+        };
+        let rpc_context = RpcContext {
+            rpc_urls: &rpc_urls,
+            block_number: Some(block_number),
+        };
+
+        execute_single_take(candidate, execution_params, rpc_context).await
     }
 }
 
@@ -3380,6 +3463,7 @@ mod tests {
                 data: Some(make_test_quote_value()),
                 success: true,
                 error: None,
+                signed_context: vec![],
             }
         }
 
@@ -3425,6 +3509,7 @@ mod tests {
             let original_data = quote.data.expect("Original should have data");
             assert!(data.max_output.eq(original_data.max_output).unwrap());
             assert!(data.ratio.eq(original_data.ratio).unwrap());
+            assert!(roundtrip.signed_context.is_empty());
         }
 
         #[wasm_bindgen_test]
@@ -3439,6 +3524,7 @@ mod tests {
                 data: None,
                 success: false,
                 error: Some("Quote simulation failed".to_string()),
+                signed_context: vec![],
             };
 
             let js_value = to_js_value(&quote).expect("Should serialize failed quote to JS");
@@ -3449,6 +3535,7 @@ mod tests {
             assert!(!roundtrip.success);
             assert!(roundtrip.data.is_none());
             assert_eq!(roundtrip.error, Some("Quote simulation failed".to_string()));
+            assert!(roundtrip.signed_context.is_empty());
         }
 
         #[wasm_bindgen_test]

--- a/crates/common/src/raindex_client/take_orders/mod.rs
+++ b/crates/common/src/raindex_client/take_orders/mod.rs
@@ -18,6 +18,7 @@ use super::{RaindexClient, RaindexError};
 use crate::rpc_client::RpcClient;
 use crate::take_orders::{
     build_take_orders_config_from_simulation, find_failing_order_index, simulate_take_orders,
+    NoopInjector, SignedContextInjector,
 };
 use approval::{check_approval_needed, ApprovalCheckParams};
 use rain_orderbook_bindings::provider::mk_read_provider;
@@ -78,6 +79,21 @@ impl RaindexClient {
         )]
         request: TakeOrdersRequest,
     ) -> Result<TakeOrdersCalldataResult, RaindexError> {
+        self.get_take_orders_calldata_with_injector(request, &NoopInjector)
+            .await
+    }
+}
+
+impl RaindexClient {
+    /// Non-wasm variant of [`Self::get_take_orders_calldata`] that accepts a
+    /// caller-supplied [`SignedContextInjector`]. The injector contributes
+    /// additional `SignedContextV1` entries appended after any oracle-fetched
+    /// contexts for each candidate (composition order: `[oracle..., injected...]`).
+    pub async fn get_take_orders_calldata_with_injector(
+        &self,
+        request: TakeOrdersRequest,
+        injector: &dyn SignedContextInjector,
+    ) -> Result<TakeOrdersCalldataResult, RaindexError> {
         let req = request::parse_request(&request)?;
 
         let orders = self
@@ -94,6 +110,8 @@ impl RaindexClient {
             req.buy_token,
             Some(block_number),
             None,
+            req.taker,
+            injector,
         )
         .await?;
 

--- a/crates/common/src/raindex_client/take_orders/selection.rs
+++ b/crates/common/src/raindex_client/take_orders/selection.rs
@@ -2,7 +2,8 @@ use crate::raindex_client::orders::RaindexOrder;
 use crate::raindex_client::RaindexError;
 use crate::take_orders::{
     build_take_order_candidates_for_pair, simulate_buy_over_candidates,
-    simulate_spend_over_candidates, ParsedTakeOrdersMode, SimulationResult, TakeOrderCandidate,
+    simulate_spend_over_candidates, ParsedTakeOrdersMode, SignedContextInjector, SimulationResult,
+    TakeOrderCandidate,
 };
 use crate::utils::float::cmp_float;
 use alloy::primitives::Address;
@@ -15,6 +16,8 @@ pub(crate) async fn build_candidates_for_chain(
     buy_token: Address,
     block_number: Option<u64>,
     chunk_size: Option<u32>,
+    counterparty: Address,
+    injector: &dyn SignedContextInjector,
 ) -> Result<Vec<TakeOrderCandidate>, RaindexError> {
     let candidates = build_take_order_candidates_for_pair(
         orders,
@@ -22,6 +25,8 @@ pub(crate) async fn build_candidates_for_chain(
         buy_token,
         block_number,
         chunk_size,
+        counterparty,
+        injector,
     )
     .await?;
     if candidates.is_empty() {

--- a/crates/common/src/raindex_client/take_orders/single.rs
+++ b/crates/common/src/raindex_client/take_orders/single.rs
@@ -25,7 +25,6 @@ pub struct TakeOrderExecutionParams {
     pub price_cap: Float,
     pub taker: Address,
     pub sell_token: Address,
-    pub oracle_url: Option<String>,
 }
 
 /// RPC context for blockchain interactions.
@@ -71,7 +70,12 @@ pub fn build_candidate_from_quote(
         output_io_index,
         max_output: data.max_output,
         ratio: data.ratio,
-        signed_context: vec![],
+        // Inherit the composed signed context that the quote pipeline
+        // attached (oracle entries first, then any injector-contributed
+        // entries). Dropping it here was a regression: gated orders whose
+        // `calculate-io` asserted on signed context during quoting would
+        // then be executed without the same context at `takeOrders4` time.
+        signed_context: quote.signed_context.clone(),
     }))
 }
 
@@ -146,24 +150,9 @@ pub async fn execute_single_take(
         return Ok(approval_result);
     }
 
-    // Fetch signed context from oracle after early exits (price-cap, approval)
-    // to avoid unnecessary network calls for orders that won't be taken.
-    let mut candidate = candidate;
-    if let Some(url) = execution_params.oracle_url {
-        let body = crate::oracle::encode_oracle_body(
-            &candidate.order,
-            candidate.input_io_index,
-            candidate.output_io_index,
-            execution_params.taker,
-        );
-        match crate::oracle::fetch_signed_context(&url, body).await {
-            Ok(ctx) => candidate.signed_context = vec![ctx],
-            Err(e) => {
-                tracing::warn!("Failed to fetch oracle data: {}", e);
-            }
-        }
-    }
-
+    // Signed context (oracle + injector) is already attached to the
+    // candidate by `build_candidate_from_quote`, which inherits it from
+    // the quote. No extra fetch is needed at execute time.
     let target = execution_params.mode.target_amount();
     let is_buy_mode = execution_params.mode.is_buy_mode();
 
@@ -297,6 +286,7 @@ mod tests {
             block_number: 1,
             data,
             success,
+            signed_context: vec![],
             error: if success {
                 None
             } else {
@@ -648,6 +638,143 @@ mod tests {
             assert!(
                 result.is_none(),
                 "Quote with zero capacity should return None"
+            );
+        });
+    }
+
+    /// Regression: a quote whose `signed_context` is populated (as produced
+    /// by the injector-aware quote pipeline) must propagate that context into
+    /// the candidate verbatim. Dropping it here previously caused gated
+    /// single-takes to execute `takeOrders4` without the context that
+    /// `calculate-io` saw at quote time.
+    #[test]
+    fn test_build_candidate_inherits_signed_context_from_quote() {
+        use crate::local_db::OrderbookIdentifier;
+        use crate::raindex_client::tests::{get_test_yaml, CHAIN_ID_1_ORDERBOOK_ADDRESS};
+        use alloy::primitives::{b256, Address, Bytes, FixedBytes, U256};
+        use httpmock::MockServer;
+        use rain_orderbook_bindings::IRaindexV6::SignedContextV1;
+        use rain_orderbook_subgraph_client::utils::float::F1;
+        use serde_json::json;
+        use std::str::FromStr;
+
+        let max_output = Float::parse("100".to_string()).unwrap();
+        let ratio = Float::parse("1".to_string()).unwrap();
+
+        let oracle_entry = SignedContextV1 {
+            signer: Address::from([0xAAu8; 20]),
+            context: vec![FixedBytes::<32>::from(U256::from(1u64).to_be_bytes::<32>())],
+            signature: Bytes::from(vec![0x01]),
+        };
+        let injected_entry = SignedContextV1 {
+            signer: Address::from([0xBBu8; 20]),
+            context: vec![FixedBytes::<32>::from(U256::from(2u64).to_be_bytes::<32>())],
+            signature: Bytes::from(vec![0x02]),
+        };
+
+        let mut quote = make_quote(0, 0, Some(make_quote_value(max_output, ratio)), true);
+        quote.signed_context = vec![oracle_entry.clone(), injected_entry.clone()];
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let server = MockServer::start_async().await;
+            server.mock(|when, then| {
+                when.path("/sg");
+                then.status(200).json_body_obj(&json!({
+                    "data": {
+                        "orders": [{
+                            "id": "0x46891c626a8a188610b902ee4a0ce8a7e81915e1b922584f8168d14525899dfb",
+                            "orderBytes": "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000005f6c104ca9812ef91fe2e26a2e7187b92d3b0e800000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000001a0000000000000000000000000000000000000000000000000000000000000022009cd210f509c66e18fab61fd30f76fb17c6c6cd09f0972ce0815b5b7630a1b050000000000000000000000005fb33d710f8b58de4c9fdec703b5c2487a5219d600000000000000000000000084c6e7f5a1e5dd89594cc25bef4722a1b8871ae600000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000075000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000015020000000c02020002011000000110000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000000000001d80c49bbbcd1c0911346656b529df9e5c2f783d0000000000000000000000000000000000000000000000000000000000000012f5bb1bfe104d351d99dcce1ccfb041ff244a2d3aaf83bd5c4f3fe20b3fceb372000000000000000000000000000000000000000000000000000000000000000100000000000000000000000012e605bc104e93b45e1ad99f9e555f659051c2bb0000000000000000000000000000000000000000000000000000000000000012f5bb1bfe104d351d99dcce1ccfb041ff244a2d3aaf83bd5c4f3fe20b3fceb372",
+                            "orderHash": "0x283508c8f56f4de2f21ee91749d64ec3948c16bc6b4bfe4f8d11e4e67d76f4e0",
+                            "owner": "0x0000000000000000000000000000000000000000",
+                            "outputs": [{
+                                "id": "0x0000000000000000000000000000000000000000",
+                                "owner": "0xf08bcbce72f62c95dcb7c07dcb5ed26acfcfbc11",
+                                "vaultId": "75486334982066122983501547829219246999490818941767825330875804445439814023987",
+                                "balance": F1,
+                                "token": {
+                                    "id": "0x12e605bc104e93b45e1ad99f9e555f659051c2bb",
+                                    "address": "0x12e605bc104e93b45e1ad99f9e555f659051c2bb",
+                                    "name": "sFLR",
+                                    "symbol": "sFLR",
+                                    "decimals": "18"
+                                },
+                                "orderbook": { "id": CHAIN_ID_1_ORDERBOOK_ADDRESS },
+                                "ordersAsOutput": [],
+                                "ordersAsInput": [],
+                                "balanceChanges": []
+                            }],
+                            "inputs": [{
+                                "id": "0x0000000000000000000000000000000000000000",
+                                "owner": "0xf08bcbce72f62c95dcb7c07dcb5ed26acfcfbc11",
+                                "vaultId": "75486334982066122983501547829219246999490818941767825330875804445439814023987",
+                                "balance": F1,
+                                "token": {
+                                    "id": "0x1d80c49bbbcd1c0911346656b529df9e5c2f783d",
+                                    "address": "0x1d80c49bbbcd1c0911346656b529df9e5c2f783d",
+                                    "name": "WFLR",
+                                    "symbol": "WFLR",
+                                    "decimals": "18"
+                                },
+                                "orderbook": { "id": CHAIN_ID_1_ORDERBOOK_ADDRESS },
+                                "ordersAsOutput": [],
+                                "ordersAsInput": [],
+                                "balanceChanges": []
+                            }],
+                            "orderbook": { "id": CHAIN_ID_1_ORDERBOOK_ADDRESS },
+                            "active": true,
+                            "timestampAdded": "1739448802",
+                            "meta": null,
+                            "addEvents": [],
+                            "trades": [],
+                            "removeEvents": []
+                        }]
+                    }
+                }));
+            });
+
+            let raindex_client = crate::raindex_client::RaindexClient::new(
+                vec![get_test_yaml(
+                    &server.url("/sg"),
+                    "http://localhost:3000",
+                    "http://localhost:3000",
+                    "http://localhost:3000",
+                )],
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+            let order = raindex_client
+                .get_order_by_hash(
+                    &OrderbookIdentifier::new(
+                        1,
+                        Address::from_str(CHAIN_ID_1_ORDERBOOK_ADDRESS).unwrap(),
+                    ),
+                    b256!("0x0000000000000000000000000000000000000000000000000000000000000123"),
+                )
+                .await
+                .unwrap();
+
+            let candidate = build_candidate_from_quote(&order, &quote)
+                .unwrap()
+                .expect("candidate should be built");
+
+            assert_eq!(
+                candidate.signed_context.len(),
+                2,
+                "candidate must inherit both oracle and injected context entries"
+            );
+            assert_eq!(candidate.signed_context[0].signer, oracle_entry.signer);
+            assert_eq!(candidate.signed_context[1].signer, injected_entry.signer);
+            assert_eq!(
+                candidate.signed_context[0].signature,
+                oracle_entry.signature
+            );
+            assert_eq!(
+                candidate.signed_context[1].signature,
+                injected_entry.signature
             );
         });
     }

--- a/crates/common/src/raindex_client/take_orders/single_tests.rs
+++ b/crates/common/src/raindex_client/take_orders/single_tests.rs
@@ -132,7 +132,7 @@ async fn test_single_order_take_happy_path_buy_up_to() {
     let price_cap = Float::parse(high_price_cap()).unwrap();
     let rpc_urls = vec![url::Url::parse(&setup.local_evm.url()).unwrap()];
 
-    let execution_params = create_execution_params(mode, price_cap, taker, setup.token1, None);
+    let execution_params = create_execution_params(mode, price_cap, taker, setup.token1);
     let rpc_context = RpcContext {
         rpc_urls: &rpc_urls,
         block_number: None,
@@ -239,7 +239,7 @@ async fn test_single_order_take_happy_path_buy_exact() {
     let price_cap = Float::parse(high_price_cap()).unwrap();
     let rpc_urls = vec![url::Url::parse(&setup.local_evm.url()).unwrap()];
 
-    let execution_params = create_execution_params(mode, price_cap, taker, setup.token1, None);
+    let execution_params = create_execution_params(mode, price_cap, taker, setup.token1);
     let rpc_context = RpcContext {
         rpc_urls: &rpc_urls,
         block_number: None,
@@ -339,7 +339,7 @@ async fn test_single_order_take_happy_path_spend_up_to() {
     let price_cap = Float::parse(high_price_cap()).unwrap();
     let rpc_urls = vec![url::Url::parse(&setup.local_evm.url()).unwrap()];
 
-    let execution_params = create_execution_params(mode, price_cap, taker, setup.token1, None);
+    let execution_params = create_execution_params(mode, price_cap, taker, setup.token1);
     let rpc_context = RpcContext {
         rpc_urls: &rpc_urls,
         block_number: None,
@@ -481,6 +481,7 @@ async fn test_single_order_take_invalid_io_index_returns_none() {
         data: Some(make_quote_value(max_output, max_input, ratio)),
         success: true,
         error: None,
+        signed_context: vec![],
     };
 
     let result = build_candidate_from_quote(&order, &quote).unwrap();
@@ -563,7 +564,7 @@ async fn test_single_order_take_buy_exact_insufficient_liquidity() {
     let price_cap = Float::parse(high_price_cap()).unwrap();
     let rpc_urls = vec![url::Url::parse(&setup.local_evm.url()).unwrap()];
 
-    let execution_params = create_execution_params(mode, price_cap, taker, setup.token1, None);
+    let execution_params = create_execution_params(mode, price_cap, taker, setup.token1);
     let rpc_context = RpcContext {
         rpc_urls: &rpc_urls,
         block_number: None,
@@ -651,7 +652,7 @@ async fn test_single_order_take_price_exceeds_cap() {
     let price_cap = Float::parse("2".to_string()).unwrap();
     let rpc_urls = vec![url::Url::parse(&setup.local_evm.url()).unwrap()];
 
-    let execution_params = create_execution_params(mode, price_cap, taker, setup.token1, None);
+    let execution_params = create_execution_params(mode, price_cap, taker, setup.token1);
     let rpc_context = RpcContext {
         rpc_urls: &rpc_urls,
         block_number: None,
@@ -780,7 +781,7 @@ async fn test_single_order_take_preflight_insufficient_balance() {
     let price_cap = Float::parse(high_price_cap()).unwrap();
     let rpc_urls = vec![url::Url::parse(&setup.local_evm.url()).unwrap()];
 
-    let execution_params = create_execution_params(mode, price_cap, taker, setup.token1, None);
+    let execution_params = create_execution_params(mode, price_cap, taker, setup.token1);
     let rpc_context = RpcContext {
         rpc_urls: &rpc_urls,
         block_number: None,
@@ -883,7 +884,7 @@ async fn test_single_order_take_preflight_insufficient_allowance() {
     let price_cap = Float::parse(high_price_cap()).unwrap();
     let rpc_urls = vec![url::Url::parse(&setup.local_evm.url()).unwrap()];
 
-    let execution_params = create_execution_params(mode, price_cap, taker, setup.token1, None);
+    let execution_params = create_execution_params(mode, price_cap, taker, setup.token1);
     let rpc_context = RpcContext {
         rpc_urls: &rpc_urls,
         block_number: None,
@@ -987,7 +988,7 @@ async fn test_single_order_take_approval_then_ready_flow() {
     let rpc_urls = vec![url::Url::parse(&setup.local_evm.url()).unwrap()];
 
     // Step 1: First call should return NeedsApproval
-    let execution_params = create_execution_params(mode, price_cap, taker, setup.token1, None);
+    let execution_params = create_execution_params(mode, price_cap, taker, setup.token1);
     let rpc_context = RpcContext {
         rpc_urls: &rpc_urls,
         block_number: None,
@@ -1031,7 +1032,7 @@ async fn test_single_order_take_approval_then_ready_flow() {
     );
 
     // Step 3: Second call should return Ready with take order calldata
-    let execution_params = create_execution_params(mode, price_cap, taker, setup.token1, None);
+    let execution_params = create_execution_params(mode, price_cap, taker, setup.token1);
     let rpc_context = RpcContext {
         rpc_urls: &rpc_urls,
         block_number: None,
@@ -1141,7 +1142,7 @@ async fn test_single_order_take_calldata_encoding_buy_mode() {
     let price_cap = Float::parse(price_cap_str.to_string()).unwrap();
     let rpc_urls = vec![url::Url::parse(&setup.local_evm.url()).unwrap()];
 
-    let execution_params = create_execution_params(mode, price_cap, taker, setup.token1, None);
+    let execution_params = create_execution_params(mode, price_cap, taker, setup.token1);
     let rpc_context = RpcContext {
         rpc_urls: &rpc_urls,
         block_number: None,
@@ -1246,7 +1247,7 @@ async fn test_single_order_take_expected_spend_calculation() {
     let price_cap = Float::parse(high_price_cap()).unwrap();
     let rpc_urls = vec![url::Url::parse(&setup.local_evm.url()).unwrap()];
 
-    let execution_params = create_execution_params(mode, price_cap, taker, setup.token1, None);
+    let execution_params = create_execution_params(mode, price_cap, taker, setup.token1);
     let rpc_context = RpcContext {
         rpc_urls: &rpc_urls,
         block_number: None,
@@ -1355,7 +1356,7 @@ async fn test_single_order_take_spend_exact_mode() {
     let price_cap = Float::parse(high_price_cap()).unwrap();
     let rpc_urls = vec![url::Url::parse(&setup.local_evm.url()).unwrap()];
 
-    let execution_params = create_execution_params(mode, price_cap, taker, setup.token1, None);
+    let execution_params = create_execution_params(mode, price_cap, taker, setup.token1);
     let rpc_context = RpcContext {
         rpc_urls: &rpc_urls,
         block_number: None,
@@ -1583,7 +1584,7 @@ async fn test_single_order_take_spend_exact_insufficient_liquidity() {
     let price_cap = Float::parse(high_price_cap()).unwrap();
     let rpc_urls = vec![url::Url::parse(&setup.local_evm.url()).unwrap()];
 
-    let execution_params = create_execution_params(mode, price_cap, taker, setup.token1, None);
+    let execution_params = create_execution_params(mode, price_cap, taker, setup.token1);
     let rpc_context = RpcContext {
         rpc_urls: &rpc_urls,
         block_number: None,
@@ -1673,7 +1674,7 @@ async fn test_single_order_take_calldata_encoding_spend_mode() {
     let price_cap = Float::parse(price_cap_str.to_string()).unwrap();
     let rpc_urls = vec![url::Url::parse(&setup.local_evm.url()).unwrap()];
 
-    let execution_params = create_execution_params(mode, price_cap, taker, setup.token1, None);
+    let execution_params = create_execution_params(mode, price_cap, taker, setup.token1);
     let rpc_context = RpcContext {
         rpc_urls: &rpc_urls,
         block_number: None,
@@ -1720,14 +1721,12 @@ fn create_execution_params(
     price_cap: Float,
     taker: Address,
     sell_token: Address,
-    oracle_url: Option<String>,
 ) -> TakeOrderExecutionParams {
     TakeOrderExecutionParams {
         mode,
         price_cap,
         taker,
         sell_token,
-        oracle_url,
     }
 }
 
@@ -1804,7 +1803,7 @@ async fn test_single_order_take_expected_receive_calculation() {
     let price_cap = Float::parse(high_price_cap()).unwrap();
     let rpc_urls = vec![url::Url::parse(&setup.local_evm.url()).unwrap()];
 
-    let execution_params = create_execution_params(mode, price_cap, taker, setup.token1, None);
+    let execution_params = create_execution_params(mode, price_cap, taker, setup.token1);
     let rpc_context = RpcContext {
         rpc_urls: &rpc_urls,
         block_number: None,

--- a/crates/common/src/take_orders/candidates.rs
+++ b/crates/common/src/take_orders/candidates.rs
@@ -1,9 +1,12 @@
-use crate::raindex_client::order_quotes::{get_order_quotes_batch, RaindexOrderQuote};
+use crate::raindex_client::order_quotes::{
+    get_order_quotes_batch_with_injector, RaindexOrderQuote,
+};
 use crate::raindex_client::orders::RaindexOrder;
 use crate::raindex_client::RaindexError;
 use alloy::primitives::Address;
 use rain_math_float::Float;
 use rain_orderbook_bindings::IRaindexV6::{OrderV4, SignedContextV1};
+use rain_orderbook_quote::SignedContextInjector;
 #[cfg(target_family = "wasm")]
 use std::str::FromStr;
 
@@ -38,7 +41,12 @@ pub struct TakeOrderCandidate {
     pub output_io_index: u32,
     pub max_output: Float,
     pub ratio: Float,
-    /// Signed context data fetched from the order's oracle endpoint (if any).
+    /// Signed context data attached to this candidate.
+    ///
+    /// Composition order is `[oracle..., injected...]`: any entries fetched
+    /// from the order's oracle endpoint come first, followed by entries
+    /// contributed by a caller-supplied [`SignedContextInjector`]. Strategies
+    /// that verify signed context by index must be aware of this ordering.
     pub signed_context: Vec<SignedContextV1>,
 }
 
@@ -59,42 +67,33 @@ pub async fn build_take_order_candidates_for_pair(
     output_token: Address,
     block_number: Option<u64>,
     chunk_size: Option<u32>,
+    counterparty: Address,
+    injector: &dyn SignedContextInjector,
 ) -> Result<Vec<TakeOrderCandidate>, RaindexError> {
-    let all_quotes = get_order_quotes_batch(orders, block_number, chunk_size).await?;
+    // Oracle fetch and injector invocation both happen inside the quote
+    // pipeline now: `get_order_quotes_batch_with_injector` composes them into
+    // `QuoteV2.signedContext` before issuing the quote RPC, so gated orders
+    // whose `calculate-io` asserts on signed context do not revert during
+    // quoting. Each returned quote carries the exact composed context that
+    // the quote call saw, which we propagate straight into the candidate.
+    let all_quotes = get_order_quotes_batch_with_injector(
+        orders,
+        block_number,
+        chunk_size,
+        counterparty,
+        injector,
+    )
+    .await?;
 
     let mut all_candidates = vec![];
     for (order, quotes) in orders.iter().zip(all_quotes) {
         let order_v4: OrderV4 = order.try_into()?;
         let orderbook = get_orderbook_address(order)?;
-        let oracle_url = order.oracle_url();
 
         for quote in &quotes {
-            let signed_context = match &oracle_url {
-                Some(url) => {
-                    fetch_oracle_for_pair(
-                        url,
-                        &order_v4,
-                        quote.pair.input_index,
-                        quote.pair.output_index,
-                        // Counterparty is unknown at candidate-building time (the taker
-                        // address isn't known until the transaction is submitted).
-                        // The oracle server ignores this field — it only uses the order's
-                        // input/output tokens to determine the price pair.
-                        Address::ZERO,
-                    )
-                    .await?
-                }
-                None => vec![],
-            };
-
-            if let Some(candidate) = try_build_candidate(
-                orderbook,
-                &order_v4,
-                quote,
-                input_token,
-                output_token,
-                signed_context,
-            )? {
+            if let Some(candidate) =
+                try_build_candidate(orderbook, &order_v4, quote, input_token, output_token)?
+            {
                 all_candidates.push(candidate);
             }
         }
@@ -103,32 +102,12 @@ pub async fn build_take_order_candidates_for_pair(
     Ok(all_candidates)
 }
 
-/// Fetch signed context from an order's oracle endpoint for a specific IO pair.
-async fn fetch_oracle_for_pair(
-    oracle_url: &str,
-    order: &OrderV4,
-    input_io_index: u32,
-    output_io_index: u32,
-    counterparty: Address,
-) -> Result<Vec<SignedContextV1>, RaindexError> {
-    let body =
-        crate::oracle::encode_oracle_body(order, input_io_index, output_io_index, counterparty);
-    match crate::oracle::fetch_signed_context(oracle_url, body).await {
-        Ok(ctx) => Ok(vec![ctx]),
-        Err(e) => Err(RaindexError::OracleFetchError(format!(
-            "Oracle fetch failed for pair ({}, {}): {}",
-            input_io_index, output_io_index, e
-        ))),
-    }
-}
-
 fn try_build_candidate(
     orderbook: Address,
     order: &OrderV4,
     quote: &RaindexOrderQuote,
     input_token: Address,
     output_token: Address,
-    signed_context: Vec<SignedContextV1>,
 ) -> Result<Option<TakeOrderCandidate>, RaindexError> {
     let data = match (quote.success, &quote.data) {
         (true, Some(d)) => d,
@@ -156,6 +135,7 @@ fn try_build_candidate(
         return Ok(None);
     }
 
+    // Defer clone until the candidate survives all filters.
     Ok(Some(TakeOrderCandidate {
         orderbook,
         order: order.clone(),
@@ -163,7 +143,7 @@ fn try_build_candidate(
         output_io_index,
         max_output: data.max_output,
         ratio: data.ratio,
-        signed_context,
+        signed_context: quote.signed_context.clone(),
     }))
 }
 
@@ -289,8 +269,7 @@ mod tests {
         let f1 = Float::parse("1".to_string()).unwrap();
         let quote = make_quote(0, 0, Some(make_quote_value(f1, f1, f1)), true);
 
-        let result =
-            try_build_candidate(orderbook, &order, &quote, token_b, token_a, vec![]).unwrap();
+        let result = try_build_candidate(orderbook, &order, &quote, token_b, token_a).unwrap();
 
         assert!(result.is_none());
     }
@@ -306,8 +285,7 @@ mod tests {
         let f1 = Float::parse("1".to_string()).unwrap();
         let quote = make_quote(0, 0, Some(make_quote_value(zero, zero, f1)), true);
 
-        let result =
-            try_build_candidate(orderbook, &order, &quote, token_a, token_b, vec![]).unwrap();
+        let result = try_build_candidate(orderbook, &order, &quote, token_a, token_b).unwrap();
 
         assert!(result.is_none());
     }
@@ -323,8 +301,7 @@ mod tests {
         let f2 = Float::parse("2".to_string()).unwrap();
         let quote = make_quote(0, 0, Some(make_quote_value(f2, f1, f1)), true);
 
-        let result =
-            try_build_candidate(orderbook, &order, &quote, token_a, token_b, vec![]).unwrap();
+        let result = try_build_candidate(orderbook, &order, &quote, token_a, token_b).unwrap();
 
         assert!(result.is_some());
         let candidate = result.unwrap();
@@ -343,7 +320,7 @@ mod tests {
         let order = make_basic_order(token_a, token_b);
         let quote = make_quote(0, 0, None, false);
 
-        let result = try_build_candidate(orderbook, &order, &quote, token_a, token_b, vec![]);
+        let result = try_build_candidate(orderbook, &order, &quote, token_a, token_b);
 
         assert!(
             result.is_ok(),
@@ -356,6 +333,55 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn test_noop_injector_returns_empty() {
+        use rain_orderbook_quote::injector::{NoopInjector, SignedContextInjector};
+
+        let token_a = Address::from([4u8; 20]);
+        let token_b = Address::from([5u8; 20]);
+        let order = make_basic_order(token_a, token_b);
+
+        let injector = NoopInjector;
+        let ctxs = injector.contexts_for(&order, 0, 0, Address::ZERO).await;
+        assert!(ctxs.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_try_build_candidate_propagates_signed_context() {
+        use alloy::primitives::{FixedBytes, U256};
+
+        // A candidate built from a quote that already carries signed context
+        // (as produced by the quote pipeline) should inherit that exact list.
+        let oracle_entry = SignedContextV1 {
+            signer: Address::from([0xAAu8; 20]),
+            context: vec![FixedBytes::<32>::from(U256::from(1u64).to_be_bytes::<32>())],
+            signature: alloy::primitives::Bytes::from(vec![0x01]),
+        };
+        let injected_entry = SignedContextV1 {
+            signer: Address::from([0xBBu8; 20]),
+            context: vec![FixedBytes::<32>::from(U256::from(2u64).to_be_bytes::<32>())],
+            signature: alloy::primitives::Bytes::from(vec![0x02]),
+        };
+
+        let token_a = Address::from([4u8; 20]);
+        let token_b = Address::from([5u8; 20]);
+        let orderbook = Address::from([0xAAu8; 20]);
+
+        let order = make_basic_order(token_a, token_b);
+        let f1 = Float::parse("1".to_string()).unwrap();
+        let f2 = Float::parse("2".to_string()).unwrap();
+        let mut quote = make_quote(0, 0, Some(make_quote_value(f2, f1, f1)), true);
+        quote.signed_context = vec![oracle_entry.clone(), injected_entry.clone()];
+
+        let result = try_build_candidate(orderbook, &order, &quote, token_a, token_b)
+            .unwrap()
+            .expect("candidate should be built");
+
+        assert_eq!(result.signed_context.len(), 2);
+        assert_eq!(result.signed_context[0].signer, oracle_entry.signer);
+        assert_eq!(result.signed_context[1].signer, injected_entry.signer);
+    }
+
     #[test]
     fn test_try_build_candidate_out_of_bounds_indices() {
         let token_a = Address::from([4u8; 20]);
@@ -366,14 +392,8 @@ mod tests {
         let f1 = Float::parse("1".to_string()).unwrap();
 
         let quote_bad_input_index = make_quote(99, 0, Some(make_quote_value(f1, f1, f1)), true);
-        let result = try_build_candidate(
-            orderbook,
-            &order,
-            &quote_bad_input_index,
-            token_a,
-            token_b,
-            vec![],
-        );
+        let result =
+            try_build_candidate(orderbook, &order, &quote_bad_input_index, token_a, token_b);
         assert!(
             result.is_ok(),
             "Out-of-bounds input index must not cause an error"
@@ -384,14 +404,8 @@ mod tests {
         );
 
         let quote_bad_output_index = make_quote(0, 99, Some(make_quote_value(f1, f1, f1)), true);
-        let result = try_build_candidate(
-            orderbook,
-            &order,
-            &quote_bad_output_index,
-            token_a,
-            token_b,
-            vec![],
-        );
+        let result =
+            try_build_candidate(orderbook, &order, &quote_bad_output_index, token_a, token_b);
         assert!(
             result.is_ok(),
             "Out-of-bounds output index must not cause an error"

--- a/crates/common/src/take_orders/mod.rs
+++ b/crates/common/src/take_orders/mod.rs
@@ -13,6 +13,7 @@ pub use preflight::{
     check_taker_balance_and_allowance, find_failing_order_index, simulate_take_orders,
     AllowanceOnlyResult, BalanceAndAllowanceResult, PreflightError,
 };
+pub use rain_orderbook_quote::injector::{NoopInjector, SignedContextInjector};
 pub use simulation::{
     simulate_buy_over_candidates, simulate_spend_over_candidates, SelectedTakeOrderLeg,
     SimulationResult,

--- a/crates/common/src/test_helpers.rs
+++ b/crates/common/src/test_helpers.rs
@@ -654,6 +654,7 @@ pub mod quotes {
             block_number: 1,
             data,
             success,
+            signed_context: vec![],
             error: if success {
                 None
             } else {

--- a/crates/quote/Cargo.toml
+++ b/crates/quote/Cargo.toml
@@ -31,6 +31,7 @@ reqwest = { workspace = true }
 clap = { workspace = true, features = ["env"] }
 tracing-subscriber = { workspace = true, features = ['env-filter'] }
 wasm-bindgen-utils = { workspace = true }
+async-trait = { workspace = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 tokio = { workspace = true, features = ["full"] }
@@ -55,4 +56,3 @@ rain_orderbook_common = { workspace = true }
 wasm-bindgen-test = "0.3"
 rain_orderbook_app_settings = { workspace = true }
 tempfile.workspace = true
-async-trait = "0.1"

--- a/crates/quote/src/injector.rs
+++ b/crates/quote/src/injector.rs
@@ -1,0 +1,40 @@
+use alloy::primitives::Address;
+use async_trait::async_trait;
+use rain_orderbook_bindings::IRaindexV6::{OrderV4, SignedContextV1};
+
+/// Caller-supplied source of additional `SignedContextV1` entries for each
+/// order candidate. Invoked during candidate building, after any oracle-URL
+/// contexts have been fetched. Returned contexts are appended (not replacing
+/// oracle contexts). Strategies that verify signed context by index must
+/// therefore know the composition order: `[oracle..., injected...]`.
+///
+/// Implementors may inspect any field of `order` (tokens, owner, nonce,
+/// evaluable bytecode), the IO indices selected for this take, and the
+/// `counterparty` that will execute the take, to produce per-order
+/// signatures or other signed attestations.
+#[async_trait]
+pub trait SignedContextInjector: Send + Sync {
+    async fn contexts_for(
+        &self,
+        order: &OrderV4,
+        input_io_index: u32,
+        output_io_index: u32,
+        counterparty: Address,
+    ) -> Vec<SignedContextV1>;
+}
+
+/// No-op injector used as the default when no caller-supplied injector is given.
+pub struct NoopInjector;
+
+#[async_trait]
+impl SignedContextInjector for NoopInjector {
+    async fn contexts_for(
+        &self,
+        _order: &OrderV4,
+        _input_io_index: u32,
+        _output_io_index: u32,
+        _counterparty: Address,
+    ) -> Vec<SignedContextV1> {
+        vec![]
+    }
+}

--- a/crates/quote/src/lib.rs
+++ b/crates/quote/src/lib.rs
@@ -6,8 +6,10 @@ mod quote;
 mod quote_debug;
 pub mod rpc;
 
+pub mod injector;
 pub mod oracle;
 mod order_quotes;
+pub use injector::{NoopInjector, SignedContextInjector};
 pub use order_quotes::*;
 
 pub use quote::*;

--- a/crates/quote/src/order_quotes.rs
+++ b/crates/quote/src/order_quotes.rs
@@ -1,11 +1,14 @@
+#[cfg(test)]
+use crate::injector::NoopInjector;
 use crate::{
     error::Error,
+    injector::SignedContextInjector,
     quote::{BatchQuoteTarget, QuoteTarget},
     OrderQuoteValue,
 };
 use alloy::primitives::{Address, U256};
 use alloy_ethers_typecast::ReadableClient;
-use rain_orderbook_bindings::IRaindexV6::{OrderV4, QuoteV2};
+use rain_orderbook_bindings::IRaindexV6::{OrderV4, QuoteV2, SignedContextV1};
 use rain_orderbook_subgraph_client::types::common::SgOrder;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
@@ -23,6 +26,14 @@ pub struct BatchOrderQuotesResponse {
     pub success: bool,
     #[cfg_attr(target_family = "wasm", tsify(optional))]
     pub error: Option<String>,
+    /// Composed signed context that was sent with the quote RPC: any
+    /// oracle-fetched entries first, followed by injector-contributed entries
+    /// (composition order: `[oracle..., injected...]`). This is propagated so
+    /// downstream candidate construction can reuse the same context that the
+    /// quote call saw, rather than re-fetching or re-composing.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[cfg_attr(target_family = "wasm", tsify(optional))]
+    pub signed_context: Vec<SignedContextV1>,
 }
 #[cfg(target_family = "wasm")]
 impl_wasm_traits!(BatchOrderQuotesResponse);
@@ -38,15 +49,23 @@ pub struct Pair {
 #[cfg(target_family = "wasm")]
 impl_wasm_traits!(Pair);
 
-/// Get order quotes, automatically fetching signed oracle context from order meta.
+/// Get order quotes, automatically fetching signed oracle context from order
+/// meta and appending any caller-supplied injector contexts.
 ///
-/// For each order, if the meta contains a `RaindexSignedContextOracleV1` entry,
-/// the oracle URL is extracted and signed context is fetched per IO pair via POST.
+/// For each order, if the meta contains a `RaindexSignedContextOracleV1`
+/// entry, the oracle URL is extracted and signed context is fetched per IO
+/// pair via POST. Any additional entries produced by `injector` are appended
+/// after the oracle entries (composition order: `[oracle..., injected...]`),
+/// and the composed list is attached to the `QuoteV2.signedContext` before
+/// the multicall is issued. This matters for gated orders whose
+/// `calculate-io` asserts on signed context during quoting.
 pub async fn get_order_quotes(
     orders: Vec<SgOrder>,
     block_number: Option<u64>,
     rpcs: Vec<String>,
     chunk_size: Option<usize>,
+    counterparty: Address,
+    injector: &dyn SignedContextInjector,
 ) -> Result<Vec<BatchOrderQuotesResponse>, Error> {
     let req_block_number = match block_number {
         Some(block) => block,
@@ -59,6 +78,7 @@ pub async fn get_order_quotes(
 
     let mut all_pairs: Vec<Pair> = Vec::new();
     let mut all_quote_targets: Vec<QuoteTarget> = Vec::new();
+    let mut all_signed_contexts: Vec<Vec<SignedContextV1>> = Vec::new();
     let mut oracle_errors: Vec<BatchOrderQuotesResponse> = Vec::new();
 
     for order in &orders {
@@ -103,12 +123,12 @@ pub async fn get_order_quotes(
                 // the quote is pinned to a historical block. This means historical quotes
                 // for oracle-backed orders reflect current oracle prices against past chain
                 // state, which may not represent a quote that actually existed.
-                let signed_context = if let Some(ref url) = oracle_url {
+                let oracle_context = if let Some(ref url) = oracle_url {
                     let body = crate::oracle::encode_oracle_body(
                         &order_struct,
                         input_index as u32,
                         output_index as u32,
-                        Address::ZERO, // counterparty unknown at quote time
+                        counterparty,
                     );
                     match crate::oracle::fetch_signed_context(url, body).await {
                         Ok(ctx) => Ok(vec![ctx]),
@@ -127,16 +147,31 @@ pub async fn get_order_quotes(
                     output_index: output_index as u32,
                 };
 
-                match signed_context {
-                    Ok(ctx) => {
+                match oracle_context {
+                    Ok(oracle_ctx) => {
+                        // Append injector-contributed contexts after the oracle
+                        // context. Gated orders that verify signed context by
+                        // index must know the composition order.
+                        let injected = injector
+                            .contexts_for(
+                                &order_struct,
+                                input_index as u32,
+                                output_index as u32,
+                                counterparty,
+                            )
+                            .await;
+                        let composed: Vec<SignedContextV1> =
+                            oracle_ctx.into_iter().chain(injected).collect();
+
                         all_pairs.push(pair);
+                        all_signed_contexts.push(composed.clone());
                         all_quote_targets.push(QuoteTarget {
                             orderbook,
                             quote_config: QuoteV2 {
                                 order: order_struct.clone(),
                                 inputIOIndex: U256::from(input_index),
                                 outputIOIndex: U256::from(output_index),
-                                signedContext: ctx,
+                                signedContext: composed,
                             },
                         });
                     }
@@ -147,6 +182,7 @@ pub async fn get_order_quotes(
                             success: false,
                             data: None,
                             error: Some(e),
+                            signed_context: vec![],
                         });
                     }
                 }
@@ -161,33 +197,40 @@ pub async fn get_order_quotes(
         Ok(quote_values) => quote_values
             .into_iter()
             .zip(all_pairs)
-            .map(|(quote_result, pair)| match quote_result {
-                Ok(data) => BatchOrderQuotesResponse {
-                    pair,
-                    block_number: req_block_number,
-                    success: true,
-                    data: Some(data),
-                    error: None,
+            .zip(all_signed_contexts)
+            .map(
+                |((quote_result, pair), signed_context)| match quote_result {
+                    Ok(data) => BatchOrderQuotesResponse {
+                        pair,
+                        block_number: req_block_number,
+                        success: true,
+                        data: Some(data),
+                        error: None,
+                        signed_context,
+                    },
+                    Err(e) => BatchOrderQuotesResponse {
+                        pair,
+                        block_number: req_block_number,
+                        success: false,
+                        data: None,
+                        error: Some(e.to_string()),
+                        signed_context,
+                    },
                 },
-                Err(e) => BatchOrderQuotesResponse {
-                    pair,
-                    block_number: req_block_number,
-                    success: false,
-                    data: None,
-                    error: Some(e.to_string()),
-                },
-            })
+            )
             .collect(),
         Err(e) => {
             let error = e.to_string();
             all_pairs
                 .into_iter()
-                .map(|pair| BatchOrderQuotesResponse {
+                .zip(all_signed_contexts)
+                .map(|(pair, signed_context)| BatchOrderQuotesResponse {
                     pair,
                     block_number: req_block_number,
                     success: false,
                     data: None,
                     error: Some(error.clone()),
+                    signed_context,
                 })
                 .collect()
         }
@@ -434,9 +477,16 @@ amount price: 2 3;
 
         let order = create_sg_order(&setup, order, inputs, outputs);
 
-        let result = get_order_quotes(vec![order], None, vec![setup.local_evm.url()], None)
-            .await
-            .unwrap();
+        let result = get_order_quotes(
+            vec![order],
+            None,
+            vec![setup.local_evm.url()],
+            None,
+            Address::ZERO,
+            &NoopInjector,
+        )
+        .await
+        .unwrap();
 
         let expected_max_output = Float::parse("2".to_string()).unwrap();
         let expected_ratio = Float::parse("3".to_string()).unwrap();
@@ -456,6 +506,7 @@ amount price: 2 3;
                 }),
                 success: true,
                 error: None,
+                signed_context: vec![],
             },
             BatchOrderQuotesResponse {
                 pair: Pair {
@@ -470,6 +521,7 @@ amount price: 2 3;
                 }),
                 success: true,
                 error: None,
+                signed_context: vec![],
             },
         ];
 
@@ -509,18 +561,32 @@ amount price: 2 3;
         let mut invalid_order = create_sg_order(&setup, order.clone(), vec![], vec![]);
         invalid_order.orderbook.id = SgBytes("invalid_address".to_string());
 
-        let err = get_order_quotes(vec![invalid_order], None, vec![setup.local_evm.url()], None)
-            .await
-            .unwrap_err();
+        let err = get_order_quotes(
+            vec![invalid_order],
+            None,
+            vec![setup.local_evm.url()],
+            None,
+            Address::ZERO,
+            &NoopInjector,
+        )
+        .await
+        .unwrap_err();
 
         assert!(matches!(err, Error::FromHexError(FromHexError::OddLength)));
 
         // Test invalid order bytes
         let invalid_order = create_sg_order(&setup, B256::random().to_string(), vec![], vec![]);
 
-        let err = get_order_quotes(vec![invalid_order], None, vec![setup.local_evm.url()], None)
-            .await
-            .unwrap_err();
+        let err = get_order_quotes(
+            vec![invalid_order],
+            None,
+            vec![setup.local_evm.url()],
+            None,
+            Address::ZERO,
+            &NoopInjector,
+        )
+        .await
+        .unwrap_err();
 
         assert!(matches!(
             err,
@@ -535,6 +601,8 @@ amount price: 2 3;
             None,
             vec!["invalid_rpc_url".to_string()],
             None,
+            Address::ZERO,
+            &NoopInjector,
         )
         .await
         .unwrap_err();


### PR DESCRIPTION
## Motivation

There is currently no way for a caller of the take-orders flow to contribute its own `SignedContextV1` entries per order. The only source of signed contexts today is the `RaindexSignedContextOracleV1` URL discovered from order meta — fetched by the library via HTTP POST. That model assumes a single, publicly-reachable oracle URL per order, which doesn't fit callers that need to produce per-request, per-user signatures in-process (for example, an API that reserves specific orders for authenticated clients by issuing a per-request gating signature).

## Solution

- New `SignedContextInjector` trait in `crates/quote/src/injector.rs`:
  ```rust
  async fn contexts_for(&self, order: &OrderV4, input_io_index: u32, output_io_index: u32, counterparty: Address) -> Vec<SignedContextV1>;
  ```
  Default `NoopInjector` preserves existing behaviour. Placed in the quote crate because common depends on quote, not the reverse; re-exported from `rain_orderbook_common::take_orders` for API parity.
- Threaded through `get_order_quotes_batch_with_injector` so composed contexts land on `QuoteV2.signedContext` **before** the quote RPC. Strategies whose `calculate-io` asserts on signed context now quote successfully instead of silently being filtered as failed quotes.
- `RaindexOrderQuote` gains `signed_context: Vec<SignedContextV1>` (serde-default, tsify-optional, skip-if-empty) so candidates inherit the exact context the quote saw — no post-quote re-attach.
- `build_take_order_candidates_for_pair` forwards `counterparty: Address` + `&dyn SignedContextInjector`.
- `get_take_orders_calldata` stays backward-compatible (defaults to `NoopInjector` + `Address::ZERO`). Added `get_take_orders_calldata_with_injector` as the injector-aware entry point; deliberately not `#[wasm_export]`ed since trait objects don't serialize.
- Composition order is `[oracle..., injected...]`. Strategies that read contexts positionally (`signer<N>()`, `signed-context<N M>()`) must follow this convention.
- Minor behavioural change: oracle fetches now receive the real `counterparty` rather than the hardcoded `Address::ZERO` stub. Existing oracle servers ignore this field (per the removed comment), so this is a no-op in practice but removes a misleading value.

## Checks

By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)

Verified locally:
- `cargo check --workspace` clean
- `cargo test -p rain_orderbook_common --lib take_orders` — 176 passed
- `cargo test -p rain_orderbook_quote --lib` — 48 passed
- `cargo fmt`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Quotes now include signed context data and accept counterparty information.
  * Added an extensible injector interface (and a no-op default) to append custom signed contexts during quote generation.
  * New APIs allow callers to provide an injector when requesting quotes or take-calldata.

* **Refactor**
  * Candidate/quote pipeline now composes contexts as [oracle..., injected...] up-front and preserves them through selection and execution (removes deferred oracle fetch).

* **Tests**
  * Serialization and quote tests updated to validate signed context behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->