### PR TITLE
fix: make subgraph order token filters directional

### DIFF
--- a/.github/workflows/vercel-preview-pr-target.yaml
+++ b/.github/workflows/vercel-preview-pr-target.yaml
@@ -75,7 +75,7 @@ jobs:
         shell: bash --noprofile --norc -euo pipefail {0}
         run: |
           VERCEL_DIR="$(mktemp -d)"
-          npm install --no-audit --no-fund --no-save --ignore-scripts --prefix "$VERCEL_DIR" vercel@33.4.1
+          npm install --no-audit --no-fund --no-save --ignore-scripts --prefix "$VERCEL_DIR" vercel@47.2.2
           echo "VERCEL_BIN=$VERCEL_DIR/node_modules/.bin/vercel" >> "$GITHUB_ENV"
           test -x "$VERCEL_DIR/node_modules/.bin/vercel"
       - name: Pull Vercel Environment Information

--- a/.github/workflows/vercel-preview-pr-target.yaml
+++ b/.github/workflows/vercel-preview-pr-target.yaml
@@ -75,7 +75,7 @@ jobs:
         shell: bash --noprofile --norc -euo pipefail {0}
         run: |
           VERCEL_DIR="$(mktemp -d)"
-          npm install --no-audit --no-fund --no-save --ignore-scripts --prefix "$VERCEL_DIR" vercel@47.2.2
+          npm install --no-audit --no-fund --no-save --ignore-scripts --prefix "$VERCEL_DIR" vercel@51.8.0
           echo "VERCEL_BIN=$VERCEL_DIR/node_modules/.bin/vercel" >> "$GITHUB_ENV"
           test -x "$VERCEL_DIR/node_modules/.bin/vercel"
       - name: Pull Vercel Environment Information

--- a/.github/workflows/vercel-preview.yaml
+++ b/.github/workflows/vercel-preview.yaml
@@ -81,7 +81,7 @@ jobs:
         shell: bash --noprofile --norc -euo pipefail {0}
         run: |
           VERCEL_DIR="$(mktemp -d)"
-          npm install --no-audit --no-fund --no-save --prefix "$VERCEL_DIR" vercel@33.4.1
+          npm install --no-audit --no-fund --no-save --prefix "$VERCEL_DIR" vercel@47.2.2
           echo "VERCEL_BIN=$VERCEL_DIR/node_modules/.bin/vercel" >> "$GITHUB_ENV"
       - name: Pull Vercel Environment Information
         shell: bash --noprofile --norc -euo pipefail {0}

--- a/.github/workflows/vercel-preview.yaml
+++ b/.github/workflows/vercel-preview.yaml
@@ -81,7 +81,7 @@ jobs:
         shell: bash --noprofile --norc -euo pipefail {0}
         run: |
           VERCEL_DIR="$(mktemp -d)"
-          npm install --no-audit --no-fund --no-save --prefix "$VERCEL_DIR" vercel@47.2.2
+          npm install --no-audit --no-fund --no-save --prefix "$VERCEL_DIR" vercel@51.8.0
           echo "VERCEL_BIN=$VERCEL_DIR/node_modules/.bin/vercel" >> "$GITHUB_ENV"
       - name: Pull Vercel Environment Information
         shell: bash --noprofile --norc -euo pipefail {0}

--- a/crates/subgraph/src/orderbook_client/order.rs
+++ b/crates/subgraph/src/orderbook_client/order.rs
@@ -48,7 +48,7 @@ impl OrderbookSubgraphClient {
         let has_token_filters = has_input_tokens || has_output_tokens;
 
         let filters = if has_basic_filters || has_token_filters {
-            let basic_filters = SgOrdersListQueryFilters {
+            let mut filters = SgOrdersListQueryFilters {
                 owner_in: filter_args.owners.clone(),
                 active: filter_args.active,
                 order_hash: filter_args.order_hash.clone(),
@@ -57,42 +57,20 @@ impl OrderbookSubgraphClient {
                 orderbook_in: filter_args.orderbooks.clone(),
             };
 
-            let or_filters = if has_input_tokens && has_output_tokens {
+            if has_input_tokens {
                 let tokens = tokens.unwrap();
-                let filter_with_inputs = SgOrdersListQueryFilters {
-                    inputs_: Some(SgVaultTokenFilter {
-                        token_in: tokens.inputs.clone(),
-                    }),
-                    ..basic_filters.clone()
-                };
-                let filter_with_outputs = SgOrdersListQueryFilters {
-                    outputs_: Some(SgVaultTokenFilter {
-                        token_in: tokens.outputs.clone(),
-                    }),
-                    ..basic_filters.clone()
-                };
-                vec![filter_with_inputs, filter_with_outputs]
-            } else if has_input_tokens {
+                filters.inputs_ = Some(SgVaultTokenFilter {
+                    token_in: tokens.inputs.clone(),
+                });
+            }
+            if has_output_tokens {
                 let tokens = tokens.unwrap();
-                vec![SgOrdersListQueryFilters {
-                    inputs_: Some(SgVaultTokenFilter {
-                        token_in: tokens.inputs.clone(),
-                    }),
-                    ..basic_filters
-                }]
-            } else if has_output_tokens {
-                let tokens = tokens.unwrap();
-                vec![SgOrdersListQueryFilters {
-                    outputs_: Some(SgVaultTokenFilter {
-                        token_in: tokens.outputs.clone(),
-                    }),
-                    ..basic_filters
-                }]
-            } else {
-                vec![basic_filters]
-            };
+                filters.outputs_ = Some(SgVaultTokenFilter {
+                    token_in: tokens.outputs.clone(),
+                });
+            }
 
-            Some(SgOrdersListQueryAnyFilters { or: or_filters })
+            Some(filters)
         } else {
             None
         };
@@ -908,7 +886,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_orders_list_with_both_token_filters_uses_or() {
+    async fn test_orders_list_with_both_token_filters_uses_directional_and() {
         let sg_server = MockServer::start_async().await;
         let client = setup_client(&sg_server);
         let token1 = "0x1d80c49bbbcd1c0911346656b529df9e5c2f783d".to_string();
@@ -932,7 +910,6 @@ mod tests {
         sg_server.mock(|when, then| {
             when.method(POST)
                 .path("/")
-                .body_contains("\"or\":[{")
                 .body_contains("\"inputs_\":")
                 .body_contains("\"outputs_\":")
                 .body_contains(format!("\"token_in\":[\"{}\"]", token1))

--- a/crates/subgraph/src/types/common.rs
+++ b/crates/subgraph/src/types/common.rs
@@ -56,13 +56,6 @@ pub struct SgOrdersListQueryFilters {
 }
 
 #[derive(cynic::InputObject, Debug, Clone, Tsify)]
-#[cynic(graphql_type = "Order_filter")]
-pub struct SgOrdersListQueryAnyFilters {
-    #[cynic(rename = "or", skip_serializing_if = "Vec::is_empty")]
-    pub or: Vec<SgOrdersListQueryFilters>,
-}
-
-#[derive(cynic::InputObject, Debug, Clone, Tsify)]
 #[cynic(graphql_type = "Vault_filter")]
 pub struct SgVaultTokenFilter {
     #[cynic(rename = "token_in")]
@@ -77,7 +70,7 @@ pub struct SgOrdersListQueryVariables {
     pub skip: Option<i32>,
     #[cynic(rename = "filters")]
     #[cfg_attr(target_family = "wasm", tsify(optional))]
-    pub filters: Option<SgOrdersListQueryAnyFilters>,
+    pub filters: Option<SgOrdersListQueryFilters>,
 }
 
 #[derive(cynic::QueryVariables, Debug, Clone, Tsify)]

--- a/package-lock.json
+++ b/package-lock.json
@@ -17677,7 +17677,7 @@
         },
         "packages/orderbook": {
             "name": "@rainlanguage/orderbook",
-            "version": "0.0.1-alpha.229",
+            "version": "0.0.1-alpha.231",
             "license": "LicenseRef-DCL-1.0",
             "dependencies": {
                 "buffer": "6.0.3"
@@ -17791,14 +17791,14 @@
         },
         "packages/ui-components": {
             "name": "@rainlanguage/ui-components",
-            "version": "0.0.1-alpha.229",
+            "version": "0.0.1-alpha.231",
             "license": "LicenseRef-DCL-1.0",
             "dependencies": {
                 "@codemirror/lang-yaml": "6.1.1",
                 "@fontsource/dm-sans": "5.1.0",
                 "@imask/svelte": "7.6.1",
                 "@observablehq/plot": "0.6.16",
-                "@rainlanguage/orderbook": "0.0.1-alpha.229",
+                "@rainlanguage/orderbook": "0.0.1-alpha.231",
                 "@reown/appkit": "1.6.4",
                 "@reown/appkit-adapter-wagmi": "1.6.4",
                 "@sentry/sveltekit": "7.120.0",

--- a/packages/orderbook/package.json
+++ b/packages/orderbook/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@rainlanguage/orderbook",
     "description": "Provides RainLanguage Orderbook rust crates' functionalities in typescript through wasm bindgen",
-    "version": "0.0.1-alpha.229",
+    "version": "0.0.1-alpha.231",
     "license": "LicenseRef-DCL-1.0",
     "author": "Rain Open Source Software Ltd",
     "repository": {

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rainlanguage/ui-components",
-	"version": "0.0.1-alpha.229",
+	"version": "0.0.1-alpha.231",
 	"description": "A component library for building Svelte applications to be used with Raindex.",
 	"license": "LicenseRef-DCL-1.0",
 	"author": "Rain Open Source Software Ltd",
@@ -57,7 +57,7 @@
 		"@fontsource/dm-sans": "5.1.0",
 		"@imask/svelte": "7.6.1",
 		"@observablehq/plot": "0.6.16",
-		"@rainlanguage/orderbook": "0.0.1-alpha.229",
+		"@rainlanguage/orderbook": "0.0.1-alpha.231",
 		"@reown/appkit": "1.6.4",
 		"@reown/appkit-adapter-wagmi": "1.6.4",
 		"@sentry/sveltekit": "7.120.0",


### PR DESCRIPTION
## Motivation

`RaindexClient.getTakeOrdersCalldata` expects pair discovery to return orders where the sell token is an input and the buy token is an output. The subgraph order query was wrapping input/output token filters in `or`, so orders matching only one side of the pair could enter quote preparation and trigger unrelated oracle context fetches.

## Solution

- Build one subgraph `Order_filter` containing both `inputs_` and `outputs_` filters instead of an `or` filter.
- Update the subgraph query variable type to use the direct filter shape.
- Update the token-filter unit test to assert directional AND behavior.
- Bump `@rainlanguage/orderbook` and `@rainlanguage/ui-components` from `0.0.1-alpha.229` to `0.0.1-alpha.231`.

## Checks

Verified locally:

- `cargo fmt --all --check`
- `nix develop -c cargo test -p rain_orderbook_subgraph_client orderbook_client::order::tests -- --nocapture`
- `nix develop -c rainix-rs-static`
- `nix develop -c npm run build:orderbook`
- `npm run build:ui`
- `npm run lint-format-check:all`

Live repro comparison, using a temporary local test that is not included in this PR:

- Before: 100 fetched orders, 93 non-matching directions, 2 stale `/context` oracle 404s.
- After: 7 fetched orders, 0 non-matching directions, 0 stale oracle 404s, calldata generation returned approval info.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped package versions for orderbook and UI components.
  * Updated preview workflow tooling to a newer Vercel CLI.

* **Refactor**
  * Simplified order-list filtering to use a single filter shape, changing how token filters are combined.

* **Tests**
  * Adjusted a unit test to align with the new filter request shape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->