### PR TITLE
feat: add local-db manifest URL command

### DIFF
--- a/crates/cli/src/commands/local_db/manifest_urls.rs
+++ b/crates/cli/src/commands/local_db/manifest_urls.rs
@@ -1,0 +1,152 @@
+use anyhow::{Context, Result};
+use clap::Parser;
+use raindex_app_settings::yaml::{
+    raindex::{RaindexYaml, RaindexYamlValidation},
+    YamlParsable,
+};
+use std::io::{self, Write};
+use url::Url;
+
+#[derive(Debug, Clone, Parser)]
+#[command(about = "Print local DB remote manifest URLs from settings YAML")]
+pub struct ManifestUrls {
+    #[clap(
+        long,
+        help = "Full YAML document that configures local DB remotes",
+        value_name = "YAML"
+    )]
+    pub settings_yaml: String,
+}
+
+impl ManifestUrls {
+    pub fn execute(self) -> Result<()> {
+        let mut stdout = io::stdout();
+        self.execute_to(&mut stdout)
+    }
+
+    fn execute_to<W: Write>(&self, writer: &mut W) -> Result<()> {
+        let urls = manifest_urls_from_settings(&self.settings_yaml)?;
+
+        for url in urls {
+            writeln!(writer, "{url}")?;
+        }
+
+        Ok(())
+    }
+}
+
+fn manifest_urls_from_settings(settings_yaml: &str) -> Result<Vec<Url>> {
+    let raindex_yaml = RaindexYaml::new(
+        vec![settings_yaml.to_string()],
+        RaindexYamlValidation {
+            local_db_remotes: true,
+            ..Default::default()
+        },
+    )
+    .context("failed to parse settings YAML")?;
+    let remotes = raindex_yaml
+        .get_local_db_remotes()
+        .context("failed to parse local-db-remotes from settings YAML")?;
+
+    Ok(remotes
+        .into_iter()
+        .collect::<std::collections::BTreeMap<_, _>>()
+        .into_values()
+        .map(|remote| remote.url)
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn render(args: ManifestUrls) -> Result<String> {
+        let mut buffer = Vec::new();
+        args.execute_to(&mut buffer)?;
+        Ok(String::from_utf8(buffer).unwrap())
+    }
+
+    #[test]
+    fn single_remote_url_prints_one_line() {
+        let yaml = r#"
+version: 6
+local-db-remotes:
+  raindex: https://example.com/manifest.yaml
+"#;
+
+        let output = render(ManifestUrls {
+            settings_yaml: yaml.to_string(),
+        })
+        .unwrap();
+
+        assert_eq!(output, "https://example.com/manifest.yaml\n");
+    }
+
+    #[test]
+    fn duplicate_remote_urls_fail_settings_parsing() {
+        let yaml = r#"
+version: 6
+local-db-remotes:
+  raindex-a: https://example.com/manifest.yaml
+  raindex-b: https://example.com/manifest.yaml
+"#;
+
+        let err = render(ManifestUrls {
+            settings_yaml: yaml.to_string(),
+        })
+        .unwrap_err();
+        let message = err.to_string();
+
+        assert!(message.contains("failed to parse settings YAML"));
+    }
+
+    #[test]
+    fn no_remotes_prints_nothing() {
+        let yaml = r#"
+version: 6
+"#;
+
+        let output = render(ManifestUrls {
+            settings_yaml: yaml.to_string(),
+        })
+        .unwrap();
+
+        assert_eq!(output, "");
+    }
+
+    #[test]
+    fn default_output_is_only_one_url_per_line() {
+        let yaml = r#"
+version: 6
+local-db-remotes:
+  raindex-a: https://example.com/a.yaml
+  raindex-b: https://example.com/b.yaml
+"#;
+
+        let output = render(ManifestUrls {
+            settings_yaml: yaml.to_string(),
+        })
+        .unwrap();
+
+        assert_eq!(
+            output,
+            "https://example.com/a.yaml\nhttps://example.com/b.yaml\n"
+        );
+    }
+
+    #[test]
+    fn missing_version_fails_before_printing_urls() {
+        let yaml = r#"
+local-db-remotes:
+  raindex: https://example.com/manifest.yaml
+"#;
+
+        let err = render(ManifestUrls {
+            settings_yaml: yaml.to_string(),
+        })
+        .unwrap_err();
+        let message = err.to_string();
+
+        assert!(message.contains("failed to parse settings YAML"));
+    }
+}

--- a/crates/cli/src/commands/local_db/mod.rs
+++ b/crates/cli/src/commands/local_db/mod.rs
@@ -1,22 +1,28 @@
 pub mod cli;
 pub mod executor;
+pub mod manifest_urls;
 pub mod pipeline;
 
 use anyhow::Result;
 use clap::Subcommand;
 use cli::RunPipeline;
+use manifest_urls::ManifestUrls;
 
 #[derive(Subcommand)]
 #[command(about = "Local database operations")]
 pub enum LocalDbCommands {
     #[command(name = "sync")]
     Sync(RunPipeline),
+
+    #[command(name = "manifest-urls")]
+    ManifestUrls(ManifestUrls),
 }
 
 impl LocalDbCommands {
     pub async fn execute(self) -> Result<()> {
         match self {
             LocalDbCommands::Sync(cmd) => cmd.execute().await,
+            LocalDbCommands::ManifestUrls(cmd) => cmd.execute(),
         }
     }
 }

--- a/crates/settings/src/local_db_remotes.rs
+++ b/crates/settings/src/local_db_remotes.rs
@@ -37,6 +37,7 @@ impl YamlParsableHash for LocalDbRemoteCfg {
         _: Option<&Context>,
     ) -> Result<HashMap<String, Self>, YamlError> {
         let mut remotes = HashMap::new();
+        let mut remote_keys_by_url = HashMap::new();
 
         for document in documents {
             let document_read = document.read().map_err(|_| YamlError::ReadLockError)?;
@@ -65,18 +66,29 @@ impl YamlParsableHash for LocalDbRemoteCfg {
                             location: location.clone(),
                         })?;
 
-                    let remote = LocalDbRemoteCfg {
-                        document: document.clone(),
-                        key: remote_key.clone(),
-                        url,
-                    };
-
                     if remotes.contains_key(&remote_key) {
                         return Err(YamlError::KeyShadowing(
                             remote_key,
                             "local-db-remotes".to_string(),
                         ));
                     }
+                    if let Some(existing_key) = remote_keys_by_url.get(&url) {
+                        return Err(YamlError::Field {
+                            kind: FieldErrorKind::InvalidValue {
+                                field: "url".to_string(),
+                                reason: format!("duplicates local-db-remotes[{}]", existing_key),
+                            },
+                            location,
+                        });
+                    }
+
+                    let remote = LocalDbRemoteCfg {
+                        document: document.clone(),
+                        key: remote_key.clone(),
+                        url,
+                    };
+
+                    remote_keys_by_url.insert(remote.url.clone(), remote.key.clone());
                     remotes.insert(remote.key.clone(), remote);
                 }
             }
@@ -153,6 +165,28 @@ local-db-remotes:
         assert_eq!(
             err,
             YamlError::KeyShadowing("mainnet".to_string(), "local-db-remotes".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_local_db_remotes_from_yaml_duplicate_url() {
+        let yaml = r#"
+local-db-remotes:
+    mainnet: https://example.com/localdb/mainnet
+    duplicate: https://example.com/localdb/mainnet
+"#;
+        let err =
+            LocalDbRemoteCfg::parse_all_from_yaml(vec![get_document(yaml)], None).unwrap_err();
+
+        assert_eq!(
+            err,
+            YamlError::Field {
+                kind: FieldErrorKind::InvalidValue {
+                    field: "url".to_string(),
+                    reason: "duplicates local-db-remotes[mainnet]".to_string(),
+                },
+                location: "local-db-remotes[duplicate]".to_string(),
+            }
         );
     }
 


### PR DESCRIPTION
## Chained PRs

- #2526

## Motivation

`rain.local-db.remote` currently fetches a settings YAML file and parses `local-db-remotes` in shell to discover manifest URLs. That duplicates settings parsing logic outside Rust and can drift from the CLI/parser behavior.

## Solution

Add a `local-db manifest-urls` CLI command that prints local DB remote manifest URLs from settings YAML:

```sh
raindex_cli local-db manifest-urls --settings-yaml "$settings_yaml"
```

- Parse settings through `RaindexYaml`, so normal settings requirements such as `version` and `local-db-remotes` validation apply.
- Print only manifest URLs to stdout, one URL per line, sorted by remote key for deterministic script output.
- Keep diagnostics/errors on stderr through the existing CLI error path.
- Reject duplicate `local-db-remotes` URL values in the core settings parser, so all settings consumers share the same uniqueness rule.
- Add focused parser and CLI tests for single URL output, duplicate URL rejection, no-remotes output, missing version failure, and exact stdout formatting.

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)

Verified locally:

- `nix develop -c cargo fmt --all`
- `nix develop -c cargo test -p raindex_app_settings local_db_remotes`
- `nix develop -c cargo test -p raindex_cli manifest_urls`
- `nix develop -c cargo test -p raindex_cli verify_cli`
- `nix develop -c rainix-rs-static`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI subcommand to list resolved manifest URLs from local-DB remotes configuration.

* **Improvements**
  * Enhanced validation to detect and report duplicate remote URLs with clearer error messages.

* **Tests**
  * Added unit tests covering URL listing, duplicate-URL errors, missing version handling, and empty/multiple-remote behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rainlanguage/raindex/pull/2553?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->