### PR TITLE
fix: recover old local DB schemas before watermark inspection

### DIFF
--- a/crates/common/src/local_db/query/create_tables/mod.rs
+++ b/crates/common/src/local_db/query/create_tables/mod.rs
@@ -31,55 +31,136 @@ pub fn create_tables_stmt() -> SqlStatement {
     SqlStatement::new(CREATE_TABLES_SQL)
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RequiredTableSchema {
+    pub name: String,
+    pub columns: Vec<String>,
+}
+
+pub fn required_table_schema() -> Vec<RequiredTableSchema> {
+    parse_required_table_schema(CREATE_TABLES_SQL)
+}
+
+fn parse_required_table_schema(sql: &str) -> Vec<RequiredTableSchema> {
+    let sql_lower = sql.to_lowercase();
+    let mut parsed = Vec::new();
+    let mut offset = 0usize;
+    let needle = "create table";
+
+    while let Some(rel_idx) = sql_lower[offset..].find(needle) {
+        let start = offset + rel_idx;
+        let Some(open_paren_rel) = sql_lower[start..].find('(') else {
+            break;
+        };
+        let open_paren = start + open_paren_rel;
+        let Some(close_paren) = find_matching_paren(sql, open_paren) else {
+            break;
+        };
+
+        if let Some(name) = parse_create_table_name(&sql[start + needle.len()..open_paren]) {
+            parsed.push(RequiredTableSchema {
+                name,
+                columns: parse_column_names(&sql[open_paren + 1..close_paren]),
+            });
+        }
+
+        offset = close_paren + 1;
+    }
+
+    parsed
+}
+
+fn find_matching_paren(sql: &str, open_paren: usize) -> Option<usize> {
+    let mut depth = 0usize;
+    for (idx, ch) in sql[open_paren..].char_indices() {
+        match ch {
+            '(' => depth += 1,
+            ')' => {
+                depth = depth.saturating_sub(1);
+                if depth == 0 {
+                    return Some(open_paren + idx);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+fn parse_create_table_name(raw: &str) -> Option<String> {
+    raw.split_whitespace().last().map(normalize_ident)
+}
+
+fn parse_column_names(raw_columns: &str) -> Vec<String> {
+    split_top_level_columns(raw_columns)
+        .into_iter()
+        .filter_map(|definition| {
+            let first = definition.split_whitespace().next()?;
+            let column = normalize_ident(first);
+            match column.as_str() {
+                "primary" | "foreign" | "unique" | "check" | "constraint" => None,
+                _ => Some(column),
+            }
+        })
+        .collect()
+}
+
+fn split_top_level_columns(raw_columns: &str) -> Vec<String> {
+    let mut items = Vec::new();
+    let mut current = String::new();
+    let mut depth = 0usize;
+
+    for ch in raw_columns.chars() {
+        match ch {
+            '(' => {
+                depth += 1;
+                current.push(ch);
+            }
+            ')' => {
+                depth = depth.saturating_sub(1);
+                current.push(ch);
+            }
+            ',' if depth == 0 => {
+                let item = current.trim();
+                if !item.is_empty() {
+                    items.push(item.to_string());
+                }
+                current.clear();
+            }
+            _ => current.push(ch),
+        }
+    }
+
+    let item = current.trim();
+    if !item.is_empty() {
+        items.push(item.to_string());
+    }
+
+    items
+}
+
+fn normalize_ident(s: &str) -> String {
+    let s = s.trim();
+    let s = s.trim_matches('`').trim_matches('"');
+    let s = if s.starts_with('[') && s.ends_with(']') && s.len() >= 2 {
+        &s[1..s.len() - 1]
+    } else {
+        s
+    };
+    s.to_lowercase()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::HashSet;
-
-    fn normalize_ident(s: &str) -> String {
-        let s = s.trim();
-        let s = s.trim_matches('`').trim_matches('"');
-        let s = if s.starts_with('[') && s.ends_with(']') && s.len() >= 2 {
-            &s[1..s.len() - 1]
-        } else {
-            s
-        };
-        s.to_lowercase()
-    }
+    use std::collections::{HashMap, HashSet};
 
     #[test]
     fn required_tables_match_sql_create_statements() {
-        let sql = create_tables_sql();
-        let sql_lower = sql.to_lowercase();
-
-        let mut parsed_tables: HashSet<String> = HashSet::new();
-        let mut offset = 0usize;
-        let needle = "create table";
-
-        while let Some(rel_idx) = sql_lower[offset..].find(needle) {
-            let start = offset + rel_idx;
-            // Find the opening parenthesis that starts the column list
-            let open_paren_rel = sql_lower[start..]
-                .find('(')
-                .expect("CREATE TABLE without opening '('");
-            let open_paren = start + open_paren_rel;
-
-            // Slice between 'create table' and '('
-            let name_part = &sql[start + needle.len()..open_paren];
-            // Tokenize and take the last token which should be the table name,
-            // handling the optional 'IF NOT EXISTS'
-            let tokens: Vec<&str> = name_part.split_whitespace().collect();
-            if let Some(last) = tokens.last() {
-                let table = normalize_ident(last);
-                // Exclude accidental matches on CREATE TABLE that aren't actual table definitions
-                if !table.is_empty() {
-                    parsed_tables.insert(table);
-                }
-            }
-
-            // Advance after this '('
-            offset = open_paren + 1;
-        }
+        let parsed_tables: HashSet<String> = required_table_schema()
+            .into_iter()
+            .map(|table| table.name)
+            .collect();
 
         let required_tables: HashSet<String> =
             REQUIRED_TABLES.iter().map(|t| normalize_ident(t)).collect();
@@ -100,5 +181,21 @@ mod tests {
             missing,
             extra
         );
+    }
+
+    #[test]
+    fn required_table_schema_parses_tables_and_columns() {
+        let schema = required_table_schema();
+        let by_table: HashMap<_, _> = schema
+            .iter()
+            .map(|table| (table.name.as_str(), table.columns.as_slice()))
+            .collect();
+
+        assert_eq!(schema.len(), REQUIRED_TABLES.len());
+        assert!(by_table["db_metadata"].contains(&"db_schema_version".to_string()));
+        assert!(by_table["target_watermarks"].contains(&"raindex_address".to_string()));
+        assert!(by_table["order_events"].contains(&"order_hash".to_string()));
+        assert!(by_table["running_vault_balances"].contains(&"balance".to_string()));
+        assert!(!by_table["order_ios"].contains(&"foreign".to_string()));
     }
 }

--- a/crates/common/src/local_db/query/fetch_table_columns/mod.rs
+++ b/crates/common/src/local_db/query/fetch_table_columns/mod.rs
@@ -1,0 +1,33 @@
+use crate::local_db::query::SqlStatement;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TableColumnResponse {
+    pub name: String,
+}
+
+pub fn fetch_table_columns_stmt(table: &str) -> SqlStatement {
+    SqlStatement::new(format!("PRAGMA table_info({});", quote_identifier(table)))
+}
+
+fn quote_identifier(identifier: &str) -> String {
+    format!("\"{}\"", identifier.replace('"', "\"\""))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fetch_table_columns_stmt_quotes_identifier() {
+        let stmt = fetch_table_columns_stmt("target_watermarks");
+        assert_eq!(stmt.sql(), "PRAGMA table_info(\"target_watermarks\");");
+        assert!(stmt.params().is_empty());
+    }
+
+    #[test]
+    fn fetch_table_columns_stmt_escapes_quotes() {
+        let stmt = fetch_table_columns_stmt("bad\"name");
+        assert_eq!(stmt.sql(), "PRAGMA table_info(\"bad\"\"name\");");
+    }
+}

--- a/crates/common/src/local_db/query/mod.rs
+++ b/crates/common/src/local_db/query/mod.rs
@@ -17,6 +17,7 @@ pub mod fetch_owner_trades;
 pub(crate) mod fetch_owner_trades_common;
 pub mod fetch_owner_trades_count;
 pub mod fetch_store_addresses;
+pub mod fetch_table_columns;
 pub mod fetch_tables;
 pub mod fetch_target_watermark;
 pub mod fetch_trades;

--- a/crates/common/src/raindex_client/local_db/pipeline/bootstrap.rs
+++ b/crates/common/src/raindex_client/local_db/pipeline/bootstrap.rs
@@ -422,6 +422,19 @@ mod tests {
             .await
             .unwrap();
 
+        let calls = db.calls();
+        let expected_views: Vec<String> = create_views_batch()
+            .statements()
+            .iter()
+            .map(|s| s.sql().to_string())
+            .collect();
+        assert!(calls.contains(&clear_tables_stmt().sql().to_string()));
+        assert!(calls.contains(&create_tables_stmt().sql().to_string()));
+        assert!(calls.contains(&insert_db_metadata_stmt(DB_SCHEMA_VERSION).sql().to_string()));
+        assert!(
+            expected_views.iter().all(|stmt| calls.contains(stmt)),
+            "missing view creation statements"
+        );
         assert!(
             !db.json_calls().contains(
                 &fetch_target_watermark_stmt(&runner_ob_id())

--- a/crates/common/src/raindex_client/local_db/pipeline/bootstrap.rs
+++ b/crates/common/src/raindex_client/local_db/pipeline/bootstrap.rs
@@ -95,6 +95,16 @@ impl BootstrapPipeline for ClientBootstrapAdapter {
             return Ok(());
         }
 
+        match self.ensure_schema(db, db_schema_version).await {
+            Ok(_) => {}
+            Err(LocalDbError::MissingDbMetadataRow)
+            | Err(LocalDbError::SchemaVersionMismatch { .. }) => {
+                self.reset_db(db, db_schema_version).await?;
+                return Ok(());
+            }
+            Err(err) => return Err(err),
+        }
+
         let BootstrapState {
             has_required_tables,
             ..
@@ -104,15 +114,6 @@ impl BootstrapPipeline for ClientBootstrapAdapter {
 
         if !has_required_tables {
             self.reset_db(db, db_schema_version).await?;
-        }
-
-        match self.ensure_schema(db, db_schema_version).await {
-            Ok(_) => {}
-            Err(LocalDbError::MissingDbMetadataRow)
-            | Err(LocalDbError::SchemaVersionMismatch { .. }) => {
-                self.reset_db(db, db_schema_version).await?;
-            }
-            Err(err) => return Err(err),
         }
 
         Ok(())
@@ -152,6 +153,7 @@ mod tests {
     struct MockDb {
         json_map: HashMap<String, String>,
         text_map: HashMap<String, String>,
+        calls_json: Mutex<Vec<String>>,
         calls_text: Mutex<Vec<String>>,
     }
 
@@ -168,6 +170,9 @@ mod tests {
         }
         fn calls(&self) -> Vec<String> {
             self.calls_text.lock().unwrap().clone()
+        }
+        fn json_calls(&self) -> Vec<String> {
+            self.calls_json.lock().unwrap().clone()
         }
 
         fn with_views(self) -> Self {
@@ -203,6 +208,7 @@ mod tests {
             T: FromDbJson,
         {
             let sql = stmt.sql();
+            self.calls_json.lock().unwrap().push(sql.to_string());
             let Some(body) = self.json_map.get(sql) else {
                 return Err(LocalDbQueryError::database("no json for sql"));
             };
@@ -311,22 +317,10 @@ mod tests {
     #[tokio::test]
     async fn runner_run_resets_on_missing_db_metadata() {
         let adapter = ClientBootstrapAdapter::new();
-        let tables_json = serde_json::to_value(
-            REQUIRED_TABLES
-                .iter()
-                .map(|&t| TableResponse {
-                    name: t.to_string(),
-                })
-                .collect::<Vec<_>>(),
-        )
-        .unwrap();
 
         let db = MockDb::default()
             .with_healthy_integrity()
-            .with_json(&fetch_tables_stmt(), tables_json)
             .with_json(&fetch_db_metadata_stmt(), json!([])) // triggers reset
-            // inspect_state will look for watermark since table exists
-            .with_json(&fetch_target_watermark_stmt(&runner_ob_id()), json!([]))
             .with_text(&clear_tables_stmt(), "ok")
             .with_text(&create_tables_stmt(), "ok")
             .with_text(&insert_db_metadata_stmt(DB_SCHEMA_VERSION), "ok")
@@ -349,20 +343,19 @@ mod tests {
             expected_views.iter().all(|stmt| calls.contains(stmt)),
             "missing view creation statements"
         );
+        assert!(
+            !db.json_calls().contains(
+                &fetch_target_watermark_stmt(&runner_ob_id())
+                    .sql()
+                    .to_string()
+            ),
+            "schema recovery should not inspect target watermarks before reset"
+        );
     }
 
     #[tokio::test]
     async fn runner_run_resets_on_schema_mismatch() {
         let adapter = ClientBootstrapAdapter::new();
-        let tables_json = serde_json::to_value(
-            REQUIRED_TABLES
-                .iter()
-                .map(|&t| TableResponse {
-                    name: t.to_string(),
-                })
-                .collect::<Vec<_>>(),
-        )
-        .unwrap();
 
         let mismatched_row = DbMetadataRow {
             id: 1,
@@ -373,8 +366,6 @@ mod tests {
 
         let db = MockDb::default()
             .with_healthy_integrity()
-            .with_json(&fetch_tables_stmt(), tables_json)
-            .with_json(&fetch_target_watermark_stmt(&runner_ob_id()), json!([]))
             .with_json(&fetch_db_metadata_stmt(), json!([mismatched_row]))
             .with_text(&clear_tables_stmt(), "ok")
             .with_text(&create_tables_stmt(), "ok")
@@ -397,6 +388,47 @@ mod tests {
         assert!(
             expected_views.iter().all(|stmt| calls.contains(stmt)),
             "missing view creation statements"
+        );
+        assert!(
+            !db.json_calls().contains(
+                &fetch_target_watermark_stmt(&runner_ob_id())
+                    .sql()
+                    .to_string()
+            ),
+            "schema recovery should not inspect target watermarks before reset"
+        );
+    }
+
+    #[tokio::test]
+    async fn runner_run_resets_old_schema_before_watermark_query() {
+        let adapter = ClientBootstrapAdapter::new();
+        let old_schema_row = DbMetadataRow {
+            id: 1,
+            db_schema_version: DB_SCHEMA_VERSION - 1,
+            created_at: None,
+            updated_at: None,
+        };
+
+        let db = MockDb::default()
+            .with_healthy_integrity()
+            .with_json(&fetch_db_metadata_stmt(), json!([old_schema_row]))
+            .with_text(&clear_tables_stmt(), "ok")
+            .with_text(&create_tables_stmt(), "ok")
+            .with_text(&insert_db_metadata_stmt(DB_SCHEMA_VERSION), "ok")
+            .with_views();
+
+        adapter
+            .runner_run(&db, Some(DB_SCHEMA_VERSION))
+            .await
+            .unwrap();
+
+        assert!(
+            !db.json_calls().contains(
+                &fetch_target_watermark_stmt(&runner_ob_id())
+                    .sql()
+                    .to_string()
+            ),
+            "old schema should reset before preparing current-schema watermark SQL"
         );
     }
 
@@ -440,12 +472,8 @@ mod tests {
     #[tokio::test]
     async fn runner_run_propagates_unexpected_ensure_schema_error() {
         let adapter = ClientBootstrapAdapter::new();
-        let tables_json = required_tables_json();
 
-        let db = MockDb::default()
-            .with_healthy_integrity()
-            .with_json(&fetch_tables_stmt(), tables_json)
-            .with_json(&fetch_target_watermark_stmt(&runner_ob_id()), json!([]));
+        let db = MockDb::default().with_healthy_integrity();
 
         let err = adapter
             .runner_run(&db, Some(DB_SCHEMA_VERSION))

--- a/crates/common/src/raindex_client/local_db/pipeline/bootstrap.rs
+++ b/crates/common/src/raindex_client/local_db/pipeline/bootstrap.rs
@@ -1,12 +1,15 @@
 use crate::local_db::{
     pipeline::adapters::bootstrap::{BootstrapConfig, BootstrapPipeline, BootstrapState},
     query::{
+        create_tables::{required_table_schema, REQUIRED_TABLES},
+        fetch_table_columns::{fetch_table_columns_stmt, TableColumnResponse},
+        fetch_tables::{fetch_tables_stmt, TableResponse},
         fetch_target_watermark::{fetch_target_watermark_stmt, TargetWatermarkRow},
         LocalDbQueryExecutor,
     },
     LocalDbError, RaindexIdentifier,
 };
-use alloy::primitives::Address;
+use std::collections::HashSet;
 
 #[derive(Debug, Default, Clone, Copy)]
 pub struct ClientBootstrapAdapter;
@@ -14,6 +17,56 @@ pub struct ClientBootstrapAdapter;
 impl ClientBootstrapAdapter {
     pub fn new() -> Self {
         Self {}
+    }
+
+    async fn fetch_existing_tables<DB>(&self, db: &DB) -> Result<HashSet<String>, LocalDbError>
+    where
+        DB: LocalDbQueryExecutor + ?Sized,
+    {
+        let existing: Vec<TableResponse> = db.query_json(&fetch_tables_stmt()).await?;
+        Ok(existing
+            .into_iter()
+            .map(|t| t.name.to_ascii_lowercase())
+            .collect())
+    }
+
+    fn has_required_tables(existing: &HashSet<String>) -> bool {
+        REQUIRED_TABLES
+            .iter()
+            .all(|&t| existing.contains(&t.to_ascii_lowercase()))
+    }
+
+    async fn has_required_schema_shape<DB>(
+        &self,
+        db: &DB,
+        existing_tables: &HashSet<String>,
+    ) -> Result<bool, LocalDbError>
+    where
+        DB: LocalDbQueryExecutor + ?Sized,
+    {
+        for required_table in required_table_schema() {
+            if !existing_tables.contains(&required_table.name) {
+                return Ok(false);
+            }
+
+            let actual_columns: Vec<TableColumnResponse> = db
+                .query_json(&fetch_table_columns_stmt(&required_table.name))
+                .await?;
+            let actual_column_names: HashSet<String> = actual_columns
+                .into_iter()
+                .map(|column| column.name.to_ascii_lowercase())
+                .collect();
+
+            if required_table
+                .columns
+                .iter()
+                .any(|column| !actual_column_names.contains(column))
+            {
+                return Ok(false);
+            }
+        }
+
+        Ok(true)
     }
 
     fn check_threshold(
@@ -95,24 +148,28 @@ impl BootstrapPipeline for ClientBootstrapAdapter {
             return Ok(());
         }
 
-        match self.ensure_schema(db, db_schema_version).await {
-            Ok(_) => {}
-            Err(LocalDbError::MissingDbMetadataRow)
-            | Err(LocalDbError::SchemaVersionMismatch { .. }) => {
+        let existing_tables = self.fetch_existing_tables(db).await?;
+
+        if !existing_tables.contains("db_metadata") {
+            self.reset_db(db, db_schema_version).await?;
+            return Ok(());
+        }
+
+        if let Err(err) = self.ensure_schema(db, db_schema_version).await {
+            if matches!(
+                err,
+                LocalDbError::MissingDbMetadataRow | LocalDbError::SchemaVersionMismatch { .. }
+            ) {
                 self.reset_db(db, db_schema_version).await?;
                 return Ok(());
             }
-            Err(err) => return Err(err),
+
+            return Err(err);
         }
 
-        let BootstrapState {
-            has_required_tables,
-            ..
-        } = self
-            .inspect_state(db, &RaindexIdentifier::new(0, Address::ZERO))
-            .await?;
-
-        if !has_required_tables {
+        if !Self::has_required_tables(&existing_tables)
+            || !self.has_required_schema_shape(db, &existing_tables).await?
+        {
             self.reset_db(db, db_schema_version).await?;
         }
 
@@ -191,6 +248,29 @@ mod tests {
             };
             self.with_json(&integrity_check_stmt(), json!([row]))
         }
+
+        fn with_required_schema_columns(self) -> Self {
+            required_table_schema().into_iter().fold(self, |db, table| {
+                let rows = table
+                    .columns
+                    .iter()
+                    .map(|name| TableColumnResponse { name: name.clone() })
+                    .collect::<Vec<_>>();
+                db.with_json(&fetch_table_columns_stmt(&table.name), json!(rows))
+            })
+        }
+
+        fn with_required_schema_columns_missing(self, table_name: &str, column_name: &str) -> Self {
+            required_table_schema().into_iter().fold(self, |db, table| {
+                let rows = table
+                    .columns
+                    .iter()
+                    .filter(|&name| table.name != table_name || name != column_name)
+                    .map(|name| TableColumnResponse { name: name.clone() })
+                    .collect::<Vec<_>>();
+                db.with_json(&fetch_table_columns_stmt(&table.name), json!(rows))
+            })
+        }
     }
 
     #[cfg_attr(target_family = "wasm", async_trait(?Send))]
@@ -265,6 +345,31 @@ mod tests {
         .unwrap()
     }
 
+    fn table_names_json(names: &[&str]) -> serde_json::Value {
+        serde_json::to_value(
+            names
+                .iter()
+                .map(|&name| TableResponse {
+                    name: name.to_string(),
+                })
+                .collect::<Vec<_>>(),
+        )
+        .unwrap()
+    }
+
+    fn required_tables_without_db_metadata_json() -> serde_json::Value {
+        serde_json::to_value(
+            REQUIRED_TABLES
+                .iter()
+                .filter(|&&name| name != "db_metadata")
+                .map(|&name| TableResponse {
+                    name: name.to_string(),
+                })
+                .collect::<Vec<_>>(),
+        )
+        .unwrap()
+    }
+
     fn watermark_row(last_block: u64) -> TargetWatermarkRow {
         TargetWatermarkRow {
             chain_id: sample_ob_id().chain_id,
@@ -290,6 +395,7 @@ mod tests {
             .with_healthy_integrity()
             .with_json(&fetch_tables_stmt(), tables_json)
             .with_json(&fetch_db_metadata_stmt(), json!([db_meta_row]))
+            .with_required_schema_columns()
             .with_text(&clear_tables_stmt(), "ok")
             .with_text(&create_tables_stmt(), "ok")
             .with_text(&insert_db_metadata_stmt(DB_SCHEMA_VERSION), "ok")
@@ -320,6 +426,7 @@ mod tests {
 
         let db = MockDb::default()
             .with_healthy_integrity()
+            .with_json(&fetch_tables_stmt(), table_names_json(&["db_metadata"]))
             .with_json(&fetch_db_metadata_stmt(), json!([])) // triggers reset
             .with_text(&clear_tables_stmt(), "ok")
             .with_text(&create_tables_stmt(), "ok")
@@ -354,6 +461,54 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn runner_run_resets_on_missing_db_metadata_table() {
+        let adapter = ClientBootstrapAdapter::new();
+
+        let db = MockDb::default()
+            .with_healthy_integrity()
+            .with_json(
+                &fetch_tables_stmt(),
+                required_tables_without_db_metadata_json(),
+            )
+            .with_text(&clear_tables_stmt(), "ok")
+            .with_text(&create_tables_stmt(), "ok")
+            .with_text(&insert_db_metadata_stmt(DB_SCHEMA_VERSION), "ok")
+            .with_views();
+
+        adapter
+            .runner_run(&db, Some(DB_SCHEMA_VERSION))
+            .await
+            .unwrap();
+
+        let calls = db.calls();
+        let expected_views: Vec<String> = create_views_batch()
+            .statements()
+            .iter()
+            .map(|s| s.sql().to_string())
+            .collect();
+        assert!(calls.contains(&clear_tables_stmt().sql().to_string()));
+        assert!(calls.contains(&create_tables_stmt().sql().to_string()));
+        assert!(calls.contains(&insert_db_metadata_stmt(DB_SCHEMA_VERSION).sql().to_string()));
+        assert!(
+            expected_views.iter().all(|stmt| calls.contains(stmt)),
+            "missing view creation statements"
+        );
+        assert!(
+            !db.json_calls()
+                .contains(&fetch_db_metadata_stmt().sql().to_string()),
+            "missing metadata table should reset before querying db_metadata"
+        );
+        assert!(
+            !db.json_calls().contains(
+                &fetch_target_watermark_stmt(&runner_ob_id())
+                    .sql()
+                    .to_string()
+            ),
+            "missing metadata table should reset before target watermark inspection"
+        );
+    }
+
+    #[tokio::test]
     async fn runner_run_resets_on_schema_mismatch() {
         let adapter = ClientBootstrapAdapter::new();
 
@@ -366,6 +521,7 @@ mod tests {
 
         let db = MockDb::default()
             .with_healthy_integrity()
+            .with_json(&fetch_tables_stmt(), table_names_json(&["db_metadata"]))
             .with_json(&fetch_db_metadata_stmt(), json!([mismatched_row]))
             .with_text(&clear_tables_stmt(), "ok")
             .with_text(&create_tables_stmt(), "ok")
@@ -411,6 +567,7 @@ mod tests {
 
         let db = MockDb::default()
             .with_healthy_integrity()
+            .with_json(&fetch_tables_stmt(), table_names_json(&["db_metadata"]))
             .with_json(&fetch_db_metadata_stmt(), json!([old_schema_row]))
             .with_text(&clear_tables_stmt(), "ok")
             .with_text(&create_tables_stmt(), "ok")
@@ -469,6 +626,7 @@ mod tests {
             .with_healthy_integrity()
             .with_json(&fetch_tables_stmt(), tables_json)
             .with_json(&fetch_db_metadata_stmt(), json!([db_row]))
+            .with_required_schema_columns()
             .with_json(&fetch_target_watermark_stmt(&runner_ob_id()), json!([]));
 
         adapter
@@ -479,6 +637,54 @@ mod tests {
         assert!(
             db.calls().is_empty(),
             "no text queries should be called when schema is ok"
+        );
+    }
+
+    #[tokio::test]
+    async fn runner_run_resets_when_required_column_is_missing() {
+        let adapter = ClientBootstrapAdapter::new();
+        let db_row = DbMetadataRow {
+            id: 1,
+            db_schema_version: DB_SCHEMA_VERSION,
+            created_at: None,
+            updated_at: None,
+        };
+
+        let db = MockDb::default()
+            .with_healthy_integrity()
+            .with_json(&fetch_tables_stmt(), required_tables_json())
+            .with_json(&fetch_db_metadata_stmt(), json!([db_row]))
+            .with_required_schema_columns_missing("target_watermarks", "raindex_address")
+            .with_text(&clear_tables_stmt(), "ok")
+            .with_text(&create_tables_stmt(), "ok")
+            .with_text(&insert_db_metadata_stmt(DB_SCHEMA_VERSION), "ok")
+            .with_views();
+
+        adapter
+            .runner_run(&db, Some(DB_SCHEMA_VERSION))
+            .await
+            .unwrap();
+
+        let calls = db.calls();
+        let expected_views: Vec<String> = create_views_batch()
+            .statements()
+            .iter()
+            .map(|s| s.sql().to_string())
+            .collect();
+        assert!(calls.contains(&clear_tables_stmt().sql().to_string()));
+        assert!(calls.contains(&create_tables_stmt().sql().to_string()));
+        assert!(calls.contains(&insert_db_metadata_stmt(DB_SCHEMA_VERSION).sql().to_string()));
+        assert!(
+            expected_views.iter().all(|stmt| calls.contains(stmt)),
+            "missing view creation statements"
+        );
+        assert!(
+            !db.json_calls().contains(
+                &fetch_target_watermark_stmt(&runner_ob_id())
+                    .sql()
+                    .to_string()
+            ),
+            "invalid schema shape should reset before target watermark inspection"
         );
     }
 


### PR DESCRIPTION
## Motivation

Browser users with a persisted local DB from schema version 2 can hit a startup recovery failure after upgrading to schema version 3. Bootstrap inspected target watermarks before checking `db_metadata.db_schema_version`, so an old table shape could fail statement preparation on current-schema columns before the version mismatch reset path ran.

## Solution

- Move local DB compatibility checks ahead of state/watermark inspection in client bootstrap.
- Use structural introspection before operational queries:
  - `sqlite_master` table presence before querying `db_metadata`
  - `db_metadata.db_schema_version` for version compatibility
  - `PRAGMA table_info(...)` for required table/column shape
- Reset immediately on missing metadata table, missing metadata row, schema-version mismatch, or invalid required schema shape.
- Derive the required table/column shape from the canonical `create_tables/query.sql` so validation does not hard-code a one-off migration.
- Add regression coverage for old schema rows, missing metadata tables, and claimed-current schemas missing required columns.

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)

Verified locally:

- `cargo fmt --all`
- `COMMIT_SHA=local-test cargo test -p raindex_common raindex_client::local_db::pipeline::bootstrap`
- `COMMIT_SHA=local-test cargo test -p raindex_common local_db::query::create_tables`
- `COMMIT_SHA=local-test cargo test -p raindex_common local_db::query::fetch_table_columns`
