### PR TITLE
Superseded: Materialize vault deltas for balance sync

### DIFF
--- a/crates/common/src/local_db/pipeline/adapters/apply.rs
+++ b/crates/common/src/local_db/pipeline/adapters/apply.rs
@@ -7,6 +7,7 @@ use crate::local_db::insert::{
 };
 use crate::local_db::query::fetch_erc20_tokens_by_addresses::Erc20TokenRow;
 use crate::local_db::query::upsert_derived_trades::upsert_derived_trades_batch;
+use crate::local_db::query::upsert_derived_vault_deltas::upsert_derived_vault_deltas_batch;
 use crate::local_db::query::upsert_target_watermark::upsert_target_watermark_stmt;
 use crate::local_db::query::upsert_vault_balances::upsert_vault_balances_batch;
 use crate::local_db::query::{LocalDbQueryExecutor, SqlStatement, SqlStatementBatch};
@@ -81,8 +82,13 @@ pub trait ApplyPipeline {
             build_decoded_event_sql(&target_info.raindex_id, decoded_events, &decimals_by_token)?;
         batch.extend(decoded_batch);
 
-        // Vault balance change/running balance updates
+        // Derived delta refresh plus vault balance change/running balance updates
         if target_info.start_block <= target_info.target_block {
+            batch.extend(upsert_derived_vault_deltas_batch(
+                &target_info.raindex_id,
+                target_info.start_block,
+                target_info.target_block,
+            ));
             batch.extend(upsert_vault_balances_batch(
                 &target_info.raindex_id,
                 target_info.start_block,
@@ -369,7 +375,13 @@ mod tests {
 
         // Expect derived state refreshes plus the watermark and ANALYZE when there is no work.
         let texts: Vec<_> = batch.statements().iter().map(|s| s.sql().trim()).collect();
-        assert_eq!(texts.len(), 6);
+        assert_eq!(texts.len(), 8);
+        assert!(texts
+            .iter()
+            .any(|s| s.contains("DELETE FROM derived_vault_deltas")));
+        assert!(texts
+            .iter()
+            .any(|s| s.contains("INSERT OR REPLACE INTO derived_vault_deltas")));
         assert!(texts.iter().any(|s| s.contains("vault_balance_changes")));
         assert!(texts
             .iter()
@@ -1042,7 +1054,12 @@ mod tests {
             .iter()
             .position(|s| s.sql().starts_with("INSERT INTO target_watermarks"))
             .expect("watermark present");
-        let idx_derived = batch
+        let idx_derived_vault_deltas = batch
+            .statements()
+            .iter()
+            .position(|s| s.sql().starts_with("DELETE FROM derived_vault_deltas"))
+            .expect("derived vault deltas refresh present");
+        let idx_derived_trades = batch
             .statements()
             .iter()
             .position(|s| s.sql().starts_with("DELETE FROM derived_trades"))
@@ -1050,9 +1067,16 @@ mod tests {
 
         assert!(idx_raw < idx_token, "raw should precede token upserts");
         assert!(idx_token < idx_decoded, "token upserts before decoded");
-        assert!(idx_decoded < idx_derived, "decoded before derived refresh");
         assert!(
-            idx_derived < idx_watermark,
+            idx_decoded < idx_derived_vault_deltas,
+            "decoded before derived vault deltas refresh"
+        );
+        assert!(
+            idx_derived_vault_deltas < idx_derived_trades,
+            "vault deltas refresh before derived trades"
+        );
+        assert!(
+            idx_derived_trades < idx_watermark,
             "derived refresh before watermark"
         );
     }

--- a/crates/common/src/local_db/query/clear_raindex_data/query.sql
+++ b/crates/common/src/local_db/query/clear_raindex_data/query.sql
@@ -51,6 +51,9 @@ WHERE chain_id = ?1 AND raindex_address = ?2;
 DELETE FROM running_vault_balances
 WHERE chain_id = ?1 AND raindex_address = ?2;
 
+DELETE FROM derived_vault_deltas
+WHERE chain_id = ?1 AND raindex_address = ?2;
+
 DELETE FROM derived_trades
 WHERE chain_id = ?1 AND raindex_address = ?2;
 

--- a/crates/common/src/local_db/query/clear_tables/query.sql
+++ b/crates/common/src/local_db/query/clear_tables/query.sql
@@ -20,6 +20,7 @@ DROP TABLE IF EXISTS interpreter_store_sets;
 DROP TABLE IF EXISTS sync_status;
 DROP TABLE IF EXISTS vault_balance_changes;
 DROP TABLE IF EXISTS running_vault_balances;
+DROP TABLE IF EXISTS derived_vault_deltas;
 DROP TABLE IF EXISTS derived_trades;
 
 COMMIT;

--- a/crates/common/src/local_db/query/create_tables/mod.rs
+++ b/crates/common/src/local_db/query/create_tables/mod.rs
@@ -21,6 +21,7 @@ pub const REQUIRED_TABLES: &[&str] = &[
     "interpreter_store_sets",
     "vault_balance_changes",
     "running_vault_balances",
+    "derived_vault_deltas",
     "derived_trades",
 ];
 
@@ -197,6 +198,7 @@ mod tests {
         assert!(by_table["target_watermarks"].contains(&"raindex_address".to_string()));
         assert!(by_table["order_events"].contains(&"order_hash".to_string()));
         assert!(by_table["running_vault_balances"].contains(&"balance".to_string()));
+        assert!(by_table["derived_vault_deltas"].contains(&"delta".to_string()));
         assert!(by_table["derived_trades"].contains(&"trade_id".to_string()));
         assert!(!by_table["order_ios"].contains(&"foreign".to_string()));
     }

--- a/crates/common/src/local_db/query/create_tables/query.sql
+++ b/crates/common/src/local_db/query/create_tables/query.sql
@@ -351,6 +351,34 @@ CREATE INDEX idx_rvb_token ON running_vault_balances(chain_id, raindex_address, 
 
 -- Pipeline-maintained read models use the `derived_` prefix. These tables are
 -- not DB-native materialized views; they are rebuilt by local DB sync writes.
+CREATE TABLE IF NOT EXISTS derived_vault_deltas (
+    chain_id INTEGER NOT NULL,
+    raindex_address TEXT NOT NULL,
+    transaction_hash TEXT NOT NULL,
+    log_index INTEGER NOT NULL,
+    block_number INTEGER NOT NULL,
+    block_timestamp INTEGER NOT NULL,
+    owner TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    token TEXT NOT NULL,
+    vault_id TEXT NOT NULL,
+    delta TEXT NOT NULL,
+    PRIMARY KEY (
+        chain_id,
+        raindex_address,
+        transaction_hash,
+        log_index,
+        owner,
+        kind,
+        token,
+        vault_id
+    )
+);
+CREATE INDEX idx_derived_vault_deltas_window
+    ON derived_vault_deltas(chain_id, raindex_address, block_number, log_index);
+CREATE INDEX idx_derived_vault_deltas_balance_key
+    ON derived_vault_deltas(chain_id, raindex_address, owner, token, vault_id, block_number, log_index);
+
 CREATE TABLE IF NOT EXISTS derived_trades (
     chain_id INTEGER NOT NULL,
     raindex_address TEXT NOT NULL,

--- a/crates/common/src/local_db/query/mod.rs
+++ b/crates/common/src/local_db/query/mod.rs
@@ -31,6 +31,7 @@ pub mod sql_statement;
 pub mod sql_statement_batch;
 pub mod update_last_synced_block;
 pub mod upsert_derived_trades;
+pub mod upsert_derived_vault_deltas;
 pub mod upsert_target_watermark;
 pub mod upsert_vault_balances;
 

--- a/crates/common/src/local_db/query/upsert_derived_vault_deltas/mod.rs
+++ b/crates/common/src/local_db/query/upsert_derived_vault_deltas/mod.rs
@@ -1,0 +1,320 @@
+use crate::local_db::{
+    query::{SqlStatement, SqlStatementBatch, SqlValue},
+    RaindexIdentifier,
+};
+
+const INSERT_DERIVED_VAULT_DELTAS_SQL: &str = include_str!("query.sql");
+
+pub fn upsert_derived_vault_deltas_batch(
+    raindex_id: &RaindexIdentifier,
+    start_block: u64,
+    end_block: u64,
+) -> SqlStatementBatch {
+    SqlStatementBatch::from(vec![
+        delete_derived_vault_deltas_stmt(raindex_id, start_block, end_block),
+        insert_derived_vault_deltas_stmt(raindex_id, start_block, end_block),
+    ])
+}
+
+fn delete_derived_vault_deltas_stmt(
+    raindex_id: &RaindexIdentifier,
+    start_block: u64,
+    end_block: u64,
+) -> SqlStatement {
+    SqlStatement::new_with_params(
+        "DELETE FROM derived_vault_deltas
+WHERE chain_id = ?1
+  AND raindex_address = ?2
+  AND block_number BETWEEN ?3 AND ?4",
+        bind_params(raindex_id, start_block, end_block),
+    )
+}
+
+fn insert_derived_vault_deltas_stmt(
+    raindex_id: &RaindexIdentifier,
+    start_block: u64,
+    end_block: u64,
+) -> SqlStatement {
+    SqlStatement::new_with_params(
+        INSERT_DERIVED_VAULT_DELTAS_SQL,
+        bind_params(raindex_id, start_block, end_block),
+    )
+}
+
+fn bind_params(raindex_id: &RaindexIdentifier, start_block: u64, end_block: u64) -> [SqlValue; 4] {
+    [
+        SqlValue::from(raindex_id.chain_id),
+        SqlValue::from(raindex_id.raindex_address),
+        SqlValue::from(start_block),
+        SqlValue::from(end_block),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::primitives::Address;
+
+    #[test]
+    fn batch_binds_delete_and_insert_params() {
+        let raindex_id = RaindexIdentifier::new(111, Address::from([0x11u8; 20]));
+        let batch = upsert_derived_vault_deltas_batch(&raindex_id, 100, 200);
+
+        assert_eq!(batch.len(), 2);
+        for stmt in batch.statements() {
+            assert_eq!(stmt.params().len(), 4);
+            assert_eq!(stmt.params()[0], SqlValue::U64(111));
+            assert_eq!(
+                stmt.params()[1],
+                SqlValue::Text(raindex_id.raindex_address.to_string())
+            );
+            assert_eq!(stmt.params()[2], SqlValue::U64(100));
+            assert_eq!(stmt.params()[3], SqlValue::U64(200));
+        }
+    }
+
+    #[test]
+    fn batch_deletes_window_before_rebuilding() {
+        let batch =
+            upsert_derived_vault_deltas_batch(&RaindexIdentifier::new(1, Address::ZERO), 0, 10);
+        let statements = batch.statements();
+
+        assert!(statements[0]
+            .sql()
+            .contains("DELETE FROM derived_vault_deltas"));
+        assert!(statements[0]
+            .sql()
+            .contains("block_number BETWEEN ?3 AND ?4"));
+        assert!(statements[1]
+            .sql()
+            .contains("INSERT OR REPLACE INTO derived_vault_deltas"));
+    }
+
+    #[test]
+    fn insert_is_window_bounded_from_vault_deltas() {
+        let batch =
+            upsert_derived_vault_deltas_batch(&RaindexIdentifier::new(1, Address::ZERO), 0, 10);
+        let sql = batch.statements()[1].sql();
+
+        assert!(sql.contains("FROM vault_deltas vd"));
+        assert!(sql.contains("vd.block_number BETWEEN ?3 AND ?4"));
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    mod sqlite_integration {
+        use super::*;
+        use crate::local_db::query::create_tables::CREATE_TABLES_SQL;
+        use crate::local_db::query::create_views::create_views_batch;
+        use rain_math_float::Float;
+        use rusqlite::{params, Connection};
+
+        const CHAIN_ID: u32 = 8453;
+        const RAINDEX: &str = "0xe522cb4a5fcb2eb31a52ff41a4653d85a4fd7c9d";
+        const OWNER: &str = "0xowner";
+        const TOKEN: &str = "0xtoken";
+        const VAULT: &str = "1";
+
+        fn setup_conn() -> Connection {
+            let conn = Connection::open_in_memory().expect("open sqlite");
+            crate::local_db::functions::register_all(&conn).expect("register local db functions");
+            conn.execute_batch(CREATE_TABLES_SQL)
+                .expect("create tables");
+            for stmt in create_views_batch().statements() {
+                conn.execute_batch(stmt.sql()).expect("create views");
+            }
+            conn
+        }
+
+        fn raindex_id() -> RaindexIdentifier {
+            RaindexIdentifier::new(CHAIN_ID, RAINDEX.parse().expect("valid raindex"))
+        }
+
+        fn float(value: &str) -> String {
+            Float::parse(value.to_string())
+                .expect("valid float")
+                .as_hex()
+        }
+
+        fn tx(byte: u8) -> String {
+            format!("0x{:064x}", byte)
+        }
+
+        fn sqlvalue_to_rusqlite(v: SqlValue) -> rusqlite::types::Value {
+            match v {
+                SqlValue::Text(t) => rusqlite::types::Value::Text(t),
+                SqlValue::I64(i) => rusqlite::types::Value::Integer(i),
+                SqlValue::U64(u) => rusqlite::types::Value::Integer(u as i64),
+                SqlValue::Null => rusqlite::types::Value::Null,
+            }
+        }
+
+        fn execute_stmt(conn: &Connection, stmt: &SqlStatement) {
+            if stmt.params().is_empty() {
+                conn.execute_batch(stmt.sql()).expect("execute SQL batch");
+                return;
+            }
+
+            let params = stmt
+                .params()
+                .iter()
+                .cloned()
+                .map(sqlvalue_to_rusqlite)
+                .collect::<Vec<_>>();
+            conn.execute(stmt.sql(), rusqlite::params_from_iter(params))
+                .expect("execute SQL statement");
+        }
+
+        fn execute_batch(conn: &Connection, batch: SqlStatementBatch) {
+            for stmt in batch.statements() {
+                execute_stmt(conn, stmt);
+            }
+        }
+
+        fn seed_deposit(conn: &Connection, block_number: u64, log_index: u64, amount: &str) {
+            conn.execute(
+                "INSERT INTO deposits (
+                    chain_id, raindex_address, transaction_hash, log_index, block_number,
+                    block_timestamp, sender, token, vault_id, deposit_amount, deposit_amount_uint256
+                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+                params![
+                    CHAIN_ID,
+                    RAINDEX,
+                    tx(log_index as u8),
+                    log_index,
+                    block_number,
+                    block_number + 1000,
+                    OWNER,
+                    TOKEN,
+                    VAULT,
+                    float(amount),
+                    amount
+                ],
+            )
+            .expect("insert deposit");
+        }
+
+        fn seed_withdrawal(conn: &Connection, block_number: u64, log_index: u64, amount: &str) {
+            conn.execute(
+                "INSERT INTO withdrawals (
+                    chain_id, raindex_address, transaction_hash, log_index, block_number,
+                    block_timestamp, sender, token, vault_id, target_amount, withdraw_amount,
+                    withdraw_amount_uint256
+                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+                params![
+                    CHAIN_ID,
+                    RAINDEX,
+                    tx(log_index as u8),
+                    log_index,
+                    block_number,
+                    block_number + 1000,
+                    OWNER,
+                    TOKEN,
+                    VAULT,
+                    float(amount),
+                    float(amount),
+                    amount
+                ],
+            )
+            .expect("insert withdrawal");
+        }
+
+        #[test]
+        fn rebuilds_window_and_matches_vault_deltas_view() {
+            let conn = setup_conn();
+            seed_deposit(&conn, 20, 1, "10");
+            seed_withdrawal(&conn, 30, 2, "4");
+
+            execute_batch(
+                &conn,
+                upsert_derived_vault_deltas_batch(&raindex_id(), 20, 30),
+            );
+
+            let view_rows: Vec<(String, String)> = conn
+                .prepare(
+                    "SELECT kind, delta FROM vault_deltas
+                     WHERE block_number BETWEEN 20 AND 30
+                     ORDER BY block_number, log_index",
+                )
+                .expect("prepare view query")
+                .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+                .expect("query view")
+                .collect::<Result<_, _>>()
+                .expect("view rows");
+            let derived_rows: Vec<(String, String)> = conn
+                .prepare(
+                    "SELECT kind, delta FROM derived_vault_deltas
+                     ORDER BY block_number, log_index",
+                )
+                .expect("prepare derived query")
+                .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+                .expect("query derived")
+                .collect::<Result<_, _>>()
+                .expect("derived rows");
+
+            assert_eq!(derived_rows, view_rows);
+            assert_eq!(derived_rows.len(), 2);
+            assert_eq!(derived_rows[0].0, "DEPOSIT");
+            assert_eq!(derived_rows[1].0, "WITHDRAW");
+        }
+
+        #[test]
+        fn incremental_windows_replace_only_target_range() {
+            let conn = setup_conn();
+            seed_deposit(&conn, 20, 1, "10");
+            seed_deposit(&conn, 30, 2, "12");
+
+            execute_batch(
+                &conn,
+                upsert_derived_vault_deltas_batch(&raindex_id(), 20, 20),
+            );
+            execute_batch(
+                &conn,
+                upsert_derived_vault_deltas_batch(&raindex_id(), 30, 30),
+            );
+
+            assert_eq!(
+                conn.query_row("SELECT COUNT(*) FROM derived_vault_deltas", [], |row| {
+                    row.get::<_, i64>(0)
+                })
+                .expect("count"),
+                2
+            );
+
+            conn.execute(
+                "UPDATE deposits SET deposit_amount = ?1 WHERE block_number = 20",
+                params![float("99")],
+            )
+            .expect("update source deposit");
+            execute_batch(
+                &conn,
+                upsert_derived_vault_deltas_batch(&raindex_id(), 20, 20),
+            );
+
+            assert_eq!(
+                conn.query_row("SELECT COUNT(*) FROM derived_vault_deltas", [], |row| {
+                    row.get::<_, i64>(0)
+                })
+                .expect("count"),
+                2
+            );
+            assert_eq!(
+                conn.query_row(
+                    "SELECT delta FROM derived_vault_deltas WHERE block_number = 20",
+                    [],
+                    |row| row.get::<_, String>(0)
+                )
+                .expect("block 20 delta"),
+                float("99")
+            );
+            assert_eq!(
+                conn.query_row(
+                    "SELECT delta FROM derived_vault_deltas WHERE block_number = 30",
+                    [],
+                    |row| row.get::<_, String>(0)
+                )
+                .expect("block 30 delta"),
+                float("12")
+            );
+        }
+    }
+}

--- a/crates/common/src/local_db/query/upsert_derived_vault_deltas/query.sql
+++ b/crates/common/src/local_db/query/upsert_derived_vault_deltas/query.sql
@@ -1,0 +1,29 @@
+INSERT OR REPLACE INTO derived_vault_deltas (
+  chain_id,
+  raindex_address,
+  transaction_hash,
+  log_index,
+  block_number,
+  block_timestamp,
+  owner,
+  kind,
+  token,
+  vault_id,
+  delta
+)
+SELECT
+  vd.chain_id,
+  vd.raindex_address,
+  vd.transaction_hash,
+  vd.log_index,
+  vd.block_number,
+  vd.block_timestamp,
+  vd.owner,
+  vd.kind,
+  vd.token,
+  vd.vault_id,
+  vd.delta
+FROM vault_deltas vd
+WHERE vd.chain_id = ?1
+  AND vd.raindex_address = ?2
+  AND vd.block_number BETWEEN ?3 AND ?4;

--- a/crates/common/src/local_db/query/upsert_vault_balances/insert_balance_changes.sql
+++ b/crates/common/src/local_db/query/upsert_vault_balances/insert_balance_changes.sql
@@ -23,7 +23,7 @@ filtered AS (
       ORDER BY vd.block_number, vd.log_index
     ) AS rn,
     COALESCE(rvb.balance, FLOAT_ZERO_HEX()) AS prefix_balance
-  FROM vault_deltas vd
+  FROM derived_vault_deltas vd
   JOIN params p
     ON p.chain_id = vd.chain_id
    AND p.raindex_address = vd.raindex_address

--- a/crates/common/src/local_db/query/upsert_vault_balances/insert_running_balances.sql
+++ b/crates/common/src/local_db/query/upsert_vault_balances/insert_running_balances.sql
@@ -6,7 +6,7 @@ WITH latest_blocks AS (
     token,
     vault_id,
     MAX(block_number) AS last_block
-  FROM vault_deltas vd
+  FROM derived_vault_deltas vd
   WHERE vd.chain_id = ?1
     AND vd.raindex_address = ?2
     AND vd.block_number BETWEEN ?3 AND ?4
@@ -26,7 +26,7 @@ delta_batches AS (
     lb.last_block,
     (
       SELECT MAX(vd2.log_index)
-      FROM vault_deltas vd2
+      FROM derived_vault_deltas vd2
       WHERE vd2.chain_id = vd.chain_id
         AND vd2.raindex_address = vd.raindex_address
         AND vd2.owner = vd.owner
@@ -34,7 +34,7 @@ delta_batches AS (
         AND vd2.vault_id = vd.vault_id
         AND vd2.block_number = lb.last_block
     ) AS last_log_index
-  FROM vault_deltas vd
+  FROM derived_vault_deltas vd
   JOIN latest_blocks lb
     ON lb.chain_id = vd.chain_id
    AND lb.raindex_address = vd.raindex_address

--- a/crates/settings/src/local_db_manifest.rs
+++ b/crates/settings/src/local_db_manifest.rs
@@ -9,7 +9,7 @@ use strict_yaml_rust::{strict_yaml::Hash, StrictYaml, StrictYamlEmitter};
 use url::Url;
 
 pub const MANIFEST_VERSION: u32 = 1;
-pub const DB_SCHEMA_VERSION: u32 = 4;
+pub const DB_SCHEMA_VERSION: u32 = 5;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct LocalDbManifest {
@@ -534,18 +534,18 @@ mod tests {
         // OK header
         let yaml_ok = r#"
 manifest-version: 1
-db-schema-version: 3
+db-schema-version: 5
 networks: {}
 "#;
         let doc = load(yaml_ok);
         let (mv, sv) = parse_manifest_header(&doc, "manifest").expect("header parses");
         assert_eq!(mv, 1);
-        assert_eq!(sv, 3);
+        assert_eq!(sv, 5);
 
         // Incompatible manifest version
         let yaml_bad = r#"
 manifest-version: 999
-db-schema-version: 3
+db-schema-version: 5
 networks: {}
 "#;
         let err = parse_manifest_header(&load(yaml_bad), "manifest").unwrap_err();
@@ -583,7 +583,7 @@ networks: {}
     fn test_networks_helper_empty_key_rejected() {
         let yaml = r#"
 manifest-version: 1
-db-schema-version: 3
+db-schema-version: 5
 networks:
   "":
     chain-id: 1
@@ -644,7 +644,7 @@ end-block-time-ms: 1
     #[test]
     fn test_missing_manifest_version() {
         let yaml = r#"
-db-schema-version: 3
+db-schema-version: 5
 networks: {}
 "#;
         let err = parse_manifest_doc(&load(yaml)).unwrap_err();
@@ -665,7 +665,7 @@ networks: {}
     fn test_missing_networks_defaults_to_empty() {
         let yaml = r#"
 manifest-version: 1
-db-schema-version: 3
+db-schema-version: 5
 "#;
         let manifest = parse_manifest_doc(&load(yaml)).unwrap();
         assert!(manifest.networks.is_empty());
@@ -695,7 +695,7 @@ networks: {}
     fn test_zero_or_invalid_manifest_and_schema_versions() {
         let yaml_zero_manifest = r#"
 manifest-version: 0
-db-schema-version: 3
+db-schema-version: 5
 networks: {}
 "#;
         let err = parse_manifest_doc(&load(yaml_zero_manifest)).unwrap_err();
@@ -714,7 +714,7 @@ networks: {}
     fn test_network_missing_chain_id_and_invalid() {
         let yaml_missing = r#"
 manifest-version: 1
-db-schema-version: 3
+db-schema-version: 5
 networks:
   mainnet: {}
 "#;
@@ -723,7 +723,7 @@ networks:
 
         let yaml_zero = r#"
 manifest-version: 1
-db-schema-version: 3
+db-schema-version: 5
 networks:
   mainnet:
     chain-id: 0
@@ -737,7 +737,7 @@ networks:
     fn test_raindexes_required_and_type() {
         let yaml_missing = r#"
 manifest-version: 1
-db-schema-version: 3
+db-schema-version: 5
 networks:
   mainnet:
     chain-id: 1
@@ -747,7 +747,7 @@ networks:
 
         let yaml_non_list = r#"
 manifest-version: 1
-db-schema-version: 3
+db-schema-version: 5
 networks:
   mainnet:
     chain-id: 1
@@ -762,7 +762,7 @@ networks:
         // Full, valid baseline
         let good = r#"
 manifest-version: 1
-db-schema-version: 3
+db-schema-version: 5
 networks:
   mainnet:
     chain-id: 1
@@ -778,7 +778,7 @@ networks:
         // Now omit each required field individually
         let missing_address = r#"
 manifest-version: 1
-db-schema-version: 3
+db-schema-version: 5
 networks:
   mainnet:
     chain-id: 1
@@ -795,7 +795,7 @@ networks:
 
         let missing_dump = r#"
 manifest-version: 1
-db-schema-version: 3
+db-schema-version: 5
 networks:
   mainnet:
     chain-id: 1
@@ -812,7 +812,7 @@ networks:
 
         let missing_end_block = r#"
 manifest-version: 1
-db-schema-version: 3
+db-schema-version: 5
 networks:
   mainnet:
     chain-id: 1
@@ -829,7 +829,7 @@ networks:
 
         let missing_end_hash = r#"
 manifest-version: 1
-db-schema-version: 3
+db-schema-version: 5
 networks:
   mainnet:
     chain-id: 1
@@ -846,7 +846,7 @@ networks:
 
         let missing_end_time = r#"
 manifest-version: 1
-db-schema-version: 3
+db-schema-version: 5
 networks:
   mainnet:
     chain-id: 1
@@ -866,7 +866,7 @@ networks:
     fn test_find_across_networks_and_negatives() {
         let yaml = r#"
 manifest-version: 1
-db-schema-version: 3
+db-schema-version: 5
 networks:
   mainnet:
     chain-id: 1
@@ -924,7 +924,7 @@ networks:
     fn test_incompatible_manifest_version_rejected() {
         let yaml = r#"
 manifest-version: 999
-db-schema-version: 3
+db-schema-version: 5
 networks: {}
 "#;
         let err = parse_manifest_doc(&load(yaml)).unwrap_err();
@@ -944,7 +944,7 @@ networks: {}
     fn test_empty_network_key_is_rejected() {
         let yaml = r#"
 manifest-version: 1
-db-schema-version: 3
+db-schema-version: 5
 networks:
   "":
     chain-id: 1


### PR DESCRIPTION
Superseded by standalone PR #2592, which is based directly on `main` and does not depend on the derived-trades stack.

Keeping this PR out of review to avoid coupling the vault-delta optimization to the derived-trades stack.