### PR TITLE
feat: add local db sync snapshot endpoint

### DIFF
--- a/crates/common/src/raindex_client/local_db/mod.rs
+++ b/crates/common/src/raindex_client/local_db/mod.rs
@@ -20,14 +20,16 @@ pub mod orders;
 pub mod pipeline;
 pub mod query;
 mod state;
-mod status;
+pub(crate) mod status;
 pub mod transactions;
 pub mod vaults;
 
 pub use state::SyncReadiness;
 pub(crate) use state::{ClassifiedChains, LocalDbState, QuerySource};
 pub use status::{
-    LocalDbStatus, LocalDbStatusSnapshot, NetworkSyncStatus, OrderbookSyncStatus, SchedulerState,
+    LocalDbStatus, LocalDbStatusSnapshot, LocalDbSyncSnapshot, LocalDbSyncStatusStore,
+    NetworkSyncStatus, NetworkSyncStatusSnapshot, OrderbookSyncStatus, OrderbookSyncStatusSnapshot,
+    SchedulerState,
 };
 
 #[cfg(target_family = "wasm")]

--- a/crates/common/src/raindex_client/local_db/pipeline/runner/environment.rs
+++ b/crates/common/src/raindex_client/local_db/pipeline/runner/environment.rs
@@ -7,6 +7,7 @@ use crate::local_db::pipeline::runner::environment::{
 };
 use crate::local_db::pipeline::runner::utils::RunnerTarget;
 use crate::raindex_client::local_db::pipeline::bootstrap::ClientBootstrapAdapter;
+use crate::raindex_client::local_db::LocalDbSyncStatusStore;
 use std::sync::Arc;
 
 #[cfg(target_family = "wasm")]
@@ -16,7 +17,9 @@ use crate::raindex_client::local_db::pipeline::status::ClientStatusBus;
 use crate::raindex_client::local_db::pipeline::status::TracingStatusBus;
 
 #[cfg(target_family = "wasm")]
-pub fn default_environment() -> RunnerEnvironment<
+pub fn default_environment(
+    status_store: LocalDbSyncStatusStore,
+) -> RunnerEnvironment<
     ClientBootstrapAdapter,
     DefaultWindowPipeline,
     DefaultEventsPipeline,
@@ -27,12 +30,15 @@ pub fn default_environment() -> RunnerEnvironment<
     RunnerEnvironment::new(
         default_manifest_fetcher(),
         default_dump_downloader(),
-        Arc::new(|target: &RunnerTarget| {
+        Arc::new(move |target: &RunnerTarget| {
             let events =
                 DefaultEventsPipeline::with_regular_rpcs(target.inputs.metadata_rpcs.clone())?;
             let tokens = DefaultTokensPipeline::new(target.inputs.metadata_rpcs.clone())?;
 
-            let status_bus = ClientStatusBus::with_ob_id(target.inputs.ob_id.clone());
+            let status_bus = ClientStatusBus::with_ob_id_and_store(
+                target.inputs.ob_id.clone(),
+                status_store.clone(),
+            );
 
             Ok(EnginePipelines::new(
                 ClientBootstrapAdapter::new(),
@@ -47,7 +53,9 @@ pub fn default_environment() -> RunnerEnvironment<
 }
 
 #[cfg(not(target_family = "wasm"))]
-pub fn default_environment() -> RunnerEnvironment<
+pub fn default_environment(
+    status_store: LocalDbSyncStatusStore,
+) -> RunnerEnvironment<
     ClientBootstrapAdapter,
     DefaultWindowPipeline,
     DefaultEventsPipeline,
@@ -58,12 +66,15 @@ pub fn default_environment() -> RunnerEnvironment<
     RunnerEnvironment::new(
         default_manifest_fetcher(),
         default_dump_downloader(),
-        Arc::new(|target: &RunnerTarget| {
+        Arc::new(move |target: &RunnerTarget| {
             let events =
                 DefaultEventsPipeline::with_regular_rpcs(target.inputs.metadata_rpcs.clone())?;
             let tokens = DefaultTokensPipeline::new(target.inputs.metadata_rpcs.clone())?;
 
-            let status_bus = TracingStatusBus::with_ob_id(target.inputs.ob_id.clone());
+            let status_bus = TracingStatusBus::with_ob_id_and_store(
+                target.inputs.ob_id.clone(),
+                status_store.clone(),
+            );
 
             Ok(EnginePipelines::new(
                 ClientBootstrapAdapter::new(),
@@ -115,7 +126,8 @@ mod tests {
 
     #[test]
     fn build_engine_uses_regular_rpcs() {
-        let env = default_environment();
+        let env =
+            default_environment(crate::raindex_client::local_db::LocalDbSyncStatusStore::new());
         let target = sample_target(vec![Url::parse("https://rpc.client.example/anvil").unwrap()]);
         let engine = env.build_engine(&target).expect("engine available");
 
@@ -132,7 +144,8 @@ mod tests {
 
     #[test]
     fn build_engine_requires_metadata_rpcs() {
-        let env = default_environment();
+        let env =
+            default_environment(crate::raindex_client::local_db::LocalDbSyncStatusStore::new());
         let target = sample_target(Vec::new());
         match env.build_engine(&target) {
             Err(LocalDbError::Rpc(RpcClientError::Config { message })) => {
@@ -145,7 +158,8 @@ mod tests {
 
     #[test]
     fn build_engine_preserves_rpc_order() {
-        let env = default_environment();
+        let env =
+            default_environment(crate::raindex_client::local_db::LocalDbSyncStatusStore::new());
         let target = sample_target(vec![
             Url::parse("https://alpha.client.example/rpc-one").unwrap(),
             Url::parse("https://beta.client.example/rpc-two").unwrap(),

--- a/crates/common/src/raindex_client/local_db/pipeline/runner/mod.rs
+++ b/crates/common/src/raindex_client/local_db/pipeline/runner/mod.rs
@@ -286,7 +286,8 @@ impl
     >
 {
     pub fn new(settings_yaml: String) -> Result<Self, LocalDbError> {
-        let environment = default_environment();
+        let environment =
+            default_environment(crate::raindex_client::local_db::LocalDbSyncStatusStore::new());
         Self::with_environment(settings_yaml, environment, DefaultLeadership::new())
     }
 }
@@ -304,7 +305,8 @@ impl
     >
 {
     pub fn new(settings_yaml: String) -> Result<Self, LocalDbError> {
-        let environment = default_environment();
+        let environment =
+            default_environment(crate::raindex_client::local_db::LocalDbSyncStatusStore::new());
         Self::with_environment(settings_yaml, environment, DefaultLeadership::new())
     }
 }

--- a/crates/common/src/raindex_client/local_db/pipeline/runner/scheduler/native.rs
+++ b/crates/common/src/raindex_client/local_db/pipeline/runner/scheduler/native.rs
@@ -13,7 +13,10 @@ use crate::local_db::query::LocalDbQueryExecutor;
 use crate::local_db::LocalDbError;
 use crate::raindex_client::local_db::pipeline::bootstrap::ClientBootstrapAdapter;
 use crate::raindex_client::local_db::pipeline::status::TracingStatusBus;
-use crate::raindex_client::local_db::{LocalDb, SyncReadiness};
+use crate::raindex_client::local_db::{
+    LocalDb, LocalDbStatus, LocalDbSyncStatusStore, NetworkSyncStatus, OrderbookSyncStatus,
+    SchedulerState, SyncReadiness,
+};
 use rain_orderbook_app_settings::local_db_manifest::DB_SCHEMA_VERSION;
 use rain_orderbook_app_settings::network::NetworkCfg;
 use std::collections::HashMap;
@@ -50,6 +53,16 @@ impl NativeRunner for NativeClientRunner {
     }
 }
 
+#[derive(Clone)]
+struct NativeNetworkLoopContext {
+    stop_flag: Arc<AtomicBool>,
+    interval_ms: u64,
+    network_key: String,
+    chain_id: u32,
+    sync_readiness: SyncReadiness,
+    status_store: LocalDbSyncStatusStore,
+}
+
 pub struct NativeSyncHandle {
     stop_flag: Arc<AtomicBool>,
     thread_handle: Option<JoinHandle<()>>,
@@ -80,6 +93,7 @@ pub fn start(
     settings: ParsedRunnerSettings,
     db_path: PathBuf,
     sync_readiness: SyncReadiness,
+    status_store: LocalDbSyncStatusStore,
 ) -> Result<NativeSyncHandle, LocalDbError> {
     let mut networks_map: HashMap<String, NetworkCfg> = HashMap::new();
     for ob in settings.orderbooks.values() {
@@ -98,6 +112,7 @@ pub fn start(
 
     let stop_flag = Arc::new(AtomicBool::new(false));
     let stop_flag_clone = Arc::clone(&stop_flag);
+    status_store.seed(&settings);
 
     let thread_handle = thread::spawn(move || {
         let rt = tokio::runtime::Builder::new_current_thread()
@@ -152,7 +167,7 @@ pub fn start(
                         };
 
                         let leadership = DefaultLeadership::with_network_key(network.key.clone());
-                        let environment = default_environment();
+                        let environment = default_environment(status_store.clone());
 
                         let runner = match NativeClientRunner::from_config(
                             config,
@@ -177,11 +192,14 @@ pub fn start(
                         tokio::task::spawn_local(run_network_loop(
                             runner,
                             db_clone,
-                            stop,
-                            interval_ms,
-                            network.key.clone(),
-                            network.chain_id,
-                            sync_readiness.clone(),
+                            NativeNetworkLoopContext {
+                                stop_flag: stop,
+                                interval_ms,
+                                network_key: network.key.clone(),
+                                chain_id: network.chain_id,
+                                sync_readiness: sync_readiness.clone(),
+                                status_store: status_store.clone(),
+                            },
                         ));
                     }
 
@@ -205,13 +223,19 @@ pub fn start(
 async fn run_network_loop<R: NativeRunner>(
     mut runner: R,
     db: LocalDb,
-    stop_flag: Arc<AtomicBool>,
-    interval_ms: u64,
-    network_key: String,
-    chain_id: u32,
-    sync_readiness: SyncReadiness,
+    ctx: NativeNetworkLoopContext,
 ) {
+    let NativeNetworkLoopContext {
+        stop_flag,
+        interval_ms,
+        network_key,
+        chain_id,
+        sync_readiness,
+        status_store,
+    } = ctx;
+
     tracing::info!(network = %network_key, chain_id, "starting native sync loop");
+    status_store.record_network_status(NetworkSyncStatus::syncing(chain_id));
 
     loop {
         if stop_flag.load(Ordering::SeqCst) {
@@ -223,6 +247,11 @@ async fn run_network_loop<R: NativeRunner>(
                 RunOutcome::Report(report) => {
                     if report.failures.is_empty() {
                         sync_readiness.mark_ready(chain_id);
+                        status_store.record_chain_ready(chain_id);
+                        status_store.record_network_status(NetworkSyncStatus::active(
+                            chain_id,
+                            SchedulerState::Leader,
+                        ));
                         tracing::debug!(
                             network = %network_key,
                             chain_id,
@@ -231,6 +260,13 @@ async fn run_network_loop<R: NativeRunner>(
                         );
                     } else {
                         for failure in &report.failures {
+                            let msg = failure.error.to_readable_msg();
+                            status_store.record_orderbook_status(OrderbookSyncStatus::failure(
+                                failure.ob_id.clone(),
+                                msg.clone(),
+                            ));
+                            status_store
+                                .record_network_status(NetworkSyncStatus::failure(chain_id, msg));
                             tracing::warn!(
                                 network = %network_key,
                                 chain_id,
@@ -243,6 +279,10 @@ async fn run_network_loop<R: NativeRunner>(
                     }
                 }
                 RunOutcome::NotLeader => {
+                    status_store.record_network_status(NetworkSyncStatus::active(
+                        chain_id,
+                        SchedulerState::NotLeader,
+                    ));
                     tracing::debug!(
                         network = %network_key,
                         chain_id,
@@ -251,6 +291,12 @@ async fn run_network_loop<R: NativeRunner>(
                 }
             },
             Err(err) => {
+                status_store.record_network_status(NetworkSyncStatus::new(
+                    chain_id,
+                    LocalDbStatus::Failure,
+                    SchedulerState::Leader,
+                    Some(err.to_readable_msg()),
+                ));
                 tracing::error!(
                     network = %network_key,
                     chain_id,
@@ -393,6 +439,7 @@ mod tests {
             settings,
             PathBuf::from("/tmp/test.db"),
             SyncReadiness::new(),
+            LocalDbSyncStatusStore::new(),
         );
         assert!(result.is_err());
     }
@@ -459,11 +506,14 @@ mod tests {
                 tokio::task::spawn_local(run_network_loop(
                     runner,
                     noop_local_db(),
-                    Arc::clone(&stop_flag),
-                    1,
-                    "test".to_string(),
-                    1,
-                    readiness.clone(),
+                    NativeNetworkLoopContext {
+                        stop_flag: Arc::clone(&stop_flag),
+                        interval_ms: 1,
+                        network_key: "test".to_string(),
+                        chain_id: 1,
+                        sync_readiness: readiness.clone(),
+                        status_store: LocalDbSyncStatusStore::new(),
+                    },
                 ));
 
                 tokio::time::sleep(std::time::Duration::from_millis(20)).await;
@@ -498,11 +548,14 @@ mod tests {
                 tokio::task::spawn_local(run_network_loop(
                     runner,
                     noop_local_db(),
-                    Arc::clone(&stop_flag),
-                    1,
-                    "test".to_string(),
-                    1,
-                    readiness.clone(),
+                    NativeNetworkLoopContext {
+                        stop_flag: Arc::clone(&stop_flag),
+                        interval_ms: 1,
+                        network_key: "test".to_string(),
+                        chain_id: 1,
+                        sync_readiness: readiness.clone(),
+                        status_store: LocalDbSyncStatusStore::new(),
+                    },
                 ));
 
                 tokio::time::sleep(std::time::Duration::from_millis(30)).await;
@@ -537,11 +590,14 @@ mod tests {
                 tokio::task::spawn_local(run_network_loop(
                     runner,
                     noop_local_db(),
-                    Arc::clone(&stop_flag),
-                    1,
-                    "test".to_string(),
-                    1,
-                    readiness.clone(),
+                    NativeNetworkLoopContext {
+                        stop_flag: Arc::clone(&stop_flag),
+                        interval_ms: 1,
+                        network_key: "test".to_string(),
+                        chain_id: 1,
+                        sync_readiness: readiness.clone(),
+                        status_store: LocalDbSyncStatusStore::new(),
+                    },
                 ));
 
                 tokio::time::sleep(std::time::Duration::from_millis(30)).await;
@@ -573,11 +629,14 @@ mod tests {
                 tokio::task::spawn_local(run_network_loop(
                     runner,
                     noop_local_db(),
-                    Arc::clone(&stop_flag),
-                    1,
-                    "test".to_string(),
-                    1,
-                    readiness.clone(),
+                    NativeNetworkLoopContext {
+                        stop_flag: Arc::clone(&stop_flag),
+                        interval_ms: 1,
+                        network_key: "test".to_string(),
+                        chain_id: 1,
+                        sync_readiness: readiness.clone(),
+                        status_store: LocalDbSyncStatusStore::new(),
+                    },
                 ));
 
                 tokio::time::sleep(std::time::Duration::from_millis(30)).await;
@@ -615,11 +674,14 @@ mod tests {
                 tokio::task::spawn_local(run_network_loop(
                     runner,
                     noop_local_db(),
-                    Arc::clone(&stop_flag),
-                    1,
-                    "test".to_string(),
-                    1,
-                    readiness.clone(),
+                    NativeNetworkLoopContext {
+                        stop_flag: Arc::clone(&stop_flag),
+                        interval_ms: 1,
+                        network_key: "test".to_string(),
+                        chain_id: 1,
+                        sync_readiness: readiness.clone(),
+                        status_store: LocalDbSyncStatusStore::new(),
+                    },
                 ));
 
                 tokio::time::sleep(std::time::Duration::from_millis(20)).await;
@@ -653,11 +715,14 @@ mod tests {
                 tokio::task::spawn_local(run_network_loop(
                     runner,
                     noop_local_db(),
-                    stop_clone,
-                    10000,
-                    "test".to_string(),
-                    1,
-                    readiness.clone(),
+                    NativeNetworkLoopContext {
+                        stop_flag: stop_clone,
+                        interval_ms: 10000,
+                        network_key: "test".to_string(),
+                        chain_id: 1,
+                        sync_readiness: readiness.clone(),
+                        status_store: LocalDbSyncStatusStore::new(),
+                    },
                 ));
 
                 for _ in 0..200 {

--- a/crates/common/src/raindex_client/local_db/pipeline/runner/scheduler/wasm.rs
+++ b/crates/common/src/raindex_client/local_db/pipeline/runner/scheduler/wasm.rs
@@ -14,7 +14,10 @@ use crate::raindex_client::local_db::pipeline::bootstrap::ClientBootstrapAdapter
 use crate::raindex_client::local_db::pipeline::status::{
     set_scheduler_state, set_status_callback, ClientStatusBus,
 };
-use crate::raindex_client::local_db::{LocalDb, NetworkSyncStatus, SchedulerState, SyncReadiness};
+use crate::raindex_client::local_db::{
+    LocalDb, LocalDbSyncStatusStore, NetworkSyncStatus, OrderbookSyncStatus, SchedulerState,
+    SyncReadiness,
+};
 use gloo_timers::future::TimeoutFuture;
 use js_sys::Function;
 use rain_orderbook_app_settings::local_db_manifest::DB_SCHEMA_VERSION;
@@ -84,6 +87,7 @@ pub(crate) fn start(
     db: LocalDb,
     status_callback: Option<Function>,
     sync_readiness: SyncReadiness,
+    status_store: LocalDbSyncStatusStore,
 ) -> Result<SchedulerHandle, LocalDbError> {
     let mut networks_map: HashMap<String, NetworkCfg> = HashMap::new();
     for ob in settings.orderbooks.values() {
@@ -102,6 +106,7 @@ pub(crate) fn start(
 
     let stop_flag = Rc::new(Cell::new(false));
     let callback = status_callback.map(Rc::new);
+    status_store.seed(&settings);
 
     let bootstrap = ClientBootstrapAdapter::new();
     let db_clone = db.clone();
@@ -120,6 +125,7 @@ pub(crate) fn start(
         {
             for network in &networks_for_spawn {
                 emit_network_status(
+                    &status_store,
                     callback.as_deref(),
                     NetworkSyncStatus::failure(network.chain_id, err.to_readable_msg()),
                 );
@@ -135,6 +141,7 @@ pub(crate) fn start(
                     Ok(config) => config,
                     Err(err) => {
                         emit_network_status(
+                            &status_store,
                             callback.as_deref(),
                             NetworkSyncStatus::failure(network.chain_id, err.to_readable_msg()),
                         );
@@ -143,12 +150,13 @@ pub(crate) fn start(
                 };
 
             let leadership = DefaultLeadership::with_network_key(network.key.clone());
-            let environment = default_environment();
+            let environment = default_environment(status_store.clone());
 
             let runner = match ClientRunner::from_config(config.clone(), environment, leadership) {
                 Ok(r) => r,
                 Err(err) => {
                     emit_network_status(
+                        &status_store,
                         callback.as_deref(),
                         NetworkSyncStatus::failure(network.chain_id, err.to_readable_msg()),
                     );
@@ -160,6 +168,7 @@ pub(crate) fn start(
                 Some(sync_cfg) => sync_cfg.sync_interval_ms as u32,
                 None => {
                     emit_network_status(
+                        &status_store,
                         callback.as_deref(),
                         NetworkSyncStatus::failure(
                             network.chain_id,
@@ -180,6 +189,7 @@ pub(crate) fn start(
                 Rc::clone(&stop_flag_init),
                 interval_ms,
                 sync_readiness.clone(),
+                status_store.clone(),
             );
         }
     });
@@ -197,11 +207,21 @@ fn spawn_network_loop<R>(
     stop_flag: Rc<Cell<bool>>,
     interval_ms: u32,
     sync_readiness: SyncReadiness,
+    status_store: LocalDbSyncStatusStore,
 ) where
     R: SchedulerRunner + 'static,
 {
     spawn_local(async move {
-        run_network_loop(runner, db, callback, stop_flag, interval_ms, sync_readiness).await;
+        run_network_loop(
+            runner,
+            db,
+            callback,
+            stop_flag,
+            interval_ms,
+            sync_readiness,
+            status_store,
+        )
+        .await;
     });
 }
 
@@ -212,13 +232,18 @@ async fn run_network_loop<R>(
     stop_flag: Rc<Cell<bool>>,
     interval_ms: u32,
     sync_readiness: SyncReadiness,
+    status_store: LocalDbSyncStatusStore,
 ) where
     R: SchedulerRunner + 'static,
 {
     let chain_id = runner.chain_id().unwrap_or(0);
     let mut was_leader_last_cycle = false;
 
-    emit_network_status(callback.as_deref(), NetworkSyncStatus::syncing(chain_id));
+    emit_network_status(
+        &status_store,
+        callback.as_deref(),
+        NetworkSyncStatus::syncing(chain_id),
+    );
 
     loop {
         if stop_flag.get() {
@@ -226,7 +251,11 @@ async fn run_network_loop<R>(
         }
 
         if was_leader_last_cycle {
-            emit_network_status(callback.as_deref(), NetworkSyncStatus::syncing(chain_id));
+            emit_network_status(
+                &status_store,
+                callback.as_deref(),
+                NetworkSyncStatus::syncing(chain_id),
+            );
         }
 
         match runner.run_once(&db).await {
@@ -237,7 +266,9 @@ async fn run_network_loop<R>(
 
                     if report.failures.is_empty() {
                         sync_readiness.mark_ready(chain_id);
+                        status_store.record_chain_ready(chain_id);
                         emit_network_status(
+                            &status_store,
                             callback.as_deref(),
                             NetworkSyncStatus::active(chain_id, SchedulerState::Leader),
                         );
@@ -249,7 +280,12 @@ async fn run_network_loop<R>(
                             first.stage,
                             first.error.to_readable_msg()
                         );
+                        status_store.record_orderbook_status(OrderbookSyncStatus::failure(
+                            first.ob_id.clone(),
+                            msg.clone(),
+                        ));
                         emit_network_status(
+                            &status_store,
                             callback.as_deref(),
                             NetworkSyncStatus::failure(chain_id, msg),
                         );
@@ -259,6 +295,7 @@ async fn run_network_loop<R>(
                     was_leader_last_cycle = false;
                     set_scheduler_state(SchedulerState::NotLeader);
                     emit_network_status(
+                        &status_store,
                         callback.as_deref(),
                         NetworkSyncStatus::active(chain_id, SchedulerState::NotLeader),
                     );
@@ -267,6 +304,7 @@ async fn run_network_loop<R>(
             Err(err) => {
                 was_leader_last_cycle = true;
                 emit_network_status(
+                    &status_store,
                     callback.as_deref(),
                     NetworkSyncStatus::failure(chain_id, err.to_readable_msg()),
                 );
@@ -281,7 +319,12 @@ async fn run_network_loop<R>(
     }
 }
 
-fn emit_network_status(callback: Option<&Function>, status: NetworkSyncStatus) {
+fn emit_network_status(
+    status_store: &LocalDbSyncStatusStore,
+    callback: Option<&Function>,
+    status: NetworkSyncStatus,
+) {
+    status_store.record_network_status(status.clone());
     if let Some(callback) = callback {
         if let Ok(value) = serde_wasm_bindgen::to_value(&status) {
             let _ = callback.call1(&JsValue::NULL, &value);
@@ -411,6 +454,7 @@ mod wasm_tests {
             Rc::clone(&stop_flag),
             1,
             SyncReadiness::new(),
+            LocalDbSyncStatusStore::new(),
         );
 
         TimeoutFuture::new(0).await;
@@ -442,6 +486,7 @@ mod wasm_tests {
             Rc::clone(&stop_flag),
             1,
             SyncReadiness::new(),
+            LocalDbSyncStatusStore::new(),
         );
 
         TimeoutFuture::new(0).await;
@@ -486,6 +531,7 @@ mod wasm_tests {
             Rc::clone(&stop_flag),
             1,
             SyncReadiness::new(),
+            LocalDbSyncStatusStore::new(),
         );
 
         TimeoutFuture::new(0).await;
@@ -540,6 +586,7 @@ mod wasm_tests {
             Rc::clone(&stop_flag),
             1,
             SyncReadiness::new(),
+            LocalDbSyncStatusStore::new(),
         );
 
         TimeoutFuture::new(0).await;
@@ -605,6 +652,7 @@ mod wasm_tests {
             Rc::clone(&stop_flag),
             1,
             SyncReadiness::new(),
+            LocalDbSyncStatusStore::new(),
         );
 
         TimeoutFuture::new(0).await;
@@ -676,8 +724,14 @@ mod wasm_tests {
 
         let yaml = get_local_db_test_yaml();
         let settings = parse_runner_settings(&yaml).expect("should parse valid yaml");
-        let handle = start(settings, noop_local_db(), None, SyncReadiness::new())
-            .expect("should start with valid yaml");
+        let handle = start(
+            settings,
+            noop_local_db(),
+            None,
+            SyncReadiness::new(),
+            LocalDbSyncStatusStore::new(),
+        )
+        .expect("should start with valid yaml");
 
         handle.stop();
 
@@ -707,6 +761,7 @@ mod wasm_tests {
             Rc::clone(&stop_flag),
             1,
             SyncReadiness::new(),
+            LocalDbSyncStatusStore::new(),
         );
         spawn_network_loop(
             fast_runner,
@@ -715,6 +770,7 @@ mod wasm_tests {
             Rc::clone(&stop_flag),
             1,
             SyncReadiness::new(),
+            LocalDbSyncStatusStore::new(),
         );
 
         TimeoutFuture::new(0).await;

--- a/crates/common/src/raindex_client/local_db/pipeline/status/native.rs
+++ b/crates/common/src/raindex_client/local_db/pipeline/status/native.rs
@@ -1,10 +1,12 @@
 use crate::local_db::pipeline::{StatusBus, SyncPhase};
 use crate::local_db::{LocalDbError, OrderbookIdentifier};
+use crate::raindex_client::local_db::{LocalDbSyncStatusStore, OrderbookSyncStatus};
 
 #[derive(Debug, Clone, Default)]
 pub struct TracingStatusBus {
     ob_id: Option<OrderbookIdentifier>,
     orderbook_key: Option<String>,
+    status_store: LocalDbSyncStatusStore,
 }
 
 impl TracingStatusBus {
@@ -12,13 +14,22 @@ impl TracingStatusBus {
         Self {
             ob_id: None,
             orderbook_key: None,
+            status_store: LocalDbSyncStatusStore::new(),
         }
     }
 
     pub fn with_ob_id(ob_id: OrderbookIdentifier) -> Self {
+        Self::with_ob_id_and_store(ob_id, LocalDbSyncStatusStore::new())
+    }
+
+    pub fn with_ob_id_and_store(
+        ob_id: OrderbookIdentifier,
+        status_store: LocalDbSyncStatusStore,
+    ) -> Self {
         Self {
             ob_id: Some(ob_id),
             orderbook_key: None,
+            status_store,
         }
     }
 
@@ -26,6 +37,7 @@ impl TracingStatusBus {
         Self {
             ob_id: Some(ob_id),
             orderbook_key: Some(key),
+            status_store: LocalDbSyncStatusStore::new(),
         }
     }
 }
@@ -48,6 +60,11 @@ impl StatusBus for TracingStatusBus {
             phase = %phase.to_message(),
             "sync phase"
         );
+
+        if let Some(ob_id) = &self.ob_id {
+            self.status_store
+                .record_orderbook_status(OrderbookSyncStatus::syncing(ob_id.clone(), phase));
+        }
 
         Ok(())
     }

--- a/crates/common/src/raindex_client/local_db/pipeline/status/wasm.rs
+++ b/crates/common/src/raindex_client/local_db/pipeline/status/wasm.rs
@@ -1,6 +1,8 @@
 use crate::local_db::pipeline::{StatusBus, SyncPhase};
 use crate::local_db::{LocalDbError, OrderbookIdentifier};
-use crate::raindex_client::local_db::{OrderbookSyncStatus, SchedulerState};
+use crate::raindex_client::local_db::{
+    LocalDbSyncStatusStore, OrderbookSyncStatus, SchedulerState,
+};
 use js_sys::Function;
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -40,18 +42,33 @@ fn emit_to_callback(status: OrderbookSyncStatus) {
 #[derive(Debug, Clone, Default)]
 pub struct ClientStatusBus {
     ob_id: Option<OrderbookIdentifier>,
+    status_store: LocalDbSyncStatusStore,
 }
 
 impl ClientStatusBus {
     pub fn new() -> Self {
-        Self { ob_id: None }
+        Self {
+            ob_id: None,
+            status_store: LocalDbSyncStatusStore::new(),
+        }
     }
 
     pub fn with_ob_id(ob_id: OrderbookIdentifier) -> Self {
-        Self { ob_id: Some(ob_id) }
+        Self::with_ob_id_and_store(ob_id, LocalDbSyncStatusStore::new())
+    }
+
+    pub fn with_ob_id_and_store(
+        ob_id: OrderbookIdentifier,
+        status_store: LocalDbSyncStatusStore,
+    ) -> Self {
+        Self {
+            ob_id: Some(ob_id),
+            status_store,
+        }
     }
 
     fn emit(&self, status: OrderbookSyncStatus) {
+        self.status_store.record_orderbook_status(status.clone());
         emit_to_callback(status);
     }
 

--- a/crates/common/src/raindex_client/local_db/state.rs
+++ b/crates/common/src/raindex_client/local_db/state.rs
@@ -1,4 +1,4 @@
-use super::LocalDb;
+use super::{LocalDb, LocalDbSyncStatusStore};
 #[cfg(not(target_family = "wasm"))]
 use crate::raindex_client::local_db::pipeline::runner::scheduler::NativeSyncHandle;
 #[cfg(target_family = "wasm")]
@@ -32,6 +32,7 @@ pub(crate) struct LocalDbState {
     pub(crate) scheduler: Arc<Mutex<Option<NativeSyncHandle>>>,
     pub(crate) sync_readiness: SyncReadiness,
     pub(crate) sync_configured_chains: HashSet<u32>,
+    pub(crate) sync_status_store: LocalDbSyncStatusStore,
 }
 
 impl Default for LocalDbState {
@@ -47,6 +48,7 @@ impl Default for LocalDbState {
             scheduler: Arc::new(Mutex::new(None)),
             sync_readiness: SyncReadiness::new(),
             sync_configured_chains: HashSet::new(),
+            sync_status_store: LocalDbSyncStatusStore::new(),
         }
     }
 }
@@ -58,12 +60,14 @@ impl LocalDbState {
         scheduler: Rc<RefCell<Option<SchedulerHandle>>>,
         sync_readiness: SyncReadiness,
         sync_configured_chains: HashSet<u32>,
+        sync_status_store: LocalDbSyncStatusStore,
     ) -> Self {
         Self {
             db: Rc::new(RefCell::new(db)),
             scheduler,
             sync_readiness,
             sync_configured_chains,
+            sync_status_store,
         }
     }
 
@@ -79,12 +83,14 @@ impl LocalDbState {
         scheduler: Arc<Mutex<Option<NativeSyncHandle>>>,
         sync_readiness: SyncReadiness,
         sync_configured_chains: HashSet<u32>,
+        sync_status_store: LocalDbSyncStatusStore,
     ) -> Self {
         Self {
             db: Arc::new(Mutex::new(db)),
             scheduler,
             sync_readiness,
             sync_configured_chains,
+            sync_status_store,
         }
     }
 
@@ -125,6 +131,10 @@ impl LocalDbState {
             }
         }
         QuerySource::Subgraph
+    }
+
+    pub(crate) fn local_db(&self) -> Option<LocalDb> {
+        self.db()
     }
 
     pub(crate) fn classify_chains(&self, networks: &[NetworkCfg]) -> ClassifiedChains {
@@ -273,6 +283,7 @@ mod tests {
             Arc::new(Mutex::new(None)),
             readiness,
             configured.iter().copied().collect(),
+            LocalDbSyncStatusStore::new(),
         )
     }
 

--- a/crates/common/src/raindex_client/local_db/status.rs
+++ b/crates/common/src/raindex_client/local_db/status.rs
@@ -1,6 +1,9 @@
+use crate::local_db::pipeline::runner::utils::ParsedRunnerSettings;
 use crate::local_db::pipeline::SyncPhase;
 use crate::local_db::OrderbookIdentifier;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
 use tsify::Tsify;
 use wasm_bindgen_utils::{impl_wasm_traits, prelude::*};
 
@@ -149,6 +152,317 @@ impl LocalDbStatusSnapshot {
 
     pub fn failure(error: String) -> Self {
         Self::new(LocalDbStatus::Failure, Some(error))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Tsify)]
+#[serde(rename_all = "camelCase")]
+pub struct NetworkSyncStatusSnapshot {
+    pub chain_id: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub network_key: Option<String>,
+    pub status: LocalDbStatus,
+    pub scheduler_state: SchedulerState,
+    pub orderbook_count: usize,
+    pub ready: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+impl_wasm_traits!(NetworkSyncStatusSnapshot);
+
+impl NetworkSyncStatusSnapshot {
+    pub fn new(chain_id: u32, network_key: Option<String>) -> Self {
+        Self {
+            chain_id,
+            network_key,
+            status: LocalDbStatus::Syncing,
+            scheduler_state: SchedulerState::Leader,
+            orderbook_count: 0,
+            ready: false,
+            error: None,
+        }
+    }
+
+    pub fn apply_status(&mut self, status: NetworkSyncStatus) {
+        self.status = status.status;
+        self.scheduler_state = status.scheduler_state;
+        self.error = status.error;
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Tsify)]
+#[serde(rename_all = "camelCase")]
+pub struct OrderbookSyncStatusSnapshot {
+    pub ob_id: OrderbookIdentifier,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub orderbook_key: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub network_key: Option<String>,
+    pub status: LocalDbStatus,
+    pub scheduler_state: SchedulerState,
+    pub ready: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub phase_message: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_synced_block: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+impl_wasm_traits!(OrderbookSyncStatusSnapshot);
+
+impl OrderbookSyncStatusSnapshot {
+    pub fn new(
+        ob_id: OrderbookIdentifier,
+        orderbook_key: Option<String>,
+        network_key: Option<String>,
+    ) -> Self {
+        Self {
+            ob_id,
+            orderbook_key,
+            network_key,
+            status: LocalDbStatus::Syncing,
+            scheduler_state: SchedulerState::Leader,
+            ready: false,
+            phase_message: None,
+            last_synced_block: None,
+            updated_at: None,
+            error: None,
+        }
+    }
+
+    pub fn apply_status(&mut self, status: OrderbookSyncStatus) {
+        self.status = status.status;
+        self.scheduler_state = status.scheduler_state;
+        self.phase_message = status.phase_message;
+        self.error = status.error;
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Tsify)]
+#[serde(rename_all = "camelCase")]
+pub struct LocalDbSyncSnapshot {
+    pub configured: bool,
+    pub healthy: bool,
+    pub status: LocalDbStatus,
+    pub scheduler_state: SchedulerState,
+    pub networks: Vec<NetworkSyncStatusSnapshot>,
+    pub orderbooks: Vec<OrderbookSyncStatusSnapshot>,
+}
+impl_wasm_traits!(LocalDbSyncSnapshot);
+
+impl LocalDbSyncSnapshot {
+    pub fn not_configured() -> Self {
+        Self {
+            configured: false,
+            healthy: true,
+            status: LocalDbStatus::Active,
+            scheduler_state: SchedulerState::Leader,
+            networks: Vec::new(),
+            orderbooks: Vec::new(),
+        }
+    }
+
+    pub fn from_parts(
+        mut networks: Vec<NetworkSyncStatusSnapshot>,
+        mut orderbooks: Vec<OrderbookSyncStatusSnapshot>,
+    ) -> Self {
+        networks.sort_by_key(|network| network.chain_id);
+        orderbooks.sort_by(|a, b| {
+            (a.ob_id.chain_id, a.ob_id.orderbook_address)
+                .cmp(&(b.ob_id.chain_id, b.ob_id.orderbook_address))
+        });
+
+        let configured = !networks.is_empty() || !orderbooks.is_empty();
+        let all_statuses = networks
+            .iter()
+            .map(|network| network.status)
+            .chain(orderbooks.iter().map(|orderbook| orderbook.status))
+            .collect::<Vec<_>>();
+
+        let has_failure = all_statuses.contains(&LocalDbStatus::Failure);
+        let has_syncing = all_statuses.contains(&LocalDbStatus::Syncing);
+        let scheduler_state = networks
+            .iter()
+            .find_map(|network| {
+                (network.scheduler_state == SchedulerState::NotLeader)
+                    .then_some(SchedulerState::NotLeader)
+            })
+            .unwrap_or(SchedulerState::Leader);
+
+        let status = if !configured {
+            LocalDbStatus::Active
+        } else if has_failure {
+            LocalDbStatus::Failure
+        } else if has_syncing {
+            LocalDbStatus::Syncing
+        } else {
+            LocalDbStatus::Active
+        };
+
+        Self {
+            configured,
+            healthy: !has_failure,
+            status,
+            scheduler_state,
+            networks,
+            orderbooks,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct LocalDbSyncSnapshotStore {
+    networks: HashMap<u32, NetworkSyncStatusSnapshot>,
+    orderbooks: HashMap<OrderbookIdentifier, OrderbookSyncStatusSnapshot>,
+}
+
+impl LocalDbSyncSnapshotStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn seed_network(&mut self, chain_id: u32, network_key: Option<String>) {
+        self.networks
+            .entry(chain_id)
+            .or_insert_with(|| NetworkSyncStatusSnapshot::new(chain_id, network_key));
+    }
+
+    pub fn seed_orderbook(
+        &mut self,
+        ob_id: OrderbookIdentifier,
+        orderbook_key: Option<String>,
+        network_key: Option<String>,
+    ) {
+        let chain_id = ob_id.chain_id;
+        self.orderbooks
+            .entry(ob_id.clone())
+            .or_insert_with(|| OrderbookSyncStatusSnapshot::new(ob_id, orderbook_key, network_key));
+        if let Some(network) = self.networks.get_mut(&chain_id) {
+            network.orderbook_count = self
+                .orderbooks
+                .values()
+                .filter(|orderbook| orderbook.ob_id.chain_id == chain_id)
+                .count();
+        }
+    }
+
+    pub fn update_network(&mut self, status: NetworkSyncStatus) {
+        self.networks
+            .entry(status.chain_id)
+            .or_insert_with(|| NetworkSyncStatusSnapshot::new(status.chain_id, None))
+            .apply_status(status);
+    }
+
+    pub fn update_orderbook(&mut self, status: OrderbookSyncStatus) {
+        self.orderbooks
+            .entry(status.ob_id.clone())
+            .or_insert_with(|| OrderbookSyncStatusSnapshot::new(status.ob_id.clone(), None, None))
+            .apply_status(status);
+    }
+
+    pub fn mark_ready(&mut self, chain_id: u32) {
+        if let Some(network) = self.networks.get_mut(&chain_id) {
+            network.ready = true;
+            if network.status != LocalDbStatus::Failure {
+                network.status = LocalDbStatus::Active;
+            }
+        }
+        for orderbook in self.orderbooks.values_mut() {
+            if orderbook.ob_id.chain_id == chain_id {
+                orderbook.ready = true;
+                if orderbook.status != LocalDbStatus::Failure {
+                    orderbook.status = LocalDbStatus::Active;
+                    orderbook.phase_message = None;
+                }
+            }
+        }
+    }
+
+    pub fn snapshot(&self) -> LocalDbSyncSnapshot {
+        LocalDbSyncSnapshot::from_parts(
+            self.networks.values().cloned().collect(),
+            self.orderbooks.values().cloned().collect(),
+        )
+    }
+}
+
+type StoreRef = Arc<Mutex<LocalDbSyncSnapshotStore>>;
+
+#[derive(Debug, Clone)]
+pub struct LocalDbSyncStatusStore {
+    inner: StoreRef,
+}
+
+impl Default for LocalDbSyncStatusStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LocalDbSyncStatusStore {
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(LocalDbSyncSnapshotStore::new())),
+        }
+    }
+
+    fn with_store<T>(&self, f: impl FnOnce(&mut LocalDbSyncSnapshotStore) -> T) -> T {
+        let mut store = self
+            .inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        f(&mut store)
+    }
+
+    pub fn reset(&self) {
+        self.with_store(|store| {
+            *store = LocalDbSyncSnapshotStore::new();
+        });
+    }
+
+    pub fn seed(&self, settings: &ParsedRunnerSettings) {
+        self.with_store(|store| {
+            *store = LocalDbSyncSnapshotStore::new();
+            let mut orderbooks = settings.orderbooks.iter().collect::<Vec<_>>();
+            orderbooks.sort_by(|a, b| a.0.cmp(b.0));
+            for (orderbook_key, orderbook) in orderbooks {
+                if !settings.syncs.contains_key(&orderbook.network.key) {
+                    continue;
+                }
+                let chain_id = orderbook.network.chain_id;
+                let network_key = orderbook.network.key.clone();
+                store.seed_network(chain_id, Some(network_key.clone()));
+                store.seed_orderbook(
+                    OrderbookIdentifier::new(chain_id, orderbook.address),
+                    Some(orderbook_key.clone()),
+                    Some(network_key),
+                );
+            }
+        });
+    }
+
+    pub fn record_network_status(&self, status: NetworkSyncStatus) {
+        self.with_store(|store| {
+            store.update_network(status);
+        });
+    }
+
+    pub fn record_orderbook_status(&self, status: OrderbookSyncStatus) {
+        self.with_store(|store| {
+            store.update_orderbook(status);
+        });
+    }
+
+    pub fn record_chain_ready(&self, chain_id: u32) {
+        self.with_store(|store| {
+            store.mark_ready(chain_id);
+        });
+    }
+
+    pub fn snapshot(&self) -> LocalDbSyncSnapshot {
+        self.with_store(|store| store.snapshot())
     }
 }
 
@@ -351,5 +665,144 @@ mod tests {
         let failure = LocalDbStatusSnapshot::failure("test error".to_string());
         assert_eq!(failure.status, LocalDbStatus::Failure);
         assert_eq!(failure.error, Some("test error".to_string()));
+    }
+
+    #[test]
+    fn sync_snapshot_reports_not_configured_when_empty() {
+        let snapshot = LocalDbSyncSnapshot::from_parts(Vec::new(), Vec::new());
+
+        assert!(!snapshot.configured);
+        assert!(snapshot.healthy);
+        assert_eq!(snapshot.status, LocalDbStatus::Active);
+        assert!(snapshot.networks.is_empty());
+        assert!(snapshot.orderbooks.is_empty());
+    }
+
+    #[test]
+    fn sync_snapshot_failure_dominates_over_syncing() {
+        use alloy::primitives::address;
+
+        let network = NetworkSyncStatusSnapshot {
+            chain_id: 1,
+            network_key: Some("mainnet".to_string()),
+            status: LocalDbStatus::Syncing,
+            scheduler_state: SchedulerState::Leader,
+            orderbook_count: 1,
+            ready: false,
+            error: None,
+        };
+        let orderbook = OrderbookSyncStatusSnapshot {
+            ob_id: crate::local_db::OrderbookIdentifier::new(
+                1,
+                address!("0000000000000000000000000000000000001234"),
+            ),
+            orderbook_key: Some("ob".to_string()),
+            network_key: Some("mainnet".to_string()),
+            status: LocalDbStatus::Failure,
+            scheduler_state: SchedulerState::Leader,
+            ready: false,
+            phase_message: None,
+            last_synced_block: Some(100),
+            updated_at: Some("2026-05-01 10:00:00".to_string()),
+            error: Some("boom".to_string()),
+        };
+
+        let snapshot = LocalDbSyncSnapshot::from_parts(vec![network], vec![orderbook]);
+
+        assert!(snapshot.configured);
+        assert!(!snapshot.healthy);
+        assert_eq!(snapshot.status, LocalDbStatus::Failure);
+    }
+
+    #[test]
+    fn sync_snapshot_store_marks_chain_ready() {
+        use alloy::primitives::address;
+
+        let mut store = LocalDbSyncSnapshotStore::new();
+        let ob_id = crate::local_db::OrderbookIdentifier::new(
+            42161,
+            address!("0000000000000000000000000000000000001234"),
+        );
+        store.seed_network(42161, Some("arbitrum".to_string()));
+        store.seed_orderbook(
+            ob_id.clone(),
+            Some("main-ob".to_string()),
+            Some("arbitrum".to_string()),
+        );
+
+        let syncing = store.snapshot();
+        assert_eq!(syncing.status, LocalDbStatus::Syncing);
+        assert!(!syncing.networks[0].ready);
+        assert!(!syncing.orderbooks[0].ready);
+        assert_eq!(syncing.networks[0].orderbook_count, 1);
+
+        store.mark_ready(42161);
+        let ready = store.snapshot();
+
+        assert_eq!(ready.status, LocalDbStatus::Active);
+        assert!(ready.networks[0].ready);
+        assert!(ready.orderbooks[0].ready);
+        assert_eq!(ready.orderbooks[0].ob_id, ob_id);
+    }
+
+    #[test]
+    fn sync_snapshot_store_updates_live_network_and_orderbook_statuses() {
+        use crate::local_db::pipeline::SyncPhase;
+        use alloy::primitives::address;
+
+        let mut store = LocalDbSyncSnapshotStore::new();
+        let ob_id = crate::local_db::OrderbookIdentifier::new(
+            1,
+            address!("0000000000000000000000000000000000000001"),
+        );
+        store.seed_network(1, Some("mainnet".to_string()));
+        store.seed_orderbook(
+            ob_id.clone(),
+            Some("main-ob".to_string()),
+            Some("mainnet".to_string()),
+        );
+
+        store.update_network(NetworkSyncStatus::active(1, SchedulerState::NotLeader));
+        store.update_orderbook(OrderbookSyncStatus::syncing(
+            ob_id.clone(),
+            SyncPhase::FetchingOrderbookLogs,
+        ));
+
+        let snapshot = store.snapshot();
+        assert_eq!(snapshot.status, LocalDbStatus::Syncing);
+        assert_eq!(snapshot.scheduler_state, SchedulerState::NotLeader);
+        assert_eq!(snapshot.networks[0].status, LocalDbStatus::Active);
+        assert_eq!(
+            snapshot.orderbooks[0].phase_message,
+            Some("Fetching orderbook logs".to_string())
+        );
+
+        store.update_orderbook(OrderbookSyncStatus::failure(
+            ob_id,
+            "rpc failed".to_string(),
+        ));
+        let failed = store.snapshot();
+        assert_eq!(failed.status, LocalDbStatus::Failure);
+        assert!(!failed.healthy);
+        assert_eq!(failed.orderbooks[0].error, Some("rpc failed".to_string()));
+    }
+
+    #[test]
+    fn sync_status_store_clones_share_state_but_new_stores_are_isolated() {
+        let first = LocalDbSyncStatusStore::new();
+        let first_clone = first.clone();
+        let second = LocalDbSyncStatusStore::new();
+
+        first.record_network_status(NetworkSyncStatus::syncing(1));
+
+        let cloned_snapshot = first_clone.snapshot();
+        assert!(cloned_snapshot.configured);
+        assert_eq!(cloned_snapshot.networks.len(), 1);
+        assert_eq!(cloned_snapshot.networks[0].chain_id, 1);
+        assert_eq!(cloned_snapshot.status, LocalDbStatus::Syncing);
+
+        let second_snapshot = second.snapshot();
+        assert!(!second_snapshot.configured);
+        assert!(second_snapshot.networks.is_empty());
     }
 }

--- a/crates/common/src/raindex_client/mod.rs
+++ b/crates/common/src/raindex_client/mod.rs
@@ -1,5 +1,13 @@
-use crate::local_db::{query::LocalDbQueryError, LocalDbError};
-use crate::raindex_client::local_db::{LocalDb, SyncReadiness};
+use crate::local_db::{
+    query::{
+        fetch_last_synced_block::{fetch_last_synced_block_stmt, SyncStatusResponse},
+        LocalDbQueryError, LocalDbQueryExecutor,
+    },
+    LocalDbError,
+};
+use crate::raindex_client::local_db::{
+    LocalDb, LocalDbSyncSnapshot, LocalDbSyncStatusStore, SyncReadiness,
+};
 use crate::{
     add_order::AddOrderArgsError, deposit::DepositError, dotrain_order::DotrainOrderError,
     meta::TryDecodeRainlangSourceError, transaction::WritableTransactionExecuteError,
@@ -163,7 +171,11 @@ impl RaindexClient {
 
         let sync_configured_chains = LocalDbState::compute_chain_ids(&orderbook_yaml);
         let sync_readiness = SyncReadiness::new();
+        let sync_status_store = LocalDbSyncStatusStore::new();
         let has_syncs = !sync_configured_chains.is_empty();
+        if !has_syncs {
+            sync_status_store.reset();
+        }
 
         let local_db = if has_syncs {
             let cb = query_callback
@@ -186,6 +198,7 @@ impl RaindexClient {
                 db,
                 status_callback,
                 sync_readiness.clone(),
+                sync_status_store.clone(),
             )?;
             Rc::new(RefCell::new(Some(handle)))
         } else {
@@ -201,6 +214,7 @@ impl RaindexClient {
                 scheduler,
                 sync_readiness,
                 sync_configured_chains,
+                sync_status_store,
             ),
         })
     }
@@ -282,6 +296,44 @@ impl RaindexClient {
         let networks = self.resolve_networks(chain_ids)?;
         Ok(self.local_db_state.classify_chains(&networks))
     }
+
+    /// Returns the latest known local DB sync status snapshot.
+    ///
+    /// The live status fields are maintained by the sync scheduler as it emits
+    /// status updates. When a local DB handle is available, persisted
+    /// `lastSyncedBlock` watermark information is added per orderbook.
+    #[wasm_export(
+        js_name = "getLocalDbSyncSnapshot",
+        return_description = "Latest local DB sync status snapshot"
+    )]
+    pub async fn get_local_db_sync_snapshot(&self) -> Result<LocalDbSyncSnapshot, RaindexError> {
+        let mut snapshot = self.local_db_state.sync_status_store.snapshot();
+        let Some(db) = self.local_db_state.local_db() else {
+            return Ok(snapshot);
+        };
+
+        for orderbook in &mut snapshot.orderbooks {
+            let stmt = fetch_last_synced_block_stmt(&orderbook.ob_id);
+            match db.query_json::<Vec<SyncStatusResponse>>(&stmt).await {
+                Ok(rows) => {
+                    if let Some(row) = rows.into_iter().next() {
+                        orderbook.last_synced_block = Some(row.last_synced_block);
+                        orderbook.updated_at = row.updated_at;
+                    }
+                }
+                Err(err) => {
+                    tracing::debug!(
+                        chain_id = orderbook.ob_id.chain_id,
+                        orderbook = %format!("{:#x}", orderbook.ob_id.orderbook_address),
+                        error = %err,
+                        "failed to read local DB sync watermark for snapshot"
+                    );
+                }
+            }
+        }
+
+        Ok(snapshot)
+    }
 }
 
 #[cfg(not(target_family = "wasm"))]
@@ -302,7 +354,11 @@ impl RaindexClient {
 
         let sync_configured_chains = LocalDbState::compute_chain_ids(&orderbook_yaml);
         let sync_readiness = SyncReadiness::new();
+        let sync_status_store = LocalDbSyncStatusStore::new();
         let has_syncs = !sync_configured_chains.is_empty();
+        if !has_syncs {
+            sync_status_store.reset();
+        }
 
         let (local_db, scheduler) = if has_syncs {
             let path =
@@ -315,6 +371,7 @@ impl RaindexClient {
                 settings,
                 path.clone(),
                 sync_readiness.clone(),
+                sync_status_store.clone(),
             )?;
             let executor = crate::local_db::executor::RusqliteExecutor::new(&path);
             (Some(LocalDb::new(executor)), Some(handle))
@@ -329,6 +386,7 @@ impl RaindexClient {
                 Arc::new(std::sync::Mutex::new(scheduler)),
                 sync_readiness,
                 sync_configured_chains,
+                sync_status_store,
             ),
         })
     }
@@ -813,6 +871,7 @@ accounts:
                 Rc::new(RefCell::new(None)),
                 sync_readiness,
                 db_chain_ids,
+                LocalDbSyncStatusStore::new(),
             ),
         }
     }
@@ -820,8 +879,102 @@ accounts:
     #[cfg(not(target_family = "wasm"))]
     mod native_tests {
         use super::*;
+        use crate::local_db::pipeline::runner::utils::parse_runner_settings;
+        use crate::local_db::query::{FromDbJson, SqlStatement, SqlStatementBatch};
+        use crate::raindex_client::local_db::LocalDbStatus;
         use httpmock::MockServer;
         use std::str::FromStr;
+
+        #[derive(Clone)]
+        struct SnapshotDbExec {
+            rows: Vec<SyncStatusResponse>,
+        }
+
+        #[async_trait::async_trait]
+        impl crate::local_db::query::LocalDbQueryExecutor for SnapshotDbExec {
+            async fn execute_batch(&self, _: &SqlStatementBatch) -> Result<(), LocalDbQueryError> {
+                Ok(())
+            }
+
+            async fn query_json<T>(&self, _: &SqlStatement) -> Result<T, LocalDbQueryError>
+            where
+                T: FromDbJson,
+            {
+                let value = serde_json::to_value(&self.rows)
+                    .map_err(|err| LocalDbQueryError::deserialization(err.to_string()))?;
+                serde_json::from_value(value)
+                    .map_err(|err| LocalDbQueryError::deserialization(err.to_string()))
+            }
+
+            async fn query_text(&self, _: &SqlStatement) -> Result<String, LocalDbQueryError> {
+                Ok(String::new())
+            }
+
+            async fn wipe_and_recreate(&self) -> Result<(), LocalDbQueryError> {
+                Ok(())
+            }
+        }
+
+        fn local_db_snapshot_yaml() -> String {
+            format!(
+                r#"
+version: {spec_version}
+networks:
+    arbitrum:
+        rpcs:
+            - https://arb.example/rpc
+        chain-id: 42161
+        label: Arbitrum
+        network-id: 42161
+        currency: ETH
+subgraphs:
+    arbitrum: https://arb.example/subgraph
+local-db-remotes:
+    remote: https://remote.example/manifest
+local-db-sync:
+    arbitrum:
+        batch-size: 10
+        max-concurrent-batches: 2
+        retry-attempts: 1
+        retry-delay-ms: 1
+        rate-limit-delay-ms: 1
+        finality-depth: 12
+        bootstrap-block-threshold: 100
+        sync-interval-ms: 5000
+orderbooks:
+    arbitrum-orderbook:
+        address: 0x2f209e5b67A33B8fE96E28f24628dF6Da301c8eB
+        network: arbitrum
+        subgraph: arbitrum
+        local-db-remote: remote
+        deployment-block: 1
+"#,
+                spec_version = SpecVersion::current()
+            )
+        }
+
+        fn client_with_snapshot_db(
+            yaml: String,
+            rows: Vec<SyncStatusResponse>,
+            sync_status_store: LocalDbSyncStatusStore,
+        ) -> RaindexClient {
+            let orderbook_yaml = OrderbookYaml::new(vec![yaml], OrderbookYamlValidation::default())
+                .expect("test yaml should parse");
+            let sync_readiness = SyncReadiness::new();
+            sync_readiness.mark_ready(42161);
+            let mut configured_chains = std::collections::HashSet::new();
+            configured_chains.insert(42161);
+            RaindexClient {
+                orderbook_yaml,
+                local_db_state: LocalDbState::new(
+                    Some(LocalDb::new(SnapshotDbExec { rows })),
+                    Arc::new(std::sync::Mutex::new(None)),
+                    sync_readiness,
+                    configured_chains,
+                    sync_status_store,
+                ),
+            }
+        }
 
         #[tokio::test]
         async fn test_create_fetches_remote_networks() {
@@ -934,6 +1087,70 @@ using-tokens-from:
             assert_eq!(token.network.chain_id, 123);
             assert_eq!(token.network.key, "test-network");
             assert_eq!(token.decimals, Some(18));
+        }
+
+        #[tokio::test]
+        async fn get_local_db_sync_snapshot_returns_not_configured_without_syncs() {
+            let client = RaindexClient::new(
+                vec![get_test_yaml(
+                    "https://mainnet.example/subgraph",
+                    "https://polygon.example/subgraph",
+                    "https://mainnet.example/rpc",
+                    "https://polygon.example/rpc",
+                )],
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+            let snapshot = client.get_local_db_sync_snapshot().await.unwrap();
+
+            assert!(!snapshot.configured);
+            assert!(snapshot.healthy);
+            assert_eq!(snapshot.status, LocalDbStatus::Active);
+            assert!(snapshot.networks.is_empty());
+            assert!(snapshot.orderbooks.is_empty());
+        }
+
+        #[tokio::test]
+        async fn get_local_db_sync_snapshot_includes_config_and_db_watermark() {
+            let yaml = local_db_snapshot_yaml();
+            let settings = parse_runner_settings(&yaml).expect("settings should parse");
+            let sync_status_store = LocalDbSyncStatusStore::new();
+            sync_status_store.seed(&settings);
+
+            let client = client_with_snapshot_db(
+                yaml,
+                vec![SyncStatusResponse {
+                    chain_id: 42161,
+                    orderbook_address: "0x2f209e5b67a33b8fe96e28f24628df6da301c8eb".to_string(),
+                    last_synced_block: 123_456,
+                    updated_at: Some("2026-05-01 12:00:00".to_string()),
+                }],
+                sync_status_store,
+            );
+
+            let snapshot = client.get_local_db_sync_snapshot().await.unwrap();
+
+            assert!(snapshot.configured);
+            assert_eq!(snapshot.networks.len(), 1);
+            assert_eq!(snapshot.networks[0].chain_id, 42161);
+            assert_eq!(
+                snapshot.networks[0].network_key,
+                Some("arbitrum".to_string())
+            );
+            assert_eq!(snapshot.networks[0].orderbook_count, 1);
+            assert_eq!(snapshot.orderbooks.len(), 1);
+            assert_eq!(
+                snapshot.orderbooks[0].orderbook_key,
+                Some("arbitrum-orderbook".to_string())
+            );
+            assert_eq!(snapshot.orderbooks[0].last_synced_block, Some(123_456));
+            assert_eq!(
+                snapshot.orderbooks[0].updated_at,
+                Some("2026-05-01 12:00:00".to_string())
+            );
         }
     }
 


### PR DESCRIPTION
## Motivation

Local DB sync status was only available as live pushed updates while the scheduler was running. That made it hard for Rust and TypeScript consumers to ask the client for the current sync picture on demand: whether local DB sync is configured, whether it is healthy, which networks and orderbooks are syncing, whether chains are ready, and what the latest persisted sync watermark is.

## Solution

- Add `RaindexClient::get_local_db_sync_snapshot`, exported to wasm as `getLocalDbSyncSnapshot`.
- Add a serializable `LocalDbSyncSnapshot` model with overall status, health, scheduler state, per-network status, and per-orderbook status.
- Reuse the existing `LocalDbStatus` enum for snapshot status instead of introducing a parallel status type.
- Add `LocalDbSyncStatusStore` as a per-client shared status handle, avoiding global snapshot state and cross-client leakage.
- Seed the snapshot store from parsed local DB sync settings so configured networks/orderbooks appear before the first completed cycle.
- Wire native and wasm scheduler/network status updates into the same store used by the on-demand snapshot call.
- Wire native and wasm orderbook status buses into the same store used by their existing live status callbacks.
- Enrich orderbook snapshots with persisted local DB watermark data when a DB handle is available: `lastSyncedBlock` and `updatedAt`.
- Keep the existing continuous live status transport; the new endpoint is a pull-based view over the same underlying status state.

## Behavior

The snapshot reports:

- `configured`: whether local DB sync has any configured networks/orderbooks.
- `healthy`: false if any tracked network/orderbook is in failure.
- `status`: `active`, `syncing`, or `failure` using the existing `LocalDbStatus` type.
- `schedulerState`: aggregate leader/not-leader state.
- `networks`: chain id, network key, status, scheduler state, readiness, orderbook count, and error.
- `orderbooks`: orderbook id, orderbook key, network key, status, scheduler state, readiness, phase message, DB watermark, update time, and error.

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)

Verified locally:

- `nix develop -c cargo fmt --all`
- `nix develop -c cargo test -p rain_orderbook_common sync_snapshot`
- `nix develop -c cargo test -p rain_orderbook_common get_local_db_sync_snapshot`
- `nix develop -c cargo test -p rain_orderbook_common sync_status_store_clones_share_state_but_new_stores_are_isolated`
- `nix develop -c cargo clippy -p rain_orderbook_common --all-targets --all-features -- -D clippy::all`
- `nix develop -c cargo check -p rain_orderbook_common --target wasm32-unknown-unknown`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new API to retrieve local database synchronization status snapshots, providing insights into network and orderbook sync progress.
  * Enhanced synchronization status tracking across network and orderbook operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->