### PR TITLE
fix: refresh local db views during bootstrap

### DIFF
--- a/crates/common/src/local_db/query/clear_tables/mod.rs
+++ b/crates/common/src/local_db/query/clear_tables/mod.rs
@@ -32,6 +32,7 @@ mod tests {
         assert!(stmt.params.is_empty());
         let lower = stmt.sql.to_lowercase();
         assert!(lower.contains("begin transaction"));
+        assert!(lower.contains("drop view if exists vault_deltas"));
         assert!(lower.contains("drop table if exists"));
         assert!(lower.contains("vacuum"));
     }

--- a/crates/common/src/local_db/query/clear_tables/query.sql
+++ b/crates/common/src/local_db/query/clear_tables/query.sql
@@ -1,5 +1,7 @@
 BEGIN TRANSACTION;
 
+DROP VIEW IF EXISTS vault_deltas;
+
 DROP TABLE IF EXISTS target_watermarks;
 DROP TABLE IF EXISTS db_metadata;
 DROP TABLE IF EXISTS context_values;

--- a/crates/common/src/local_db/query/create_views/mod.rs
+++ b/crates/common/src/local_db/query/create_views/mod.rs
@@ -18,7 +18,7 @@ mod tests {
     fn batch_wraps_transaction() {
         let batch = create_views_batch();
         assert!(batch.is_transaction());
-        assert_eq!(batch.len(), 3); // begin + view + commit
+        assert_eq!(batch.len(), 3); // begin + drop/create view + commit
 
         let statements = batch.statements();
         assert_eq!(statements.first().unwrap().sql(), "BEGIN TRANSACTION");
@@ -30,6 +30,8 @@ mod tests {
     fn single_stmt_matches_constant() {
         let stmt = vault_deltas_view_stmt();
         assert_eq!(stmt.sql(), VAULT_DELTAS_VIEW_SQL);
+        assert!(stmt.sql().starts_with("DROP VIEW IF EXISTS vault_deltas;"));
+        assert!(stmt.sql().contains("CREATE VIEW vault_deltas AS"));
         assert!(stmt.params().is_empty());
     }
 }

--- a/crates/common/src/local_db/query/create_views/vault_deltas.sql
+++ b/crates/common/src/local_db/query/create_views/vault_deltas.sql
@@ -1,4 +1,6 @@
-CREATE VIEW IF NOT EXISTS vault_deltas AS
+DROP VIEW IF EXISTS vault_deltas;
+
+CREATE VIEW vault_deltas AS
 WITH add_order_events AS (
   SELECT *
   FROM order_events

--- a/crates/common/src/raindex_client/local_db/pipeline/bootstrap.rs
+++ b/crates/common/src/raindex_client/local_db/pipeline/bootstrap.rs
@@ -2,6 +2,7 @@ use crate::local_db::{
     pipeline::adapters::bootstrap::{BootstrapConfig, BootstrapPipeline, BootstrapState},
     query::{
         create_tables::{required_table_schema, REQUIRED_TABLES},
+        create_views::create_views_batch,
         fetch_table_columns::{fetch_table_columns_stmt, TableColumnResponse},
         fetch_tables::{fetch_tables_stmt, TableResponse},
         fetch_target_watermark::{fetch_target_watermark_stmt, TargetWatermarkRow},
@@ -171,6 +172,8 @@ impl BootstrapPipeline for ClientBootstrapAdapter {
             || !self.has_required_schema_shape(db, &existing_tables).await?
         {
             self.reset_db(db, db_schema_version).await?;
+        } else {
+            db.execute_batch(&create_views_batch()).await?;
         }
 
         Ok(())
@@ -627,16 +630,23 @@ mod tests {
             .with_json(&fetch_tables_stmt(), tables_json)
             .with_json(&fetch_db_metadata_stmt(), json!([db_row]))
             .with_required_schema_columns()
-            .with_json(&fetch_target_watermark_stmt(&runner_ob_id()), json!([]));
+            .with_json(&fetch_target_watermark_stmt(&runner_ob_id()), json!([]))
+            .with_views();
 
         adapter
             .runner_run(&db, Some(DB_SCHEMA_VERSION))
             .await
             .unwrap();
 
-        assert!(
-            db.calls().is_empty(),
-            "no text queries should be called when schema is ok"
+        let expected_views: Vec<String> = create_views_batch()
+            .statements()
+            .iter()
+            .map(|s| s.sql().to_string())
+            .collect();
+        assert_eq!(
+            db.calls(),
+            expected_views,
+            "schema-ok bootstrap should still refresh replaceable views"
         );
     }
 


### PR DESCRIPTION
## Motivation

The old-schema recovery in #2583 resets local DB tables before current-schema watermark queries run, which fixes the initial `target_watermarks.raindex_address` failure.

Production then exposed a second persisted schema artifact: SQLite kept the old `vault_deltas` view definition. Because view creation used `CREATE VIEW IF NOT EXISTS`, reset could leave a v2 view in place, and engine sync later failed with:

`no such column: newer.orderbook_address`

## Solution

- Drop `vault_deltas` during full local DB table reset.
- Make `vault_deltas` creation replace the existing view by dropping it first, then creating the current definition.
- Refresh replaceable views during bootstrap even when table metadata and required columns are already valid.
- Update tests to assert schema-ok bootstrap refreshes views and clear/reset SQL includes the view drop.

## Checks

- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)

Verified locally through `nix develop`:

- `nix develop -c cargo fmt --all`
- `nix develop -c cargo test -p raindex_common local_db::query::create_views`
- `nix develop -c cargo test -p raindex_common local_db::query::clear_tables`
- `nix develop -c cargo test -p raindex_common raindex_client::local_db::pipeline::bootstrap`
- `nix develop -c cargo check -p raindex_common --target wasm32-unknown-unknown`

Attempted browser test through `nix develop` with the CI wasm runner; local ChromeDriver was repeatedly SIGKILLed before tests executed, so this still needs CI/browser verification.