### PR TITLE
Maintain derived trades during sync

### DIFF
--- a/crates/common/src/local_db/pipeline/adapters/apply.rs
+++ b/crates/common/src/local_db/pipeline/adapters/apply.rs
@@ -6,6 +6,7 @@ use crate::local_db::insert::{
     raw_events_to_statements as build_raw_event_sql,
 };
 use crate::local_db::query::fetch_erc20_tokens_by_addresses::Erc20TokenRow;
+use crate::local_db::query::upsert_derived_trades::upsert_derived_trades_batch;
 use crate::local_db::query::upsert_target_watermark::upsert_target_watermark_stmt;
 use crate::local_db::query::upsert_vault_balances::upsert_vault_balances_batch;
 use crate::local_db::query::{LocalDbQueryExecutor, SqlStatement, SqlStatementBatch};
@@ -83,6 +84,11 @@ pub trait ApplyPipeline {
         // Vault balance change/running balance updates
         if target_info.start_block <= target_info.target_block {
             batch.extend(upsert_vault_balances_batch(
+                &target_info.raindex_id,
+                target_info.start_block,
+                target_info.target_block,
+            ));
+            batch.extend(upsert_derived_trades_batch(
                 &target_info.raindex_id,
                 target_info.start_block,
                 target_info.target_block,
@@ -361,13 +367,19 @@ mod tests {
             .build_batch(&build_target_info(&raindex_id, 1, 42), &[], &[], &[], &[])
             .expect("batch ok");
 
-        // Expect vault balance refresh plus the watermark and ANALYZE when there is no work.
+        // Expect derived state refreshes plus the watermark and ANALYZE when there is no work.
         let texts: Vec<_> = batch.statements().iter().map(|s| s.sql().trim()).collect();
-        assert_eq!(texts.len(), 4);
+        assert_eq!(texts.len(), 6);
         assert!(texts.iter().any(|s| s.contains("vault_balance_changes")));
         assert!(texts
             .iter()
             .any(|s| s.contains("INSERT OR REPLACE INTO running_vault_balances")));
+        assert!(texts
+            .iter()
+            .any(|s| s.contains("DELETE FROM derived_trades")));
+        assert!(texts
+            .iter()
+            .any(|s| s.contains("INSERT OR REPLACE INTO derived_trades")));
         assert!(texts
             .iter()
             .any(|s| s.contains("INSERT INTO target_watermarks")));
@@ -1030,10 +1042,19 @@ mod tests {
             .iter()
             .position(|s| s.sql().starts_with("INSERT INTO target_watermarks"))
             .expect("watermark present");
+        let idx_derived = batch
+            .statements()
+            .iter()
+            .position(|s| s.sql().starts_with("DELETE FROM derived_trades"))
+            .expect("derived refresh present");
 
         assert!(idx_raw < idx_token, "raw should precede token upserts");
         assert!(idx_token < idx_decoded, "token upserts before decoded");
-        assert!(idx_decoded < idx_watermark, "decoded before watermark");
+        assert!(idx_decoded < idx_derived, "decoded before derived refresh");
+        assert!(
+            idx_derived < idx_watermark,
+            "derived refresh before watermark"
+        );
     }
 
     #[test]

--- a/crates/common/src/local_db/query/mod.rs
+++ b/crates/common/src/local_db/query/mod.rs
@@ -30,6 +30,7 @@ pub mod integrity_check;
 pub mod sql_statement;
 pub mod sql_statement_batch;
 pub mod update_last_synced_block;
+pub mod upsert_derived_trades;
 pub mod upsert_target_watermark;
 pub mod upsert_vault_balances;
 

--- a/crates/common/src/local_db/query/upsert_derived_trades/mod.rs
+++ b/crates/common/src/local_db/query/upsert_derived_trades/mod.rs
@@ -1,0 +1,113 @@
+use crate::local_db::{
+    query::{SqlStatement, SqlStatementBatch, SqlValue},
+    RaindexIdentifier,
+};
+
+const INSERT_DERIVED_TRADES_SQL: &str = include_str!("query.sql");
+
+pub fn upsert_derived_trades_batch(
+    raindex_id: &RaindexIdentifier,
+    start_block: u64,
+    end_block: u64,
+) -> SqlStatementBatch {
+    SqlStatementBatch::from(vec![
+        delete_derived_trades_stmt(raindex_id, start_block, end_block),
+        insert_derived_trades_stmt(raindex_id, start_block, end_block),
+    ])
+}
+
+fn delete_derived_trades_stmt(
+    raindex_id: &RaindexIdentifier,
+    start_block: u64,
+    end_block: u64,
+) -> SqlStatement {
+    SqlStatement::new_with_params(
+        "DELETE FROM derived_trades
+WHERE chain_id = ?1
+  AND raindex_address = ?2
+  AND block_number BETWEEN ?3 AND ?4",
+        bind_params(raindex_id, start_block, end_block),
+    )
+}
+
+fn insert_derived_trades_stmt(
+    raindex_id: &RaindexIdentifier,
+    start_block: u64,
+    end_block: u64,
+) -> SqlStatement {
+    SqlStatement::new_with_params(
+        INSERT_DERIVED_TRADES_SQL,
+        bind_params(raindex_id, start_block, end_block),
+    )
+}
+
+fn bind_params(raindex_id: &RaindexIdentifier, start_block: u64, end_block: u64) -> [SqlValue; 4] {
+    [
+        SqlValue::from(raindex_id.chain_id),
+        SqlValue::from(raindex_id.raindex_address),
+        SqlValue::from(start_block),
+        SqlValue::from(end_block),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::primitives::Address;
+
+    #[test]
+    fn batch_binds_delete_and_insert_params() {
+        let raindex_id = RaindexIdentifier::new(111, Address::from([0x11u8; 20]));
+        let batch = upsert_derived_trades_batch(&raindex_id, 100, 200);
+
+        assert_eq!(batch.len(), 2);
+        for stmt in batch.statements() {
+            assert_eq!(stmt.params().len(), 4);
+            assert_eq!(stmt.params()[0], SqlValue::U64(111));
+            assert_eq!(
+                stmt.params()[1],
+                SqlValue::Text(raindex_id.raindex_address.to_string())
+            );
+            assert_eq!(stmt.params()[2], SqlValue::U64(100));
+            assert_eq!(stmt.params()[3], SqlValue::U64(200));
+        }
+    }
+
+    #[test]
+    fn batch_deletes_window_before_rebuilding() {
+        let batch = upsert_derived_trades_batch(&RaindexIdentifier::new(1, Address::ZERO), 0, 10);
+        let statements = batch.statements();
+
+        assert!(statements[0].sql().contains("DELETE FROM derived_trades"));
+        assert!(statements[0]
+            .sql()
+            .contains("block_number BETWEEN ?3 AND ?4"));
+        assert!(statements[1]
+            .sql()
+            .contains("INSERT OR REPLACE INTO derived_trades"));
+    }
+
+    #[test]
+    fn insert_is_window_bounded_but_order_lookup_can_read_history() {
+        let batch = upsert_derived_trades_batch(&RaindexIdentifier::new(1, Address::ZERO), 0, 10);
+        let sql = batch.statements()[1].sql();
+
+        assert!(sql.contains("t.block_number BETWEEN p.start_block AND p.end_block"));
+        assert!(sql.contains("c.block_number BETWEEN p.start_block AND p.end_block"));
+        assert!(sql.contains("oe.block_number < mt.block_number"));
+        assert!(sql.contains("oe.block_number < mc.block_number"));
+    }
+
+    #[test]
+    fn insert_preserves_current_trade_ids_and_clear_sides() {
+        let batch = upsert_derived_trades_batch(&RaindexIdentifier::new(1, Address::ZERO), 0, 10);
+        let sql = batch.statements()[1].sql();
+
+        assert!(sql.contains("'take' AS trade_side"));
+        assert!(sql.contains("'alice' AS trade_side"));
+        assert!(sql.contains("'bob' AS trade_side"));
+        assert!(sql.contains("printf('%016x', tr.log_index)"));
+        assert!(sql.contains("WHEN 'alice' THEN '01'"));
+        assert!(sql.contains("WHEN 'bob' THEN '02'"));
+    }
+}

--- a/crates/common/src/local_db/query/upsert_derived_trades/query.sql
+++ b/crates/common/src/local_db/query/upsert_derived_trades/query.sql
@@ -1,0 +1,343 @@
+WITH
+params AS (
+  SELECT
+    ?1 AS chain_id,
+    ?2 AS raindex_address,
+    ?3 AS start_block,
+    ?4 AS end_block
+),
+matching_take_orders AS (
+  SELECT
+    'take' AS trade_kind,
+    'take' AS trade_side,
+    t.chain_id,
+    t.raindex_address,
+    t.order_owner,
+    t.order_nonce,
+    t.transaction_hash,
+    t.log_index,
+    t.block_number,
+    t.block_timestamp,
+    t.sender AS transaction_sender,
+    t.input_io_index,
+    t.output_io_index,
+    t.taker_output AS input_delta,
+    FLOAT_NEGATE(t.taker_input) AS output_delta
+  FROM take_orders t
+  JOIN params p
+    ON p.chain_id = t.chain_id
+   AND p.raindex_address = t.raindex_address
+  WHERE t.block_number BETWEEN p.start_block AND p.end_block
+),
+matching_clears AS (
+  SELECT
+    c.chain_id,
+    c.raindex_address,
+    c.transaction_hash,
+    c.log_index,
+    c.block_number,
+    c.block_timestamp,
+    c.sender,
+    c.alice_order_hash,
+    c.bob_order_hash,
+    c.alice_input_io_index,
+    c.alice_output_io_index,
+    c.alice_input_vault_id,
+    c.alice_output_vault_id,
+    c.bob_input_io_index,
+    c.bob_output_io_index,
+    c.bob_input_vault_id,
+    c.bob_output_vault_id
+  FROM clear_v3_events c
+  JOIN params p
+    ON p.chain_id = c.chain_id
+   AND p.raindex_address = c.raindex_address
+  WHERE c.block_number BETWEEN p.start_block AND p.end_block
+),
+take_trades AS (
+  SELECT
+    mt.trade_kind,
+    mt.trade_side,
+    mt.chain_id,
+    mt.raindex_address,
+    oe.order_hash,
+    mt.order_owner,
+    mt.order_nonce,
+    mt.transaction_hash,
+    mt.log_index,
+    mt.block_number,
+    mt.block_timestamp,
+    mt.transaction_sender,
+    io_in.vault_id AS input_vault_id,
+    io_in.token AS input_token,
+    mt.input_delta,
+    io_out.vault_id AS output_vault_id,
+    io_out.token AS output_token,
+    mt.output_delta
+  FROM matching_take_orders mt
+  JOIN order_events oe
+    ON oe.chain_id = mt.chain_id
+   AND oe.raindex_address = mt.raindex_address
+   AND oe.order_owner = mt.order_owner
+   AND oe.order_nonce = mt.order_nonce
+   AND oe.event_type = 'AddOrderV3'
+   AND (
+        oe.block_number < mt.block_number
+     OR (oe.block_number = mt.block_number AND oe.log_index <= mt.log_index)
+   )
+   AND NOT EXISTS (
+     SELECT 1
+     FROM order_events newer
+     WHERE newer.chain_id = oe.chain_id
+       AND newer.raindex_address = oe.raindex_address
+       AND newer.order_owner = oe.order_owner
+       AND newer.order_nonce = oe.order_nonce
+       AND newer.event_type = 'AddOrderV3'
+       AND (
+            newer.block_number < mt.block_number
+         OR (newer.block_number = mt.block_number AND newer.log_index <= mt.log_index)
+       )
+       AND (
+            newer.block_number > oe.block_number
+         OR (newer.block_number = oe.block_number AND newer.log_index > oe.log_index)
+       )
+   )
+  JOIN order_ios io_in
+    ON io_in.chain_id = oe.chain_id
+   AND io_in.raindex_address = oe.raindex_address
+   AND io_in.transaction_hash = oe.transaction_hash
+   AND io_in.log_index = oe.log_index
+   AND io_in.io_index = mt.input_io_index
+   AND io_in.io_type = 'input'
+  JOIN order_ios io_out
+    ON io_out.chain_id = oe.chain_id
+   AND io_out.raindex_address = oe.raindex_address
+   AND io_out.transaction_hash = oe.transaction_hash
+   AND io_out.log_index = oe.log_index
+   AND io_out.io_index = mt.output_io_index
+   AND io_out.io_type = 'output'
+),
+clear_alice AS (
+  SELECT DISTINCT
+    'clear' AS trade_kind,
+    'alice' AS trade_side,
+    mc.chain_id,
+    mc.raindex_address,
+    oe.order_hash,
+    oe.order_owner,
+    oe.order_nonce,
+    mc.transaction_hash,
+    mc.log_index,
+    mc.block_number,
+    mc.block_timestamp,
+    mc.sender AS transaction_sender,
+    mc.alice_input_vault_id AS input_vault_id,
+    io_in.token AS input_token,
+    a.alice_input AS input_delta,
+    mc.alice_output_vault_id AS output_vault_id,
+    io_out.token AS output_token,
+    FLOAT_NEGATE(a.alice_output) AS output_delta
+  FROM matching_clears mc
+  JOIN order_events oe
+    ON oe.chain_id = mc.chain_id
+   AND oe.raindex_address = mc.raindex_address
+   AND oe.order_hash = mc.alice_order_hash
+   AND oe.event_type = 'AddOrderV3'
+   AND (
+        oe.block_number < mc.block_number
+     OR (oe.block_number = mc.block_number AND oe.log_index <= mc.log_index)
+   )
+   AND NOT EXISTS (
+     SELECT 1
+     FROM order_events newer
+     WHERE newer.chain_id = oe.chain_id
+       AND newer.raindex_address = oe.raindex_address
+       AND newer.order_hash = oe.order_hash
+       AND newer.event_type = 'AddOrderV3'
+       AND (
+            newer.block_number < mc.block_number
+         OR (newer.block_number = mc.block_number AND newer.log_index <= mc.log_index)
+       )
+       AND (
+            newer.block_number > oe.block_number
+         OR (newer.block_number = oe.block_number AND newer.log_index > oe.log_index)
+       )
+   )
+  JOIN after_clear_v2_events a
+    ON a.chain_id = mc.chain_id
+   AND a.raindex_address = mc.raindex_address
+   AND a.transaction_hash = mc.transaction_hash
+   AND a.log_index = (
+       SELECT MIN(ac.log_index)
+       FROM after_clear_v2_events ac
+       WHERE ac.chain_id = mc.chain_id
+         AND ac.raindex_address = mc.raindex_address
+         AND ac.transaction_hash = mc.transaction_hash
+         AND ac.log_index > mc.log_index
+   )
+  JOIN order_ios io_in
+    ON io_in.chain_id = oe.chain_id
+   AND io_in.raindex_address = oe.raindex_address
+   AND io_in.transaction_hash = oe.transaction_hash
+   AND io_in.log_index = oe.log_index
+   AND io_in.io_index = mc.alice_input_io_index
+   AND io_in.io_type = 'input'
+  JOIN order_ios io_out
+    ON io_out.chain_id = oe.chain_id
+   AND io_out.raindex_address = oe.raindex_address
+   AND io_out.transaction_hash = oe.transaction_hash
+   AND io_out.log_index = oe.log_index
+   AND io_out.io_index = mc.alice_output_io_index
+   AND io_out.io_type = 'output'
+),
+clear_bob AS (
+  SELECT DISTINCT
+    'clear' AS trade_kind,
+    'bob' AS trade_side,
+    mc.chain_id,
+    mc.raindex_address,
+    oe.order_hash,
+    oe.order_owner,
+    oe.order_nonce,
+    mc.transaction_hash,
+    mc.log_index,
+    mc.block_number,
+    mc.block_timestamp,
+    mc.sender AS transaction_sender,
+    mc.bob_input_vault_id AS input_vault_id,
+    io_in.token AS input_token,
+    a.bob_input AS input_delta,
+    mc.bob_output_vault_id AS output_vault_id,
+    io_out.token AS output_token,
+    FLOAT_NEGATE(a.bob_output) AS output_delta
+  FROM matching_clears mc
+  JOIN order_events oe
+    ON oe.chain_id = mc.chain_id
+   AND oe.raindex_address = mc.raindex_address
+   AND oe.order_hash = mc.bob_order_hash
+   AND oe.event_type = 'AddOrderV3'
+   AND (
+        oe.block_number < mc.block_number
+     OR (oe.block_number = mc.block_number AND oe.log_index <= mc.log_index)
+   )
+   AND NOT EXISTS (
+     SELECT 1
+     FROM order_events newer
+     WHERE newer.chain_id = oe.chain_id
+       AND newer.raindex_address = oe.raindex_address
+       AND newer.order_hash = oe.order_hash
+       AND newer.event_type = 'AddOrderV3'
+       AND (
+            newer.block_number < mc.block_number
+         OR (newer.block_number = mc.block_number AND newer.log_index <= mc.log_index)
+       )
+       AND (
+            newer.block_number > oe.block_number
+         OR (newer.block_number = oe.block_number AND newer.log_index > oe.log_index)
+       )
+   )
+  JOIN after_clear_v2_events a
+    ON a.chain_id = mc.chain_id
+   AND a.raindex_address = mc.raindex_address
+   AND a.transaction_hash = mc.transaction_hash
+   AND a.log_index = (
+       SELECT MIN(ac.log_index)
+       FROM after_clear_v2_events ac
+       WHERE ac.chain_id = mc.chain_id
+         AND ac.raindex_address = mc.raindex_address
+         AND ac.transaction_hash = mc.transaction_hash
+         AND ac.log_index > mc.log_index
+   )
+  JOIN order_ios io_in
+    ON io_in.chain_id = oe.chain_id
+   AND io_in.raindex_address = oe.raindex_address
+   AND io_in.transaction_hash = oe.transaction_hash
+   AND io_in.log_index = oe.log_index
+   AND io_in.io_index = mc.bob_input_io_index
+   AND io_in.io_type = 'input'
+  JOIN order_ios io_out
+    ON io_out.chain_id = oe.chain_id
+   AND io_out.raindex_address = oe.raindex_address
+   AND io_out.transaction_hash = oe.transaction_hash
+   AND io_out.log_index = oe.log_index
+   AND io_out.io_index = mc.bob_output_io_index
+   AND io_out.io_type = 'output'
+),
+trade_rows AS (
+  SELECT * FROM take_trades
+  UNION ALL
+  SELECT * FROM clear_alice
+  UNION ALL
+  SELECT * FROM clear_bob
+)
+INSERT OR REPLACE INTO derived_trades (
+  chain_id,
+  raindex_address,
+  trade_id,
+  trade_kind,
+  trade_side,
+  order_hash,
+  order_owner,
+  order_nonce,
+  transaction_hash,
+  log_index,
+  block_number,
+  block_timestamp,
+  transaction_sender,
+  input_vault_id,
+  input_token,
+  input_delta,
+  input_running_balance,
+  output_vault_id,
+  output_token,
+  output_delta,
+  output_running_balance
+)
+SELECT
+  tr.chain_id,
+  tr.raindex_address,
+  (
+    '0x' ||
+    lower(replace(tr.transaction_hash, '0x', '')) ||
+    printf('%016x', tr.log_index) ||
+    CASE tr.trade_side
+      WHEN 'alice' THEN '01'
+      WHEN 'bob' THEN '02'
+      ELSE ''
+    END
+  ) AS trade_id,
+  tr.trade_kind,
+  tr.trade_side,
+  tr.order_hash,
+  tr.order_owner,
+  tr.order_nonce,
+  tr.transaction_hash,
+  tr.log_index,
+  tr.block_number,
+  tr.block_timestamp,
+  tr.transaction_sender,
+  tr.input_vault_id,
+  tr.input_token,
+  tr.input_delta,
+  vbc_input.running_balance AS input_running_balance,
+  tr.output_vault_id,
+  tr.output_token,
+  tr.output_delta,
+  vbc_output.running_balance AS output_running_balance
+FROM trade_rows tr
+LEFT JOIN vault_balance_changes vbc_input
+  ON vbc_input.chain_id = tr.chain_id
+ AND vbc_input.raindex_address = tr.raindex_address
+ AND vbc_input.owner = tr.order_owner
+ AND vbc_input.token = tr.input_token
+ AND vbc_input.vault_id = tr.input_vault_id
+ AND vbc_input.block_number = tr.block_number
+ AND vbc_input.log_index = tr.log_index
+LEFT JOIN vault_balance_changes vbc_output
+  ON vbc_output.chain_id = tr.chain_id
+ AND vbc_output.raindex_address = tr.raindex_address
+ AND vbc_output.owner = tr.order_owner
+ AND vbc_output.token = tr.output_token
+ AND vbc_output.vault_id = tr.output_vault_id
+ AND vbc_output.block_number = tr.block_number
+ AND vbc_output.log_index = tr.log_index;


### PR DESCRIPTION
## Chained PRs

Depends on #2587. Stack order: #2587 -> #2588 -> #2589 -> #2590

## Motivation

`derived_trades` must be maintained by the same local DB sync pipeline that writes source events and state, otherwise producer bootstrap DBs and client incremental syncs can diverge from read-path expectations.

## Solution

- Add `upsert_derived_trades` SQL and builder utilities.
- Delete and rebuild derived rows whose trade event block is inside the sync window.
- Allow the rebuild query to read older `order_events` so trade rows can resolve the latest active `AddOrderV3` even when the order add predates the window.
- Wire derived-trade maintenance into the apply transaction before the target watermark update.

## Checks

- `COMMIT_SHA=local nix develop -c cargo test -p raindex_common local_db::query --lib`
- `COMMIT_SHA=local nix develop -c cargo test -p raindex_common local_db::pipeline::adapters::apply --lib`
- `COMMIT_SHA=local nix develop -c cargo test -p raindex_common local_db::export --lib`
- `COMMIT_SHA=local nix develop -c cargo test -p raindex_common raindex_client::trades --lib`
