### PR TITLE
chore: update webapp registry hash

### DIFF
--- a/packages/webapp/src/lib/constants.ts
+++ b/packages/webapp/src/lib/constants.ts
@@ -1,2 +1,2 @@
 export const REGISTRY_URL =
-  "https://raw.githubusercontent.com/rainlanguage/rain.strategies/805c30972423a9e0cd3d51171344f209011bce22/registry";
+  "https://raw.githubusercontent.com/rainlanguage/rain.strategies/57a40d4f5d83e1faea9bb9570aa80d83260ff7c7/registry";


### PR DESCRIPTION
## What

- Updates the default webapp dotrain registry URL to point at rainlanguage/rain.strategies commit 57a40d4f5d83e1faea9bb9570aa80d83260ff7c7.

## Why now

The webapp should load the requested registry revision by default.

## Checks

- Pre-commit hooks run during commit: prettier and no-consumer-prettier passed.