### PR TITLE
feat: support shared orderbook yaml rpc updates

### DIFF
--- a/crates/common/src/raindex_client/mod.rs
+++ b/crates/common/src/raindex_client/mod.rs
@@ -974,6 +974,73 @@ orderbooks:
             }
         }
 
+        fn base_client_yaml(rpc: &str) -> String {
+            get_test_yaml(
+                "https://base.example/subgraph",
+                "https://polygon.example/subgraph",
+                rpc,
+                "https://polygon.example/rpc",
+            )
+            .replace("mainnet:", "base:")
+            .replace("network: mainnet", "network: base")
+            .replace("chain-id: 1", "chain-id: 8453")
+            .replace("network-id: 1", "network-id: 8453")
+            .replace("Ethereum Mainnet", "Base")
+            .replace("mainnet-orderbook:", "base-orderbook:")
+            .replace("mainnet-rainlang:", "base-rainlang:")
+        }
+
+        #[tokio::test]
+        async fn test_get_orderbook_yaml_update_network_rpcs_updates_client_networks() {
+            let client = RaindexClient::new(
+                vec![base_client_yaml("https://base.example/original-rpc")],
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+            let orderbook_yaml = client.get_orderbook_yaml();
+            orderbook_yaml
+                .update_network_rpcs(
+                    "base",
+                    vec![
+                        "https://base.example/updated-rpc-1".to_string(),
+                        "https://base.example/updated-rpc-2".to_string(),
+                    ],
+                )
+                .unwrap();
+
+            let networks = client.get_all_networks().unwrap();
+            let base = networks.get("base").unwrap();
+            assert_eq!(base.rpcs.len(), 2);
+            assert_eq!(base.rpcs[0].as_str(), "https://base.example/updated-rpc-1");
+            assert_eq!(base.rpcs[1].as_str(), "https://base.example/updated-rpc-2");
+        }
+
+        #[tokio::test]
+        async fn test_client_networks_unchanged_when_rpcs_not_updated() {
+            let client = RaindexClient::new(
+                vec![base_client_yaml("https://base.example/original-rpc")],
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+            let orderbook_yaml = client.get_orderbook_yaml();
+            let yaml_network = orderbook_yaml.get_network("base").unwrap();
+            let client_networks = client.get_all_networks().unwrap();
+            let client_network = client_networks.get("base").unwrap();
+
+            assert_eq!(client_network.rpcs, yaml_network.rpcs);
+            assert_eq!(client_network.rpcs.len(), 1);
+            assert_eq!(
+                client_network.rpcs[0].as_str(),
+                "https://base.example/original-rpc"
+            );
+        }
+
         #[tokio::test]
         async fn test_create_fetches_remote_networks() {
             let server = MockServer::start_async().await;

--- a/crates/common/src/raindex_client/orderbook_yaml.rs
+++ b/crates/common/src/raindex_client/orderbook_yaml.rs
@@ -4,6 +4,13 @@ use rain_orderbook_app_settings::{
 };
 use std::collections::{HashMap, HashSet};
 
+impl RaindexClient {
+    /// Returns an OrderbookYaml backed by the same in-memory YAML documents used by this client.
+    pub fn get_orderbook_yaml(&self) -> OrderbookYaml {
+        self.orderbook_yaml.clone()
+    }
+}
+
 #[wasm_export]
 impl RaindexClient {
     /// Retrieves a list of unique chain IDs from all configured networks

--- a/crates/js_api/src/registry.rs
+++ b/crates/js_api/src/registry.rs
@@ -1692,5 +1692,52 @@ _ _: 0 0;
             let raindex_client = registry.get_raindex_client(None).await;
             assert!(raindex_client.is_ok());
         }
+
+        #[tokio::test]
+        async fn test_registry_client_orderbook_yaml_rpc_update_updates_client_networks() {
+            let server = MockServer::start_async().await;
+
+            let test_registry_content = format!(
+                "{}/settings.yaml\ntest-order {}/order.rain",
+                server.url(""),
+                server.url("")
+            );
+
+            server.mock(|when, then| {
+                when.method("GET").path("/registry.txt");
+                then.status(200).body(test_registry_content.clone());
+            });
+
+            server.mock(|when, then| {
+                when.method("GET").path("/settings.yaml");
+                then.status(200).body(mock_settings_content());
+            });
+
+            server.mock(|when, then| {
+                when.method("GET").path("/order.rain");
+                then.status(200).body(MOCK_DOTRAIN_SIMPLE);
+            });
+
+            let registry = DotrainRegistry::new(format!("{}/registry.txt", server.url("")))
+                .await
+                .unwrap();
+
+            let client = registry.get_raindex_client(None).await.unwrap();
+            let orderbook_yaml = client.get_orderbook_yaml();
+            orderbook_yaml
+                .update_network_rpcs(
+                    "base",
+                    vec!["https://base.example/registry-updated-rpc".to_string()],
+                )
+                .unwrap();
+
+            let networks = client.get_all_networks().unwrap();
+            let base = networks.get("base").unwrap();
+            assert_eq!(base.rpcs.len(), 1);
+            assert_eq!(
+                base.rpcs[0].as_str(),
+                "https://base.example/registry-updated-rpc"
+            );
+        }
     }
 }

--- a/crates/settings/src/yaml/orderbook.rs
+++ b/crates/settings/src/yaml/orderbook.rs
@@ -234,6 +234,14 @@ impl OrderbookYaml {
         let context = self.build_context();
         NetworkCfg::parse_from_yaml(self.documents.clone(), key, Some(&context))
     }
+    pub fn update_network_rpcs(
+        &self,
+        network_key: &str,
+        rpcs: Vec<String>,
+    ) -> Result<NetworkCfg, YamlError> {
+        let mut network = self.get_network(network_key)?;
+        network.update_rpcs(rpcs)
+    }
     pub fn get_network_by_chain_id(&self, chain_id: u32) -> Result<NetworkCfg, YamlError> {
         let networks = self.get_networks()?;
         for network in networks.values() {
@@ -618,6 +626,41 @@ mod tests {
 
         assert!(matches!(deserialized.profile, ContextProfile::Strict));
         assert_eq!(deserialized.documents.len(), 1);
+    }
+
+    #[test]
+    fn test_update_network_rpcs_mutates_backing_document() {
+        let ob = OrderbookYaml::new(vec![full_yaml()], OrderbookYamlValidation::default()).unwrap();
+        let updated = ob
+            .update_network_rpcs("mainnet", vec!["https://updated-rpc.example".to_string()])
+            .unwrap();
+
+        assert_eq!(updated.rpcs.len(), 1);
+        assert_eq!(updated.rpcs[0].as_str(), "https://updated-rpc.example/");
+
+        let reparsed = ob.get_network("mainnet").unwrap();
+        assert_eq!(reparsed.rpcs.len(), 1);
+        assert_eq!(reparsed.rpcs[0].as_str(), "https://updated-rpc.example/");
+    }
+
+    #[test]
+    fn test_update_network_rpcs_errors_for_missing_network() {
+        let ob = OrderbookYaml::new(vec![full_yaml()], OrderbookYamlValidation::default()).unwrap();
+        let err = ob
+            .update_network_rpcs("missing", vec!["https://updated-rpc.example".to_string()])
+            .unwrap_err();
+
+        assert!(matches!(err, YamlError::KeyNotFound(_)));
+    }
+
+    #[test]
+    fn test_update_network_rpcs_errors_for_invalid_rpc() {
+        let ob = OrderbookYaml::new(vec![full_yaml()], OrderbookYamlValidation::default()).unwrap();
+        let err = ob
+            .update_network_rpcs("mainnet", vec!["not a url".to_string()])
+            .unwrap_err();
+
+        assert!(matches!(err, YamlError::ParseNetworkConfigSourceError(_)));
     }
 
     fn full_yaml() -> String {


### PR DESCRIPTION
## Motivation

Raindex clients need a way to adjust RPC endpoints at runtime while keeping subsequent client calls backed by the same in-memory orderbook YAML documents. This lets callers read the existing network RPCs, append their own endpoints, and update the shared config without rebuilding the client.

## Solution

- Expose `RaindexClient::get_orderbook_yaml()` as a Rust accessor that returns an `OrderbookYaml` sharing the client's backing YAML documents.
- Add `OrderbookYaml::update_network_rpcs(network_key, rpcs)`, which looks up the existing network, reuses `NetworkCfg::update_rpcs` validation and mutation, and returns the updated network config.
- Add coverage for direct clients, registry-created clients, invalid RPCs, missing networks, and unchanged behavior when RPCs are not updated.

## Checks

- `nix develop -c cargo fmt --all`
- `nix develop -c cargo test -p rain_orderbook_app_settings update_network_rpcs`
- `nix develop -c cargo test -p rain_orderbook_common get_orderbook_yaml_update_network_rpcs`
- `nix develop -c cargo test -p rain_orderbook_common client_networks_unchanged`
- `nix develop -c cargo test -p rain_orderbook_js_api registry_client_orderbook_yaml_rpc_update_updates_client_networks`
