### PR TITLE
fix typo in foundry.lock rain.interpreter rev

### DIFF
--- a/foundry.lock
+++ b/foundry.lock
@@ -3,7 +3,7 @@
     "rev": "43a6ed3a98f0141e1963b4b9136e8c80e2889bd1"
   },
   "lib/rain.interpreter": {
-    "rev": "1ea41cd0ec4a8afd7dec9aeae0a65a55c95fac46"
+    "rev": "1ea41cd004a926e3a964ba5498654f3cd538f139"
   },
   "lib/rain.raindex.interface": {
     "rev": "ad4427dcb07e6df95def94999799470db89321b3"


### PR DESCRIPTION
## Summary
- One-character-pair typo fix in \`foundry.lock\`: \`1ea41cd0ec4a8afd...\` → \`1ea41cd004a926e3...\`.
- The bad SHA does not exist on \`rainlanguage/rain.interpreter\`.
- Submodule pointer in tree was already correct (\`1ea41cd004a926e3...\`), so this is purely a lockfile correction.
- Without it, \`forge update lib/rain.interpreter\` fails with \`fatal: unable to read tree\`.

## How it shipped
Introduced in #2558 — I (Claude) typed the wrong SHA into the Edit despite the correct value being visible in the immediately-preceding tool output, then worked around the resulting \`forge update\` failure with \`git update-index --cacheinfo\` (which fixed the submodule pointer) and didn't notice the lockfile was still wrong.

## Test plan
- [ ] CI green.
- [ ] \`nix develop -c forge update lib/rain.interpreter\` is a no-op on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)