### PR TITLE
feat: support registry client additional settings

### DIFF
--- a/crates/js_api/src/registry.rs
+++ b/crates/js_api/src/registry.rs
@@ -1,6 +1,13 @@
 use crate::gui::{DotrainOrderGui, GuiError};
 use crate::yaml::{OrderbookYaml, OrderbookYamlError};
-use rain_orderbook_app_settings::gui::NameAndDescriptionCfg;
+use rain_orderbook_app_settings::{
+    gui::NameAndDescriptionCfg,
+    yaml::{
+        emitter::emit_documents,
+        orderbook::{OrderbookYaml as SettingsOrderbookYaml, OrderbookYamlValidation},
+        YamlParsable,
+    },
+};
 use rain_orderbook_common::raindex_client::{RaindexClient, RaindexError as RaindexClientError};
 use reqwest;
 use serde::{Deserialize, Serialize};
@@ -557,6 +564,7 @@ impl DotrainRegistry {
     ///
     /// ```javascript
     /// const clientResult = await registry.getRaindexClient(
+    ///   privateSettings,
     ///   localDb.query.bind(localDb),
     ///   localDb.wipeAndRecreate.bind(localDb),
     ///   updateStatus,
@@ -576,6 +584,11 @@ impl DotrainRegistry {
     pub async fn get_raindex_client(
         &self,
         #[wasm_export(
+            js_name = "additionalSettings",
+            param_description = "Optional additional YAML setting strings to layer after the public registry settings"
+        )]
+        additional_settings: Option<Vec<String>>,
+        #[wasm_export(
             js_name = "queryCallback",
             param_description = "Optional JavaScript function to execute local database queries"
         )]
@@ -591,8 +604,9 @@ impl DotrainRegistry {
         )]
         status_callback: Option<js_sys::Function>,
     ) -> Result<RaindexClient, DotrainRegistryError> {
+        let sources = self.raindex_client_sources(additional_settings)?;
         let client = RaindexClient::new(
-            vec![self.settings.clone()],
+            sources,
             None,
             query_callback,
             wipe_callback,
@@ -607,14 +621,34 @@ impl DotrainRegistry {
 impl DotrainRegistry {
     pub async fn get_raindex_client(
         &self,
+        additional_settings: Option<Vec<String>>,
         db_path: Option<std::path::PathBuf>,
     ) -> Result<RaindexClient, DotrainRegistryError> {
-        let client = RaindexClient::new(vec![self.settings.clone()], None, db_path).await?;
+        let sources = self.raindex_client_sources(additional_settings)?;
+        let client = RaindexClient::new(sources, None, db_path).await?;
         Ok(client)
     }
 }
 
 impl DotrainRegistry {
+    fn raindex_client_sources(
+        &self,
+        additional_settings: Option<Vec<String>>,
+    ) -> Result<Vec<String>, DotrainRegistryError> {
+        let mut sources = vec![self.settings.clone()];
+        if let Some(additional) = additional_settings {
+            sources.extend(additional);
+        }
+        if sources.len() == 1 {
+            return Ok(sources);
+        }
+
+        let yaml = SettingsOrderbookYaml::new(sources, OrderbookYamlValidation::default())
+            .map_err(RaindexClientError::from)?;
+        let merged = emit_documents(&yaml.documents).map_err(RaindexClientError::from)?;
+        Ok(vec![merged])
+    }
+
     fn settings_sources(&self) -> Option<Vec<String>> {
         if self.settings.is_empty() {
             None
@@ -900,6 +934,31 @@ _ _: 1 1;
         )
     }
 
+    fn additional_base_rpc_settings() -> String {
+        format!(
+            r#"version: {}
+networks:
+  base:
+    rpcs:
+      - https://private.base.rpc
+    chain-id: 8453
+    currency: ETH
+"#,
+            SpecVersion::current()
+        )
+    }
+
+    fn mock_registry_with_settings(settings: String) -> DotrainRegistry {
+        DotrainRegistry {
+            registry_url: Url::parse("https://example.com/registry.txt").unwrap(),
+            registry: MOCK_REGISTRY_CONTENT.to_string(),
+            settings_url: Url::parse("https://example.com/settings.yaml").unwrap(),
+            settings,
+            order_urls: HashMap::new(),
+            orders: HashMap::new(),
+        }
+    }
+
     #[cfg(target_family = "wasm")]
     mod wasm_tests {
         use super::*;
@@ -1145,6 +1204,34 @@ _ _: 1 1;
             let not_found_error = DotrainRegistryError::OrderKeyNotFound("test-order".to_string());
             let readable = not_found_error.to_readable_msg();
             assert!(readable.contains("order key 'test-order' was not found"));
+        }
+
+        #[wasm_bindgen_test]
+        async fn test_get_raindex_client_without_additional_settings_uses_public_settings() {
+            let registry = mock_registry_with_settings(mock_settings_content());
+
+            let client = registry
+                .get_raindex_client(None, None, None, None)
+                .await
+                .unwrap();
+
+            let networks = client.get_all_networks().unwrap();
+            let base = networks.get("base").unwrap();
+            assert_eq!(base.rpcs[0].as_str(), "https://mainnet.base.org/");
+        }
+
+        #[wasm_bindgen_test]
+        async fn test_get_raindex_client_additional_settings_override_base_rpcs() {
+            let registry = mock_registry_with_settings(mock_settings_content());
+
+            let client = registry
+                .get_raindex_client(Some(vec![additional_base_rpc_settings()]), None, None, None)
+                .await
+                .unwrap();
+
+            let networks = client.get_all_networks().unwrap();
+            let base = networks.get("base").unwrap();
+            assert_eq!(base.rpcs[0].as_str(), "https://private.base.rpc/");
         }
     }
 
@@ -1689,8 +1776,33 @@ _ _: 0 0;
                 .await
                 .unwrap();
 
-            let raindex_client = registry.get_raindex_client(None).await;
+            let raindex_client = registry.get_raindex_client(None, None).await;
             assert!(raindex_client.is_ok());
+        }
+
+        #[tokio::test]
+        async fn test_get_raindex_client_without_additional_settings_uses_public_settings() {
+            let registry = mock_registry_with_settings(mock_settings_content());
+
+            let client = registry.get_raindex_client(None, None).await.unwrap();
+
+            let networks = client.get_all_networks().unwrap();
+            let base = networks.get("base").unwrap();
+            assert_eq!(base.rpcs[0].as_str(), "https://mainnet.base.org/");
+        }
+
+        #[tokio::test]
+        async fn test_get_raindex_client_additional_settings_override_base_rpcs() {
+            let registry = mock_registry_with_settings(mock_settings_content());
+
+            let client = registry
+                .get_raindex_client(Some(vec![additional_base_rpc_settings()]), None)
+                .await
+                .unwrap();
+
+            let networks = client.get_all_networks().unwrap();
+            let base = networks.get("base").unwrap();
+            assert_eq!(base.rpcs[0].as_str(), "https://private.base.rpc/");
         }
     }
 }

--- a/packages/orderbook/README.md
+++ b/packages/orderbook/README.md
@@ -546,12 +546,22 @@ const tokens = tokensResult.value; // TokenInfo[] with chain_id, address, decima
 
 #### Get a RaindexClient from registry settings
 
-Use `getRaindexClient()` to create a `RaindexClient` directly from the registry's shared settings, without manually bridging through `OrderbookYaml`:
+Use `getRaindexClient()` to create a `RaindexClient` directly from the registry's shared settings, without manually bridging through `OrderbookYaml`. Pass private settings strings as the first argument when a caller needs to layer local settings over the public registry settings:
 
 ```ts
 const clientResult = registry.getRaindexClient();
 if (clientResult.error) throw new Error(clientResult.error.readableMsg);
 const client = clientResult.value;
+
+const privateSettings = `
+version: 5
+networks:
+  base:
+    rpcs:
+      - https://private.base.rpc
+    chain-id: 8453
+`;
+const privateClientResult = registry.getRaindexClient([privateSettings]);
 
 // Use the client to query orders, vaults, etc.
 const ordersResult = await client.getOrders([8453]);

--- a/packages/orderbook/test/js_api/dotrainRegistry.test.ts
+++ b/packages/orderbook/test/js_api/dotrainRegistry.test.ts
@@ -70,6 +70,16 @@ tokens:
     network: base
 `;
 
+const ADDITIONAL_BASE_RPC_SETTINGS = `
+version: ${SPEC_VERSION}
+networks:
+  base:
+    rpcs:
+      - https://private.base.rpc
+    chain-id: 8453
+    currency: ETH
+`;
+
 const MOCK_DOTRAIN_PREFIX = `
 version: ${SPEC_VERSION}
 gui:
@@ -511,6 +521,44 @@ test-order http://localhost:8231/order.rain`;
 			const raindexClient = extractWasmEncodedData(raindexClientResult);
 
 			assert.ok(raindexClient, 'RaindexClient instance should be returned');
+		});
+
+		it('should preserve public settings when no additional settings are provided', async () => {
+			const registryContent = `http://localhost:8231/settings.yaml
+test-order http://localhost:8231/order.rain`;
+
+			await mockServer.forGet('/registry.txt').thenReply(200, registryContent);
+			await mockServer.forGet('/settings.yaml').thenReply(200, MOCK_SETTINGS_CONTENT);
+			await mockServer.forGet('/order.rain').thenReply(200, MOCK_DOTRAIN_SIMPLE);
+
+			const registry = extractWasmEncodedData(
+				await DotrainRegistry.new('http://localhost:8231/registry.txt')
+			);
+
+			const raindexClient = extractWasmEncodedData(await registry.getRaindexClient());
+			const networks = extractWasmEncodedData(raindexClient.getAllNetworks());
+
+			assert.strictEqual(networks.get('base')?.rpcs[0], 'https://mainnet.base.org/');
+		});
+
+		it('should apply additional settings after registry settings', async () => {
+			const registryContent = `http://localhost:8231/settings.yaml
+test-order http://localhost:8231/order.rain`;
+
+			await mockServer.forGet('/registry.txt').thenReply(200, registryContent);
+			await mockServer.forGet('/settings.yaml').thenReply(200, MOCK_SETTINGS_CONTENT);
+			await mockServer.forGet('/order.rain').thenReply(200, MOCK_DOTRAIN_SIMPLE);
+
+			const registry = extractWasmEncodedData(
+				await DotrainRegistry.new('http://localhost:8231/registry.txt')
+			);
+
+			const raindexClient = extractWasmEncodedData(
+				await registry.getRaindexClient([ADDITIONAL_BASE_RPC_SETTINGS])
+			);
+			const networks = extractWasmEncodedData(raindexClient.getAllNetworks());
+
+			assert.strictEqual(networks.get('base')?.rpcs[0], 'https://private.base.rpc/');
 		});
 	});
 });

--- a/packages/webapp/src/routes/+layout.ts
+++ b/packages/webapp/src/routes/+layout.ts
@@ -77,6 +77,7 @@ export const load: LayoutLoad<LayoutData> = async ({ url }) => {
 	try {
 		if (!errorMessage && registry) {
 			const raindexClientRes = await registry.getRaindexClient(
+				undefined,
 				localDb?.query?.bind(localDb),
 				localDb?.wipeAndRecreate?.bind(localDb),
 				updateStatus


### PR DESCRIPTION
## Motivation

DotrainRegistry could only construct a RaindexClient from the public registry settings. Callers that need private RPCs or other local overrides had to modify the public registry settings before constructing the client.

## Solution

- Add optional additional settings sources to native and WASM DotrainRegistry::get_raindex_client / getRaindexClient.
- Layer additional YAML in memory only when constructing the RaindexClient, including deep-merge behavior for overriding settings like networks.base.rpcs.
- Preserve existing no-extra-settings behavior and keep registry/settings getters unchanged.
- Update the webapp call site for the new WASM parameter order and document the SDK usage.

## Checks

- nix develop -c cargo fmt --all
- nix develop -c env COMMIT_SHA=b01023a8b443f6015e61c8725f769f213db3f5d8 npm run build (packages/orderbook)
- nix develop -c npm run test -w @rainlanguage/orderbook -- dotrainRegistry
- nix develop -c npm run check -w @rainlanguage/webapp
- nix develop -c npm run test -w @rainlanguage/webapp -- +layout
- nix develop -c cargo test -p rain_orderbook_js_api test_get_raindex_client -- --nocapture