### PR TITLE
Test raindex npm release from PR

### DIFF
--- a/.github/workflows/npm-package-release.yml
+++ b/.github/workflows/npm-package-release.yml
@@ -3,10 +3,13 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 jobs:
   release:
     # skip this job if the commit was created by this workflow (prevents infinite loop)
-    if: ${{ github.ref == 'refs/heads/main' && !startsWith(github.event.head_commit.message, 'NPM Package Release') }}
+    if: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) || (github.ref == 'refs/heads/main' && !startsWith(github.event.head_commit.message, 'NPM Package Release')) }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -31,6 +34,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ssh-key: ${{ secrets.PUBLISH_PRIVATE_KEY }}
+          ref: ${{ github.head_ref || github.ref_name }}
       # WASM builds require significant disk space; free up space to prevent build failures
       - name: Free disk space
         uses: jlumbroso/free-disk-space@v1.3.1
@@ -154,12 +158,12 @@ jobs:
       - name: Set Version
         if: ${{ env.OLD_HASH != env.NEW_HASH }}
         run: |
-          npm version prerelease --preid alpha --no-git-tag-version  -w @rainlanguage/raindex
+          npm version prerelease --preid alpha --no-git-tag-version --no-workspaces-update -w @rainlanguage/raindex
           RAINDEX_NEW_VERSION=$(jq -r '.version' ./packages/raindex/package.json)
           echo "RAINDEX_NEW_VERSION=$RAINDEX_NEW_VERSION" >> $GITHUB_ENV
           jq --arg v "$RAINDEX_NEW_VERSION" '.dependencies."@rainlanguage/raindex" = $v' ./packages/ui-components/package.json > tmp.json && mv tmp.json ./packages/ui-components/package.json
           npx prettier --write ./packages/ui-components/package.json
-          npm version prerelease --preid alpha --no-git-tag-version  -w @rainlanguage/ui-components
+          npm version prerelease --preid alpha --no-git-tag-version --no-workspaces-update -w @rainlanguage/ui-components
           UC_NEW_VERSION=$(jq -r '.version' ./packages/ui-components/package.json)
           echo "UC_NEW_VERSION=$UC_NEW_VERSION" >> $GITHUB_ENV
           jq --indent 4 --arg rd "$RAINDEX_NEW_VERSION" --arg uc "$UC_NEW_VERSION" '
@@ -210,7 +214,7 @@ jobs:
       - name: Push Changes To Remote
         if: ${{ env.OLD_HASH != env.NEW_HASH }}
         run: |
-          git push origin
+          git push origin HEAD:${{ github.head_ref || github.ref_name }}
           git push -u origin "npm-raindex-v${{ env.RAINDEX_NEW_VERSION }}-uc-v${{ env.UC_NEW_VERSION }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/npm-raindex-bootstrap-publish.yml
+++ b/.github/workflows/npm-raindex-bootstrap-publish.yml
@@ -1,0 +1,49 @@
+name: Bootstrap raindex NPM Publish
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          swap-storage: false
+
+      - uses: DeterminateSystems/nix-installer-action@main
+        with:
+          determinate: true
+
+      - uses: DeterminateSystems/flakehub-cache-action@main
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24.x"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Verify npm token auth
+        run: npm whoami
+
+      - name: Install dependencies
+        run: ./prep-base.sh
+
+      - name: Build raindex package
+        run: nix develop -c npm run build -w @rainlanguage/raindex
+
+      - name: Publish raindex package
+        run: |
+          RAINDEX_VERSION=$(jq -r '.version' ./packages/raindex/package.json)
+          if npm view "@rainlanguage/raindex@${RAINDEX_VERSION}" version >/dev/null 2>&1; then
+            echo "@rainlanguage/raindex@${RAINDEX_VERSION} is already published"
+            exit 0
+          fi
+          npm publish -w @rainlanguage/raindex --access public --tag bootstrap --verbose

--- a/.github/workflows/npm-raindex-bootstrap-publish.yml
+++ b/.github/workflows/npm-raindex-bootstrap-publish.yml
@@ -1,10 +1,14 @@
 name: Bootstrap raindex NPM Publish
 
 on:
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:
   publish:
+    if: ${{ github.head_ref == 'fix-raindex-npm-release-pr-trigger' || github.ref_name == 'fix-raindex-npm-release-pr-trigger' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Motivation

The npm package release workflow is failing while bumping ui-components because npm tries to resolve @rainlanguage/raindex from the public registry before the renamed package has been published.

## Solution

- Add a temporary same-repo PR trigger for the npm release workflow so we can validate the publish path from this PR.
- Check out the PR branch when running on pull_request so release commits can be pushed back to the branch.
- Disable npm's automatic workspace dependency update during version bumps with --no-workspaces-update.
- Push CI-created release commits back to the triggering branch.

## Checks

- Parsed .github/workflows/npm-package-release.yml locally with Ruby YAML.load_file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline workflows to improve release automation and testing processes.
  * Added bootstrap publishing workflow for improved package management and deployment efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rainlanguage/raindex/pull/2585?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->