### PR TITLE
bump rain.interpreter for latest rain.metadata pin

### DIFF
--- a/foundry.lock
+++ b/foundry.lock
@@ -3,7 +3,7 @@
     "rev": "43a6ed3a98f0141e1963b4b9136e8c80e2889bd1"
   },
   "lib/rain.interpreter": {
-    "rev": "2780cdd642398ce4eee4e699363ce100cdc4ef60"
+    "rev": "1ea41cd0ec4a8afd7dec9aeae0a65a55c95fac46"
   },
   "lib/rain.raindex.interface": {
     "rev": "ad4427dcb07e6df95def94999799470db89321b3"


### PR DESCRIPTION
## Summary
- Bumps \`lib/rain.interpreter\` from \`2780cdd\` to \`1ea41cd\` (PR #451 in rain.interpreter, the smallest merge that pulls in latest rain.metadata).
- Transitively bumps \`rain.metadata\` to \`182db23\` (current main HEAD).
- Avoids the Rainterpreter→Rainlang rename cascade in later rain.interpreter commits — no source-level breaking changes.

## rain.metadata changes in scope
- Deterministic subgraph deploy versions (#99, #100).
- Rename OrderBook→Raindex in docs and test data only (#101, #102) — no contract code changes.

## Context
Audit at #2556 / #2557 surfaced that the production polygon metaboard subgraph URL 404s. Bringing raindex up to date with rain.metadata is a precondition for redeploying the polygon metaboard subgraph against the latest indexer.

## Test plan
- [ ] CI green across solidity tests, rust tests, and static checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)