### PR TITLE
Materialize vault deltas for balance sync

### DIFF
--- a/crates/cli/src/commands/local_db/pipeline/runner/manifest.rs
+++ b/crates/cli/src/commands/local_db/pipeline/runner/manifest.rs
@@ -309,7 +309,7 @@ mod tests {
             .expect("manifest build succeeds");
 
         assert_eq!(manifest.manifest_version, 1);
-        assert_eq!(manifest.db_schema_version, 3);
+        assert_eq!(manifest.db_schema_version, DB_SCHEMA_VERSION);
         assert_eq!(manifest.networks.len(), 2);
 
         let anvil = manifest.networks.get("anvil").expect("anvil network");
@@ -495,7 +495,7 @@ mod tests {
 
         assert!(manifest.networks.is_empty());
         assert_eq!(manifest.manifest_version, 1);
-        assert_eq!(manifest.db_schema_version, 3);
+        assert_eq!(manifest.db_schema_version, DB_SCHEMA_VERSION);
     }
 
     #[test]

--- a/crates/common/src/local_db/pipeline/adapters/apply.rs
+++ b/crates/common/src/local_db/pipeline/adapters/apply.rs
@@ -6,6 +6,7 @@ use crate::local_db::insert::{
     raw_events_to_statements as build_raw_event_sql,
 };
 use crate::local_db::query::fetch_erc20_tokens_by_addresses::Erc20TokenRow;
+use crate::local_db::query::upsert_derived_vault_deltas::upsert_derived_vault_deltas_batch;
 use crate::local_db::query::upsert_target_watermark::upsert_target_watermark_stmt;
 use crate::local_db::query::upsert_vault_balances::upsert_vault_balances_batch;
 use crate::local_db::query::{LocalDbQueryExecutor, SqlStatement, SqlStatementBatch};
@@ -80,8 +81,13 @@ pub trait ApplyPipeline {
             build_decoded_event_sql(&target_info.raindex_id, decoded_events, &decimals_by_token)?;
         batch.extend(decoded_batch);
 
-        // Vault balance change/running balance updates
+        // Derived delta refresh plus vault balance change/running balance updates
         if target_info.start_block <= target_info.target_block {
+            batch.extend(upsert_derived_vault_deltas_batch(
+                &target_info.raindex_id,
+                target_info.start_block,
+                target_info.target_block,
+            ));
             batch.extend(upsert_vault_balances_batch(
                 &target_info.raindex_id,
                 target_info.start_block,
@@ -363,7 +369,13 @@ mod tests {
 
         // Expect vault balance refresh plus the watermark and ANALYZE when there is no work.
         let texts: Vec<_> = batch.statements().iter().map(|s| s.sql().trim()).collect();
-        assert_eq!(texts.len(), 4);
+        assert_eq!(texts.len(), 6);
+        assert!(texts
+            .iter()
+            .any(|s| s.contains("DELETE FROM derived_vault_deltas")));
+        assert!(texts
+            .iter()
+            .any(|s| s.contains("INSERT OR REPLACE INTO derived_vault_deltas")));
         assert!(texts.iter().any(|s| s.contains("vault_balance_changes")));
         assert!(texts
             .iter()
@@ -1030,10 +1042,22 @@ mod tests {
             .iter()
             .position(|s| s.sql().starts_with("INSERT INTO target_watermarks"))
             .expect("watermark present");
+        let idx_derived_vault_deltas = batch
+            .statements()
+            .iter()
+            .position(|s| s.sql().starts_with("DELETE FROM derived_vault_deltas"))
+            .expect("derived vault deltas refresh present");
 
         assert!(idx_raw < idx_token, "raw should precede token upserts");
         assert!(idx_token < idx_decoded, "token upserts before decoded");
-        assert!(idx_decoded < idx_watermark, "decoded before watermark");
+        assert!(
+            idx_decoded < idx_derived_vault_deltas,
+            "decoded before derived vault deltas refresh"
+        );
+        assert!(
+            idx_derived_vault_deltas < idx_watermark,
+            "derived vault deltas refresh before watermark"
+        );
     }
 
     #[test]

--- a/crates/common/src/local_db/pipeline/runner/environment.rs
+++ b/crates/common/src/local_db/pipeline/runner/environment.rs
@@ -154,7 +154,7 @@ mod tests {
     use crate::rpc_client::LogEntryResponse;
     use alloy::primitives::{address, b256, Address, B256};
     use async_trait::async_trait;
-    use raindex_app_settings::local_db_manifest::MANIFEST_VERSION;
+    use raindex_app_settings::local_db_manifest::{DB_SCHEMA_VERSION, MANIFEST_VERSION};
     use raindex_app_settings::local_db_remotes::LocalDbRemoteCfg;
     use raindex_app_settings::raindex::RaindexCfg;
     use raindex_app_settings::spec_version::SpecVersion;
@@ -725,7 +725,7 @@ raindexes:
         let manifest_yaml = format!(
             r#"
 manifest-version: {version}
-db-schema-version: 3
+db-schema-version: {db_schema_version}
 networks:
   mainnet:
     chain-id: 1
@@ -737,6 +737,7 @@ networks:
         end-block-time-ms: 1000
 "#,
             version = MANIFEST_VERSION,
+            db_schema_version = DB_SCHEMA_VERSION,
             base = server.base_url()
         );
 

--- a/crates/common/src/local_db/pipeline/runner/remotes.rs
+++ b/crates/common/src/local_db/pipeline/runner/remotes.rs
@@ -81,7 +81,7 @@ mod tests {
     use flate2::write::GzEncoder;
     use httpmock::prelude::*;
     use raindex_app_settings::local_db_manifest::{
-        LocalDbManifest, ManifestNetwork, ManifestRaindex, MANIFEST_VERSION,
+        LocalDbManifest, ManifestNetwork, ManifestRaindex, DB_SCHEMA_VERSION, MANIFEST_VERSION,
     };
     use raindex_app_settings::local_db_remotes::LocalDbRemoteCfg;
     use raindex_app_settings::raindex::RaindexCfg;
@@ -261,7 +261,7 @@ raindexes:
 
         let manifest_one = r#"
 manifest-version: 1
-db-schema-version: 3
+db-schema-version: 4
 networks:
   mainnet:
     chain-id: 1
@@ -275,7 +275,7 @@ networks:
 
         let manifest_two = r#"
 manifest-version: 1
-db-schema-version: 3
+db-schema-version: 4
 networks:
   goerli:
     chain-id: 5
@@ -325,15 +325,17 @@ networks:
         let manifest_one = format!(
             r#"
 manifest-version: {MANIFEST_VERSION}
-db-schema-version: 3
+db-schema-version: {DB_SCHEMA_VERSION}
 networks: {{}}
 "#
         );
-        let manifest_two = r#"
+        let manifest_two = format!(
+            r#"
 manifest-version: 2
-db-schema-version: 3
-networks: {}
-"#;
+db-schema-version: {DB_SCHEMA_VERSION}
+networks: {{}}
+"#
+        );
 
         server_one.mock(|when, then| {
             when.method(GET).path("/");

--- a/crates/common/src/local_db/query/clear_raindex_data/query.sql
+++ b/crates/common/src/local_db/query/clear_raindex_data/query.sql
@@ -51,4 +51,7 @@ WHERE chain_id = ?1 AND raindex_address = ?2;
 DELETE FROM running_vault_balances
 WHERE chain_id = ?1 AND raindex_address = ?2;
 
+DELETE FROM derived_vault_deltas
+WHERE chain_id = ?1 AND raindex_address = ?2;
+
 COMMIT;

--- a/crates/common/src/local_db/query/clear_tables/query.sql
+++ b/crates/common/src/local_db/query/clear_tables/query.sql
@@ -20,6 +20,7 @@ DROP TABLE IF EXISTS interpreter_store_sets;
 DROP TABLE IF EXISTS sync_status;
 DROP TABLE IF EXISTS vault_balance_changes;
 DROP TABLE IF EXISTS running_vault_balances;
+DROP TABLE IF EXISTS derived_vault_deltas;
 
 COMMIT;
 

--- a/crates/common/src/local_db/query/create_tables/mod.rs
+++ b/crates/common/src/local_db/query/create_tables/mod.rs
@@ -21,6 +21,7 @@ pub const REQUIRED_TABLES: &[&str] = &[
     "interpreter_store_sets",
     "vault_balance_changes",
     "running_vault_balances",
+    "derived_vault_deltas",
 ];
 
 pub fn create_tables_sql() -> &'static str {
@@ -196,6 +197,7 @@ mod tests {
         assert!(by_table["target_watermarks"].contains(&"raindex_address".to_string()));
         assert!(by_table["order_events"].contains(&"order_hash".to_string()));
         assert!(by_table["running_vault_balances"].contains(&"balance".to_string()));
+        assert!(by_table["derived_vault_deltas"].contains(&"delta".to_string()));
         assert!(!by_table["order_ios"].contains(&"foreign".to_string()));
     }
 }

--- a/crates/common/src/local_db/query/create_tables/query.sql
+++ b/crates/common/src/local_db/query/create_tables/query.sql
@@ -349,4 +349,34 @@ CREATE TABLE IF NOT EXISTS running_vault_balances (
 CREATE INDEX idx_rvb_owner ON running_vault_balances(chain_id, raindex_address, owner);
 CREATE INDEX idx_rvb_token ON running_vault_balances(chain_id, raindex_address, token, vault_id);
 
+-- Pipeline-maintained read models use the `derived_` prefix. These tables are
+-- not DB-native materialized views; they are rebuilt by local DB sync writes.
+CREATE TABLE IF NOT EXISTS derived_vault_deltas (
+    chain_id INTEGER NOT NULL,
+    raindex_address TEXT NOT NULL,
+    transaction_hash TEXT NOT NULL,
+    log_index INTEGER NOT NULL,
+    block_number INTEGER NOT NULL,
+    block_timestamp INTEGER NOT NULL,
+    owner TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    token TEXT NOT NULL,
+    vault_id TEXT NOT NULL,
+    delta TEXT NOT NULL,
+    PRIMARY KEY (
+        chain_id,
+        raindex_address,
+        transaction_hash,
+        log_index,
+        owner,
+        kind,
+        token,
+        vault_id
+    )
+);
+CREATE INDEX idx_derived_vault_deltas_window
+    ON derived_vault_deltas(chain_id, raindex_address, block_number, log_index);
+CREATE INDEX idx_derived_vault_deltas_balance_key
+    ON derived_vault_deltas(chain_id, raindex_address, owner, token, vault_id, block_number, log_index);
+
 COMMIT;

--- a/crates/common/src/local_db/query/mod.rs
+++ b/crates/common/src/local_db/query/mod.rs
@@ -30,6 +30,7 @@ pub mod integrity_check;
 pub mod sql_statement;
 pub mod sql_statement_batch;
 pub mod update_last_synced_block;
+pub mod upsert_derived_vault_deltas;
 pub mod upsert_target_watermark;
 pub mod upsert_vault_balances;
 

--- a/crates/common/src/local_db/query/upsert_derived_vault_deltas/mod.rs
+++ b/crates/common/src/local_db/query/upsert_derived_vault_deltas/mod.rs
@@ -1,0 +1,320 @@
+use crate::local_db::{
+    query::{SqlStatement, SqlStatementBatch, SqlValue},
+    RaindexIdentifier,
+};
+
+const INSERT_DERIVED_VAULT_DELTAS_SQL: &str = include_str!("query.sql");
+
+pub fn upsert_derived_vault_deltas_batch(
+    raindex_id: &RaindexIdentifier,
+    start_block: u64,
+    end_block: u64,
+) -> SqlStatementBatch {
+    SqlStatementBatch::from(vec![
+        delete_derived_vault_deltas_stmt(raindex_id, start_block, end_block),
+        insert_derived_vault_deltas_stmt(raindex_id, start_block, end_block),
+    ])
+}
+
+fn delete_derived_vault_deltas_stmt(
+    raindex_id: &RaindexIdentifier,
+    start_block: u64,
+    end_block: u64,
+) -> SqlStatement {
+    SqlStatement::new_with_params(
+        "DELETE FROM derived_vault_deltas
+WHERE chain_id = ?1
+  AND raindex_address = ?2
+  AND block_number BETWEEN ?3 AND ?4",
+        bind_params(raindex_id, start_block, end_block),
+    )
+}
+
+fn insert_derived_vault_deltas_stmt(
+    raindex_id: &RaindexIdentifier,
+    start_block: u64,
+    end_block: u64,
+) -> SqlStatement {
+    SqlStatement::new_with_params(
+        INSERT_DERIVED_VAULT_DELTAS_SQL,
+        bind_params(raindex_id, start_block, end_block),
+    )
+}
+
+fn bind_params(raindex_id: &RaindexIdentifier, start_block: u64, end_block: u64) -> [SqlValue; 4] {
+    [
+        SqlValue::from(raindex_id.chain_id),
+        SqlValue::from(raindex_id.raindex_address),
+        SqlValue::from(start_block),
+        SqlValue::from(end_block),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::primitives::Address;
+
+    #[test]
+    fn batch_binds_delete_and_insert_params() {
+        let raindex_id = RaindexIdentifier::new(111, Address::from([0x11u8; 20]));
+        let batch = upsert_derived_vault_deltas_batch(&raindex_id, 100, 200);
+
+        assert_eq!(batch.len(), 2);
+        for stmt in batch.statements() {
+            assert_eq!(stmt.params().len(), 4);
+            assert_eq!(stmt.params()[0], SqlValue::U64(111));
+            assert_eq!(
+                stmt.params()[1],
+                SqlValue::Text(raindex_id.raindex_address.to_string())
+            );
+            assert_eq!(stmt.params()[2], SqlValue::U64(100));
+            assert_eq!(stmt.params()[3], SqlValue::U64(200));
+        }
+    }
+
+    #[test]
+    fn batch_deletes_window_before_rebuilding() {
+        let batch =
+            upsert_derived_vault_deltas_batch(&RaindexIdentifier::new(1, Address::ZERO), 0, 10);
+        let statements = batch.statements();
+
+        assert!(statements[0]
+            .sql()
+            .contains("DELETE FROM derived_vault_deltas"));
+        assert!(statements[0]
+            .sql()
+            .contains("block_number BETWEEN ?3 AND ?4"));
+        assert!(statements[1]
+            .sql()
+            .contains("INSERT OR REPLACE INTO derived_vault_deltas"));
+    }
+
+    #[test]
+    fn insert_is_window_bounded_from_vault_deltas() {
+        let batch =
+            upsert_derived_vault_deltas_batch(&RaindexIdentifier::new(1, Address::ZERO), 0, 10);
+        let sql = batch.statements()[1].sql();
+
+        assert!(sql.contains("FROM vault_deltas vd"));
+        assert!(sql.contains("vd.block_number BETWEEN ?3 AND ?4"));
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    mod sqlite_integration {
+        use super::*;
+        use crate::local_db::query::create_tables::CREATE_TABLES_SQL;
+        use crate::local_db::query::create_views::create_views_batch;
+        use rain_math_float::Float;
+        use rusqlite::{params, Connection};
+
+        const CHAIN_ID: u32 = 8453;
+        const RAINDEX: &str = "0xe522cb4a5fcb2eb31a52ff41a4653d85a4fd7c9d";
+        const OWNER: &str = "0xowner";
+        const TOKEN: &str = "0xtoken";
+        const VAULT: &str = "1";
+
+        fn setup_conn() -> Connection {
+            let conn = Connection::open_in_memory().expect("open sqlite");
+            crate::local_db::functions::register_all(&conn).expect("register local db functions");
+            conn.execute_batch(CREATE_TABLES_SQL)
+                .expect("create tables");
+            for stmt in create_views_batch().statements() {
+                conn.execute_batch(stmt.sql()).expect("create views");
+            }
+            conn
+        }
+
+        fn raindex_id() -> RaindexIdentifier {
+            RaindexIdentifier::new(CHAIN_ID, RAINDEX.parse().expect("valid raindex"))
+        }
+
+        fn float(value: &str) -> String {
+            Float::parse(value.to_string())
+                .expect("valid float")
+                .as_hex()
+        }
+
+        fn tx(byte: u8) -> String {
+            format!("0x{:064x}", byte)
+        }
+
+        fn sqlvalue_to_rusqlite(v: SqlValue) -> rusqlite::types::Value {
+            match v {
+                SqlValue::Text(t) => rusqlite::types::Value::Text(t),
+                SqlValue::I64(i) => rusqlite::types::Value::Integer(i),
+                SqlValue::U64(u) => rusqlite::types::Value::Integer(u as i64),
+                SqlValue::Null => rusqlite::types::Value::Null,
+            }
+        }
+
+        fn execute_stmt(conn: &Connection, stmt: &SqlStatement) {
+            if stmt.params().is_empty() {
+                conn.execute_batch(stmt.sql()).expect("execute SQL batch");
+                return;
+            }
+
+            let params = stmt
+                .params()
+                .iter()
+                .cloned()
+                .map(sqlvalue_to_rusqlite)
+                .collect::<Vec<_>>();
+            conn.execute(stmt.sql(), rusqlite::params_from_iter(params))
+                .expect("execute SQL statement");
+        }
+
+        fn execute_batch(conn: &Connection, batch: SqlStatementBatch) {
+            for stmt in batch.statements() {
+                execute_stmt(conn, stmt);
+            }
+        }
+
+        fn seed_deposit(conn: &Connection, block_number: u64, log_index: u64, amount: &str) {
+            conn.execute(
+                "INSERT INTO deposits (
+                    chain_id, raindex_address, transaction_hash, log_index, block_number,
+                    block_timestamp, sender, token, vault_id, deposit_amount, deposit_amount_uint256
+                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+                params![
+                    CHAIN_ID,
+                    RAINDEX,
+                    tx(log_index as u8),
+                    log_index,
+                    block_number,
+                    block_number + 1000,
+                    OWNER,
+                    TOKEN,
+                    VAULT,
+                    float(amount),
+                    amount
+                ],
+            )
+            .expect("insert deposit");
+        }
+
+        fn seed_withdrawal(conn: &Connection, block_number: u64, log_index: u64, amount: &str) {
+            conn.execute(
+                "INSERT INTO withdrawals (
+                    chain_id, raindex_address, transaction_hash, log_index, block_number,
+                    block_timestamp, sender, token, vault_id, target_amount, withdraw_amount,
+                    withdraw_amount_uint256
+                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+                params![
+                    CHAIN_ID,
+                    RAINDEX,
+                    tx(log_index as u8),
+                    log_index,
+                    block_number,
+                    block_number + 1000,
+                    OWNER,
+                    TOKEN,
+                    VAULT,
+                    float(amount),
+                    float(amount),
+                    amount
+                ],
+            )
+            .expect("insert withdrawal");
+        }
+
+        #[test]
+        fn rebuilds_window_and_matches_vault_deltas_view() {
+            let conn = setup_conn();
+            seed_deposit(&conn, 20, 1, "10");
+            seed_withdrawal(&conn, 30, 2, "4");
+
+            execute_batch(
+                &conn,
+                upsert_derived_vault_deltas_batch(&raindex_id(), 20, 30),
+            );
+
+            let view_rows: Vec<(String, String)> = conn
+                .prepare(
+                    "SELECT kind, delta FROM vault_deltas
+                     WHERE block_number BETWEEN 20 AND 30
+                     ORDER BY block_number, log_index",
+                )
+                .expect("prepare view query")
+                .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+                .expect("query view")
+                .collect::<Result<_, _>>()
+                .expect("view rows");
+            let derived_rows: Vec<(String, String)> = conn
+                .prepare(
+                    "SELECT kind, delta FROM derived_vault_deltas
+                     ORDER BY block_number, log_index",
+                )
+                .expect("prepare derived query")
+                .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+                .expect("query derived")
+                .collect::<Result<_, _>>()
+                .expect("derived rows");
+
+            assert_eq!(derived_rows, view_rows);
+            assert_eq!(derived_rows.len(), 2);
+            assert_eq!(derived_rows[0].0, "DEPOSIT");
+            assert_eq!(derived_rows[1].0, "WITHDRAW");
+        }
+
+        #[test]
+        fn incremental_windows_replace_only_target_range() {
+            let conn = setup_conn();
+            seed_deposit(&conn, 20, 1, "10");
+            seed_deposit(&conn, 30, 2, "12");
+
+            execute_batch(
+                &conn,
+                upsert_derived_vault_deltas_batch(&raindex_id(), 20, 20),
+            );
+            execute_batch(
+                &conn,
+                upsert_derived_vault_deltas_batch(&raindex_id(), 30, 30),
+            );
+
+            assert_eq!(
+                conn.query_row("SELECT COUNT(*) FROM derived_vault_deltas", [], |row| {
+                    row.get::<_, i64>(0)
+                })
+                .expect("count"),
+                2
+            );
+
+            conn.execute(
+                "UPDATE deposits SET deposit_amount = ?1 WHERE block_number = 20",
+                params![float("99")],
+            )
+            .expect("update source deposit");
+            execute_batch(
+                &conn,
+                upsert_derived_vault_deltas_batch(&raindex_id(), 20, 20),
+            );
+
+            assert_eq!(
+                conn.query_row("SELECT COUNT(*) FROM derived_vault_deltas", [], |row| {
+                    row.get::<_, i64>(0)
+                })
+                .expect("count"),
+                2
+            );
+            assert_eq!(
+                conn.query_row(
+                    "SELECT delta FROM derived_vault_deltas WHERE block_number = 20",
+                    [],
+                    |row| row.get::<_, String>(0)
+                )
+                .expect("block 20 delta"),
+                float("99")
+            );
+            assert_eq!(
+                conn.query_row(
+                    "SELECT delta FROM derived_vault_deltas WHERE block_number = 30",
+                    [],
+                    |row| row.get::<_, String>(0)
+                )
+                .expect("block 30 delta"),
+                float("12")
+            );
+        }
+    }
+}

--- a/crates/common/src/local_db/query/upsert_derived_vault_deltas/query.sql
+++ b/crates/common/src/local_db/query/upsert_derived_vault_deltas/query.sql
@@ -1,0 +1,29 @@
+INSERT OR REPLACE INTO derived_vault_deltas (
+  chain_id,
+  raindex_address,
+  transaction_hash,
+  log_index,
+  block_number,
+  block_timestamp,
+  owner,
+  kind,
+  token,
+  vault_id,
+  delta
+)
+SELECT
+  vd.chain_id,
+  vd.raindex_address,
+  vd.transaction_hash,
+  vd.log_index,
+  vd.block_number,
+  vd.block_timestamp,
+  vd.owner,
+  vd.kind,
+  vd.token,
+  vd.vault_id,
+  vd.delta
+FROM vault_deltas vd
+WHERE vd.chain_id = ?1
+  AND vd.raindex_address = ?2
+  AND vd.block_number BETWEEN ?3 AND ?4;

--- a/crates/common/src/local_db/query/upsert_vault_balances/insert_balance_changes.sql
+++ b/crates/common/src/local_db/query/upsert_vault_balances/insert_balance_changes.sql
@@ -23,7 +23,7 @@ filtered AS (
       ORDER BY vd.block_number, vd.log_index
     ) AS rn,
     COALESCE(rvb.balance, FLOAT_ZERO_HEX()) AS prefix_balance
-  FROM vault_deltas vd
+  FROM derived_vault_deltas vd
   JOIN params p
     ON p.chain_id = vd.chain_id
    AND p.raindex_address = vd.raindex_address

--- a/crates/common/src/local_db/query/upsert_vault_balances/insert_running_balances.sql
+++ b/crates/common/src/local_db/query/upsert_vault_balances/insert_running_balances.sql
@@ -6,7 +6,7 @@ WITH latest_blocks AS (
     token,
     vault_id,
     MAX(block_number) AS last_block
-  FROM vault_deltas vd
+  FROM derived_vault_deltas vd
   WHERE vd.chain_id = ?1
     AND vd.raindex_address = ?2
     AND vd.block_number BETWEEN ?3 AND ?4
@@ -26,7 +26,7 @@ delta_batches AS (
     lb.last_block,
     (
       SELECT MAX(vd2.log_index)
-      FROM vault_deltas vd2
+      FROM derived_vault_deltas vd2
       WHERE vd2.chain_id = vd.chain_id
         AND vd2.raindex_address = vd.raindex_address
         AND vd2.owner = vd.owner
@@ -34,7 +34,7 @@ delta_batches AS (
         AND vd2.vault_id = vd.vault_id
         AND vd2.block_number = lb.last_block
     ) AS last_log_index
-  FROM vault_deltas vd
+  FROM derived_vault_deltas vd
   JOIN latest_blocks lb
     ON lb.chain_id = vd.chain_id
    AND lb.raindex_address = vd.raindex_address

--- a/crates/common/src/raindex_client/local_db/pipeline/runner/scheduler/native.rs
+++ b/crates/common/src/raindex_client/local_db/pipeline/runner/scheduler/native.rs
@@ -279,6 +279,8 @@ async fn run_network_loop<R: NativeRunner>(
                     }
                 }
                 RunOutcome::NotLeader => {
+                    sync_readiness.mark_ready(chain_id);
+                    status_store.record_chain_ready(chain_id);
                     status_store.record_network_status(NetworkSyncStatus::active(
                         chain_id,
                         SchedulerState::NotLeader,
@@ -579,11 +581,8 @@ mod tests {
             .run_until(async {
                 let calls = Arc::new(AtomicUsize::new(0));
                 let failures = Arc::new(AtomicUsize::new(0));
-                let runner = RecordingRunner::new(
-                    Arc::clone(&calls),
-                    Arc::clone(&failures),
-                    vec![None, Some(false)],
-                );
+                let runner =
+                    RecordingRunner::new(Arc::clone(&calls), Arc::clone(&failures), vec![None]);
                 let stop_flag = Arc::new(AtomicBool::new(false));
                 let readiness = SyncReadiness::new();
 
@@ -604,11 +603,11 @@ mod tests {
                 stop_flag.store(true, Ordering::SeqCst);
                 tokio::time::sleep(std::time::Duration::from_millis(10)).await;
 
-                assert!(calls.load(Ordering::SeqCst) >= 2);
+                assert!(calls.load(Ordering::SeqCst) >= 1);
                 assert_eq!(failures.load(Ordering::SeqCst), 0);
                 assert!(
                     readiness.is_ready(1),
-                    "chain should be marked ready after successful cycle"
+                    "observer should be able to read local DB"
                 );
             })
             .await;

--- a/crates/common/src/raindex_client/local_db/pipeline/runner/scheduler/wasm.rs
+++ b/crates/common/src/raindex_client/local_db/pipeline/runner/scheduler/wasm.rs
@@ -294,6 +294,8 @@ async fn run_network_loop<R>(
                 RunOutcome::NotLeader => {
                     was_leader_last_cycle = false;
                     set_scheduler_state(SchedulerState::NotLeader);
+                    sync_readiness.mark_ready(chain_id);
+                    status_store.record_chain_ready(chain_id);
                     emit_network_status(
                         &status_store,
                         callback.as_deref(),
@@ -523,6 +525,7 @@ mod wasm_tests {
             closure.forget();
             function
         };
+        let readiness = SyncReadiness::new();
 
         spawn_network_loop(
             runner,
@@ -530,7 +533,7 @@ mod wasm_tests {
             Some(Rc::new(status_callback)),
             Rc::clone(&stop_flag),
             1,
-            SyncReadiness::new(),
+            readiness.clone(),
             LocalDbSyncStatusStore::new(),
         );
 
@@ -551,6 +554,10 @@ mod wasm_tests {
             get_scheduler_state(),
             SchedulerState::Leader,
             "scheduler state should be Leader after recovering"
+        );
+        assert!(
+            readiness.is_ready(1),
+            "observer should be able to read local DB"
         );
     }
 

--- a/crates/settings/src/local_db_manifest.rs
+++ b/crates/settings/src/local_db_manifest.rs
@@ -9,7 +9,7 @@ use strict_yaml_rust::{strict_yaml::Hash, StrictYaml, StrictYamlEmitter};
 use url::Url;
 
 pub const MANIFEST_VERSION: u32 = 1;
-pub const DB_SCHEMA_VERSION: u32 = 3;
+pub const DB_SCHEMA_VERSION: u32 = 4;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct LocalDbManifest {
@@ -534,18 +534,18 @@ mod tests {
         // OK header
         let yaml_ok = r#"
 manifest-version: 1
-db-schema-version: 3
+db-schema-version: 4
 networks: {}
 "#;
         let doc = load(yaml_ok);
         let (mv, sv) = parse_manifest_header(&doc, "manifest").expect("header parses");
         assert_eq!(mv, 1);
-        assert_eq!(sv, 3);
+        assert_eq!(sv, 4);
 
         // Incompatible manifest version
         let yaml_bad = r#"
 manifest-version: 999
-db-schema-version: 3
+db-schema-version: 4
 networks: {}
 "#;
         let err = parse_manifest_header(&load(yaml_bad), "manifest").unwrap_err();
@@ -583,7 +583,7 @@ networks: {}
     fn test_networks_helper_empty_key_rejected() {
         let yaml = r#"
 manifest-version: 1
-db-schema-version: 3
+db-schema-version: 4
 networks:
   "":
     chain-id: 1
@@ -644,7 +644,7 @@ end-block-time-ms: 1
     #[test]
     fn test_missing_manifest_version() {
         let yaml = r#"
-db-schema-version: 3
+db-schema-version: 4
 networks: {}
 "#;
         let err = parse_manifest_doc(&load(yaml)).unwrap_err();
@@ -665,7 +665,7 @@ networks: {}
     fn test_missing_networks_defaults_to_empty() {
         let yaml = r#"
 manifest-version: 1
-db-schema-version: 3
+db-schema-version: 4
 "#;
         let manifest = parse_manifest_doc(&load(yaml)).unwrap();
         assert!(manifest.networks.is_empty());
@@ -695,7 +695,7 @@ networks: {}
     fn test_zero_or_invalid_manifest_and_schema_versions() {
         let yaml_zero_manifest = r#"
 manifest-version: 0
-db-schema-version: 3
+db-schema-version: 4
 networks: {}
 "#;
         let err = parse_manifest_doc(&load(yaml_zero_manifest)).unwrap_err();
@@ -714,7 +714,7 @@ networks: {}
     fn test_network_missing_chain_id_and_invalid() {
         let yaml_missing = r#"
 manifest-version: 1
-db-schema-version: 3
+db-schema-version: 4
 networks:
   mainnet: {}
 "#;
@@ -723,7 +723,7 @@ networks:
 
         let yaml_zero = r#"
 manifest-version: 1
-db-schema-version: 3
+db-schema-version: 4
 networks:
   mainnet:
     chain-id: 0
@@ -737,7 +737,7 @@ networks:
     fn test_raindexes_required_and_type() {
         let yaml_missing = r#"
 manifest-version: 1
-db-schema-version: 3
+db-schema-version: 4
 networks:
   mainnet:
     chain-id: 1
@@ -747,7 +747,7 @@ networks:
 
         let yaml_non_list = r#"
 manifest-version: 1
-db-schema-version: 3
+db-schema-version: 4
 networks:
   mainnet:
     chain-id: 1
@@ -762,7 +762,7 @@ networks:
         // Full, valid baseline
         let good = r#"
 manifest-version: 1
-db-schema-version: 3
+db-schema-version: 4
 networks:
   mainnet:
     chain-id: 1
@@ -778,7 +778,7 @@ networks:
         // Now omit each required field individually
         let missing_address = r#"
 manifest-version: 1
-db-schema-version: 3
+db-schema-version: 4
 networks:
   mainnet:
     chain-id: 1
@@ -795,7 +795,7 @@ networks:
 
         let missing_dump = r#"
 manifest-version: 1
-db-schema-version: 3
+db-schema-version: 4
 networks:
   mainnet:
     chain-id: 1
@@ -812,7 +812,7 @@ networks:
 
         let missing_end_block = r#"
 manifest-version: 1
-db-schema-version: 3
+db-schema-version: 4
 networks:
   mainnet:
     chain-id: 1
@@ -829,7 +829,7 @@ networks:
 
         let missing_end_hash = r#"
 manifest-version: 1
-db-schema-version: 3
+db-schema-version: 4
 networks:
   mainnet:
     chain-id: 1
@@ -846,7 +846,7 @@ networks:
 
         let missing_end_time = r#"
 manifest-version: 1
-db-schema-version: 3
+db-schema-version: 4
 networks:
   mainnet:
     chain-id: 1
@@ -866,7 +866,7 @@ networks:
     fn test_find_across_networks_and_negatives() {
         let yaml = r#"
 manifest-version: 1
-db-schema-version: 3
+db-schema-version: 4
 networks:
   mainnet:
     chain-id: 1
@@ -924,7 +924,7 @@ networks:
     fn test_incompatible_manifest_version_rejected() {
         let yaml = r#"
 manifest-version: 999
-db-schema-version: 3
+db-schema-version: 4
 networks: {}
 "#;
         let err = parse_manifest_doc(&load(yaml)).unwrap_err();
@@ -944,7 +944,7 @@ networks: {}
     fn test_empty_network_key_is_rejected() {
         let yaml = r#"
 manifest-version: 1
-db-schema-version: 3
+db-schema-version: 4
 networks:
   "":
     chain-id: 1

--- a/crates/settings/src/remote/manifest.rs
+++ b/crates/settings/src/remote/manifest.rs
@@ -56,7 +56,7 @@ mod tests {
         let server = MockServer::start_async().await;
         let yaml = r#"
 manifest-version: 1
-db-schema-version: 3
+db-schema-version: 4
 networks:
   mainnet:
     chain-id: 1
@@ -82,7 +82,7 @@ networks:
             .unwrap();
 
         assert_eq!(manifest.manifest_version, 1);
-        assert_eq!(manifest.db_schema_version, 3);
+        assert_eq!(manifest.db_schema_version, 4);
         let net = manifest.networks.get("mainnet").unwrap();
         assert_eq!(net.chain_id, 1);
         assert_eq!(net.raindexes.len(), 1);
@@ -107,7 +107,7 @@ networks:
         let server = MockServer::start_async().await;
         let yaml = r#"
 manifest-version: 1
-db-schema-version: 3
+db-schema-version: 4
 extra-root: ignored
 networks:
   goerli:
@@ -169,7 +169,7 @@ networks:
         let server = MockServer::start_async().await;
         let yaml = r#"
 manifest-version: 1
-db-schema-version: 3
+db-schema-version: 4
 networks:
   mainnet:
     chain-id: 1
@@ -215,7 +215,7 @@ networks:
 
         let yaml_one = r#"
 manifest-version: 1
-db-schema-version: 3
+db-schema-version: 4
 networks:
   mainnet:
     chain-id: 1
@@ -229,7 +229,7 @@ networks:
 
         let yaml_two = r#"
 manifest-version: 1
-db-schema-version: 3
+db-schema-version: 4
 networks:
   goerli:
     chain-id: 5

--- a/packages/ui-components/src/__tests__/TanstackAppTable.test.ts
+++ b/packages/ui-components/src/__tests__/TanstackAppTable.test.ts
@@ -103,6 +103,20 @@ test("shows empty message", async () => {
   );
 });
 
+test("shows loading skeleton instead of empty message during initial load", async () => {
+  const pages = createPages([]);
+  const mockQuery = createMockQuery(pages, {
+    isLoading: true,
+    isFetching: true,
+    status: "pending" as const,
+    fetchStatus: "fetching" as const,
+  });
+  renderTable(mockQuery);
+
+  expect(await screen.findByTestId("tableLoadingSkeleton")).toBeInTheDocument();
+  expect(screen.queryByTestId("emptyMessage")).not.toBeInTheDocument();
+});
+
 test("renders rows when first page is empty but later pages have data", async () => {
   const pages = writable({
     pages: [[], ["page1"]],

--- a/packages/ui-components/src/lib/components/TanstackAppTable.svelte
+++ b/packages/ui-components/src/lib/components/TanstackAppTable.svelte
@@ -1,259 +1,326 @@
 <script lang="ts" generics="DataItem, InputData = DataItem[]">
-	import { invalidateTanstackQueries } from '$lib/queries/queryClient';
-	import Refresh from './icon/Refresh.svelte';
-	import type { CreateInfiniteQueryResult, InfiniteData } from '@tanstack/svelte-query';
-	import { Button, Table, TableBody, TableBodyRow, TableHead } from 'flowbite-svelte';
-	import { afterUpdate, createEventDispatcher, onDestroy, onMount } from 'svelte';
-	import { useQueryClient } from '@tanstack/svelte-query';
-	import { createWindowVirtualizer, type SvelteVirtualizer } from '@tanstack/svelte-virtual';
-	import type { Readable } from 'svelte/store';
-	import type { VirtualItem } from '@tanstack/virtual-core';
+  import { invalidateTanstackQueries } from "$lib/queries/queryClient";
+  import Refresh from "./icon/Refresh.svelte";
+  import type {
+    CreateInfiniteQueryResult,
+    InfiniteData,
+  } from "@tanstack/svelte-query";
+  import {
+    Button,
+    Table,
+    TableBody,
+    TableBodyRow,
+    TableHead,
+  } from "flowbite-svelte";
+  import {
+    afterUpdate,
+    createEventDispatcher,
+    onDestroy,
+    onMount,
+  } from "svelte";
+  import { useQueryClient } from "@tanstack/svelte-query";
+  import {
+    createWindowVirtualizer,
+    type SvelteVirtualizer,
+  } from "@tanstack/svelte-virtual";
+  import type { Readable } from "svelte/store";
+  import type { VirtualItem } from "@tanstack/virtual-core";
 
-	const queryClient = useQueryClient();
+  const queryClient = useQueryClient();
 
-	const dispatch = createEventDispatcher();
+  const dispatch = createEventDispatcher();
 
-	export let queryKey: string;
-	export let query: CreateInfiniteQueryResult<InfiniteData<InputData, unknown>, Error>;
-	export let emptyMessage: string = 'None found';
-	export let rowHoverable = true;
-	// Selector to extract DataItem[] from each page of type InputData
-	export let dataSelector: (pageData: InputData) => DataItem[] = (pageData) =>
-		Array.isArray(pageData) ? (pageData as unknown as DataItem[]) : [];
+  export let queryKey: string;
+  export let query: CreateInfiniteQueryResult<
+    InfiniteData<InputData, unknown>,
+    Error
+  >;
+  export let emptyMessage: string = "None found";
+  export let rowHoverable = true;
+  // Selector to extract DataItem[] from each page of type InputData
+  export let dataSelector: (pageData: InputData) => DataItem[] = (pageData) =>
+    Array.isArray(pageData) ? (pageData as unknown as DataItem[]) : [];
 
-	type VirtualizationConfig = {
-		enabled?: boolean;
-		estimatedRowHeight?: number;
-		overscan?: number;
-	};
-	export let virtualization: VirtualizationConfig = {};
+  type VirtualizationConfig = {
+    enabled?: boolean;
+    estimatedRowHeight?: number;
+    overscan?: number;
+  };
+  export let virtualization: VirtualizationConfig = {};
 
-	$: enableVirtualization = virtualization.enabled ?? true;
-	$: estimatedRowHeight = virtualization.estimatedRowHeight ?? 56;
-	$: virtualizationOverscan = virtualization.overscan ?? 8;
+  $: enableVirtualization = virtualization.enabled ?? true;
+  $: estimatedRowHeight = virtualization.estimatedRowHeight ?? 56;
+  $: virtualizationOverscan = virtualization.overscan ?? 8;
 
-	let measuredRowHeight: number | null = null;
-	$: rowHeight = measuredRowHeight ?? estimatedRowHeight;
+  let measuredRowHeight: number | null = null;
+  $: rowHeight = measuredRowHeight ?? estimatedRowHeight;
 
-	// Transform the query data by applying dataSelector to each page only when the page
-	// reference or selector changes. This keeps the array reference stable so large tables
-	// don't re-render on every fetch status update.
-	let transformedPages: DataItem[][] = [];
-	let lastPagesRef: InputData[] | undefined;
-	let lastSelector = dataSelector;
-	$: {
-		const currentData = $query.data;
-		const currentPages = currentData?.pages;
-		const selectorChanged = lastSelector !== dataSelector;
-		if (!currentPages) {
-			transformedPages = [];
-			lastPagesRef = undefined;
-			lastSelector = dataSelector;
-		} else if (currentPages !== lastPagesRef || selectorChanged) {
-			transformedPages = currentPages.map((page) => dataSelector(page));
-			lastPagesRef = currentPages;
-			lastSelector = dataSelector;
-		}
-	}
+  // Transform the query data by applying dataSelector to each page only when the page
+  // reference or selector changes. This keeps the array reference stable so large tables
+  // don't re-render on every fetch status update.
+  let transformedPages: DataItem[][] = [];
+  let lastPagesRef: InputData[] | undefined;
+  let lastSelector = dataSelector;
+  $: {
+    const currentData = $query.data;
+    const currentPages = currentData?.pages;
+    const selectorChanged = lastSelector !== dataSelector;
+    if (!currentPages) {
+      transformedPages = [];
+      lastPagesRef = undefined;
+      lastSelector = dataSelector;
+    } else if (currentPages !== lastPagesRef || selectorChanged) {
+      transformedPages = currentPages.map((page) => dataSelector(page));
+      lastPagesRef = currentPages;
+      lastSelector = dataSelector;
+    }
+  }
 
-	// Helper derived values kept out of the main script block for readability
-	$: flattenedRows = transformedPages.flat();
-	$: totalRows = flattenedRows.length;
-	$: hasData = totalRows > 0;
+  // Helper derived values kept out of the main script block for readability
+  $: flattenedRows = transformedPages.flat();
+  $: totalRows = flattenedRows.length;
+  $: hasData = totalRows > 0;
+  $: isInitialLoading =
+    totalRows === 0 && ($query.isLoading || $query.isFetching);
 
-	// Virtualization (TanStack Virtual) tied to window scroll so the table keeps its natural height.
-	const hasWindow = typeof window !== 'undefined';
-	let tableContainerElement: HTMLDivElement | null = null;
-	let tableOffsetTop = 0;
-	let virtualizerStore: Readable<SvelteVirtualizer<Window, HTMLElement>> | null = null;
-	let virtualizer: SvelteVirtualizer<Window, HTMLElement> | null = null;
-	let unsubscribeVirtualizer: (() => void) | null = null;
-	let virtualizationActive = false;
+  // Virtualization (TanStack Virtual) tied to window scroll so the table keeps its natural height.
+  const hasWindow = typeof window !== "undefined";
+  let tableContainerElement: HTMLDivElement | null = null;
+  let tableOffsetTop = 0;
+  let virtualizerStore: Readable<
+    SvelteVirtualizer<Window, HTMLElement>
+  > | null = null;
+  let virtualizer: SvelteVirtualizer<Window, HTMLElement> | null = null;
+  let unsubscribeVirtualizer: (() => void) | null = null;
+  let virtualizationActive = false;
 
-	function updateTableOffset() {
-		if (!enableVirtualization || !hasWindow || !tableContainerElement) {
-			tableOffsetTop = 0;
-			return;
-		}
-		const rect = tableContainerElement.getBoundingClientRect();
-		tableOffsetTop = rect.top + window.scrollY;
-	}
+  function updateTableOffset() {
+    if (!enableVirtualization || !hasWindow || !tableContainerElement) {
+      tableOffsetTop = 0;
+      return;
+    }
+    const rect = tableContainerElement.getBoundingClientRect();
+    tableOffsetTop = rect.top + window.scrollY;
+  }
 
-	onMount(() => {
-		if (!hasWindow) {
-			return;
-		}
-		virtualizerStore = createWindowVirtualizer<HTMLElement>({
-			count: totalRows,
-			estimateSize: () => rowHeight,
-			overscan: virtualizationOverscan,
-			scrollMargin: tableOffsetTop,
-			getItemKey: (index) => index,
-			enabled: enableVirtualization && totalRows > 0
-		});
-		unsubscribeVirtualizer = virtualizerStore.subscribe((instance) => {
-			virtualizer = instance;
-		});
-		updateTableOffset();
-		return () => {
-			unsubscribeVirtualizer?.();
-		};
-	});
+  onMount(() => {
+    if (!hasWindow) {
+      return;
+    }
+    virtualizerStore = createWindowVirtualizer<HTMLElement>({
+      count: totalRows,
+      estimateSize: () => rowHeight,
+      overscan: virtualizationOverscan,
+      scrollMargin: tableOffsetTop,
+      getItemKey: (index) => index,
+      enabled: enableVirtualization && totalRows > 0,
+    });
+    unsubscribeVirtualizer = virtualizerStore.subscribe((instance) => {
+      virtualizer = instance;
+    });
+    updateTableOffset();
+    return () => {
+      unsubscribeVirtualizer?.();
+    };
+  });
 
-	afterUpdate(() => {
-		if (enableVirtualization) {
-			updateTableOffset();
-		}
-	});
+  afterUpdate(() => {
+    if (enableVirtualization) {
+      updateTableOffset();
+    }
+  });
 
-	$: if (virtualizer) {
-		virtualizer.setOptions({
-			count: totalRows,
-			estimateSize: () => rowHeight,
-			overscan: virtualizationOverscan,
-			scrollMargin: tableOffsetTop,
-			getItemKey: (index) => index,
-			enabled: enableVirtualization && totalRows > 0
-		});
-	}
+  $: if (virtualizer) {
+    virtualizer.setOptions({
+      count: totalRows,
+      estimateSize: () => rowHeight,
+      overscan: virtualizationOverscan,
+      scrollMargin: tableOffsetTop,
+      getItemKey: (index) => index,
+      enabled: enableVirtualization && totalRows > 0,
+    });
+  }
 
-	$: virtualizationActive = enableVirtualization && Boolean(virtualizer);
+  $: virtualizationActive = enableVirtualization && Boolean(virtualizer);
 
-	let virtualItems: VirtualItem[] = [];
-	let totalSize = 0;
-	let topPadding = 0;
-	let bottomPadding = 0;
-	let scrollMargin = 0;
-	$: {
-		const hasRows = totalRows > 0;
-		scrollMargin = virtualizationActive ? tableOffsetTop : 0;
-		if (virtualizationActive && virtualizer && hasRows) {
-			virtualItems = virtualizer.getVirtualItems();
-			totalSize = virtualizer.getTotalSize();
-			const firstItem = virtualItems[0];
-			const lastItem = virtualItems[virtualItems.length - 1];
-			topPadding = firstItem ? Math.max(0, firstItem.start - scrollMargin) : 0;
-			bottomPadding = lastItem
-				? Math.max(0, totalSize - (lastItem.end - scrollMargin))
-				: Math.max(0, totalSize);
-		} else {
-			virtualItems = [];
-			totalSize = 0;
-			topPadding = 0;
-			bottomPadding = 0;
-		}
-	}
+  let virtualItems: VirtualItem[] = [];
+  let totalSize = 0;
+  let topPadding = 0;
+  let bottomPadding = 0;
+  let scrollMargin = 0;
+  $: {
+    const hasRows = totalRows > 0;
+    scrollMargin = virtualizationActive ? tableOffsetTop : 0;
+    if (virtualizationActive && virtualizer && hasRows) {
+      virtualItems = virtualizer.getVirtualItems();
+      totalSize = virtualizer.getTotalSize();
+      const firstItem = virtualItems[0];
+      const lastItem = virtualItems[virtualItems.length - 1];
+      topPadding = firstItem ? Math.max(0, firstItem.start - scrollMargin) : 0;
+      bottomPadding = lastItem
+        ? Math.max(0, totalSize - (lastItem.end - scrollMargin))
+        : Math.max(0, totalSize);
+    } else {
+      virtualItems = [];
+      totalSize = 0;
+      topPadding = 0;
+      bottomPadding = 0;
+    }
+  }
 
-	onDestroy(() => {
-		unsubscribeVirtualizer?.();
-	});
+  onDestroy(() => {
+    unsubscribeVirtualizer?.();
+  });
 
-	afterUpdate(() => {
-		if (!virtualizationActive || !virtualizer || !tableContainerElement) {
-			return;
-		}
-		const rows = Array.from(
-			tableContainerElement.querySelectorAll('tbody tr[data-virtual-row="true"]')
-		) as HTMLElement[];
-		if (!rows.length) {
-			return;
-		}
-		for (const row of rows) {
-			virtualizer.measureElement(row);
-		}
-		if (measuredRowHeight === null) {
-			const sampleHeight = rows[0].getBoundingClientRect().height;
-			if (sampleHeight > 0) {
-				measuredRowHeight = sampleHeight;
-			}
-		}
-	});
+  afterUpdate(() => {
+    if (!virtualizationActive || !virtualizer || !tableContainerElement) {
+      return;
+    }
+    const rows = Array.from(
+      tableContainerElement.querySelectorAll(
+        'tbody tr[data-virtual-row="true"]',
+      ),
+    ) as HTMLElement[];
+    if (!rows.length) {
+      return;
+    }
+    for (const row of rows) {
+      virtualizer.measureElement(row);
+    }
+    if (measuredRowHeight === null) {
+      const sampleHeight = rows[0].getBoundingClientRect().height;
+      if (sampleHeight > 0) {
+        measuredRowHeight = sampleHeight;
+      }
+    }
+  });
 </script>
 
 <div data-testid="title" class="flex h-16 w-full items-center justify-end">
-	<slot name="info" />
-	<slot name="timeFilter" />
-	<slot name="title" />
-	<Refresh
-		class="ml-2 h-8 w-5 cursor-pointer text-gray-400 dark:text-gray-400"
-		data-testid="refreshButton"
-		spin={$query.isLoading || $query.isFetching}
-		on:click={async () => {
-			if (queryKey) {
-				invalidateTanstackQueries(queryClient, [queryKey]);
-			}
-		}}
-	/>
+  <slot name="info" />
+  <slot name="timeFilter" />
+  <slot name="title" />
+  <Refresh
+    class="ml-2 h-8 w-5 cursor-pointer text-gray-400 dark:text-gray-400"
+    data-testid="refreshButton"
+    spin={$query.isLoading || $query.isFetching}
+    on:click={async () => {
+      if (queryKey) {
+        invalidateTanstackQueries(queryClient, [queryKey]);
+      }
+    }}
+  />
 </div>
-{#if totalRows === 0}
-	<div data-testid="emptyMessage" class="text-center text-gray-900 dark:text-white">
-		{emptyMessage}
-	</div>
+{#if isInitialLoading}
+  <div
+    data-testid="tableLoadingSkeleton"
+    class="animate-pulse overflow-hidden rounded-lg border dark:border-gray-700"
+  >
+    <div
+      class="grid grid-cols-5 gap-4 border-b bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-800"
+    >
+      {#each [0, 1, 2, 3, 4] as columnIndex (columnIndex)}
+        <div class="h-3 rounded bg-gray-200 dark:bg-gray-700" />
+      {/each}
+    </div>
+    {#each [0, 1, 2, 3, 4, 5, 6, 7] as rowIndex (rowIndex)}
+      <div
+        class="grid grid-cols-5 gap-4 border-b p-4 last:border-b-0 dark:border-gray-700"
+      >
+        <div class="h-4 rounded bg-gray-200 dark:bg-gray-700" />
+        <div class="h-4 rounded bg-gray-200 dark:bg-gray-700" />
+        <div class="h-4 rounded bg-gray-200 dark:bg-gray-700" />
+        <div class="h-4 rounded bg-gray-200 dark:bg-gray-700" />
+        <div class="h-4 rounded bg-gray-200 dark:bg-gray-700" />
+      </div>
+    {/each}
+  </div>
+{:else if totalRows === 0}
+  <div
+    data-testid="emptyMessage"
+    class="text-center text-gray-900 dark:text-white"
+  >
+    {emptyMessage}
+  </div>
 {:else if hasData}
-	<div
-		class="cursor-pointer overflow-x-auto rounded-lg border dark:border-none"
-		data-testid="tanstackTableContainer"
-		bind:this={tableContainerElement}
-	>
-		<Table divClass="min-w-full" class="w-full table-fixed" hoverable={rowHoverable}>
-			<TableHead data-testid="head">
-				<slot name="head" />
-			</TableHead>
-			<TableBody>
-				{#if virtualizationActive && topPadding > 0}
-					<tr aria-hidden="true">
-						<td colspan="1000" class="border-0 p-0" style={`height:${topPadding}px;`} />
-					</tr>
-				{/if}
-				{#if virtualizationActive}
-					{#each virtualItems as virtualItem (virtualItem.key)}
-						<TableBodyRow
-							class="whitespace-nowrap"
-							data-testid="bodyRow"
-							data-virtual-row="true"
-							on:click={() => {
-								dispatch('clickRow', { item: flattenedRows[virtualItem.index] });
-							}}
-						>
-							<slot name="bodyRow" item={flattenedRows[virtualItem.index]} />
-						</TableBodyRow>
-					{/each}
-				{:else}
-					{#each transformedPages as page}
-						{#each page as item}
-							<TableBodyRow
-								class="whitespace-nowrap"
-								data-testid="bodyRow"
-								on:click={() => {
-									dispatch('clickRow', { item });
-								}}
-							>
-								<slot name="bodyRow" {item} />
-							</TableBodyRow>
-						{/each}
-					{/each}
-				{/if}
-				{#if virtualizationActive && bottomPadding > 0}
-					<tr aria-hidden="true">
-						<td colspan="1000" class="border-0 p-0" style={`height:${bottomPadding}px;`} />
-					</tr>
-				{/if}
-			</TableBody>
-		</Table>
-	</div>
-	<div class="mt-2 flex justify-center">
-		<Button
-			data-testid="loadMoreButton"
-			size="xs"
-			color="dark"
-			on:click={() => $query.fetchNextPage()}
-			disabled={!$query.hasNextPage || $query.isFetchingNextPage}
-		>
-			{#if $query.isFetchingNextPage}
-				Loading more...
-			{:else if $query.hasNextPage}
-				Load More
-			{:else}Nothing more to load{/if}
-		</Button>
-	</div>
+  <div
+    class="cursor-pointer overflow-x-auto rounded-lg border dark:border-none"
+    data-testid="tanstackTableContainer"
+    bind:this={tableContainerElement}
+  >
+    <Table
+      divClass="min-w-full"
+      class="w-full table-fixed"
+      hoverable={rowHoverable}
+    >
+      <TableHead data-testid="head">
+        <slot name="head" />
+      </TableHead>
+      <TableBody>
+        {#if virtualizationActive && topPadding > 0}
+          <tr aria-hidden="true">
+            <td
+              colspan="1000"
+              class="border-0 p-0"
+              style={`height:${topPadding}px;`}
+            />
+          </tr>
+        {/if}
+        {#if virtualizationActive}
+          {#each virtualItems as virtualItem (virtualItem.key)}
+            <TableBodyRow
+              class="whitespace-nowrap"
+              data-testid="bodyRow"
+              data-virtual-row="true"
+              on:click={() => {
+                dispatch("clickRow", {
+                  item: flattenedRows[virtualItem.index],
+                });
+              }}
+            >
+              <slot name="bodyRow" item={flattenedRows[virtualItem.index]} />
+            </TableBodyRow>
+          {/each}
+        {:else}
+          {#each transformedPages as page}
+            {#each page as item}
+              <TableBodyRow
+                class="whitespace-nowrap"
+                data-testid="bodyRow"
+                on:click={() => {
+                  dispatch("clickRow", { item });
+                }}
+              >
+                <slot name="bodyRow" {item} />
+              </TableBodyRow>
+            {/each}
+          {/each}
+        {/if}
+        {#if virtualizationActive && bottomPadding > 0}
+          <tr aria-hidden="true">
+            <td
+              colspan="1000"
+              class="border-0 p-0"
+              style={`height:${bottomPadding}px;`}
+            />
+          </tr>
+        {/if}
+      </TableBody>
+    </Table>
+  </div>
+  <div class="mt-2 flex justify-center">
+    <Button
+      data-testid="loadMoreButton"
+      size="xs"
+      color="dark"
+      on:click={() => $query.fetchNextPage()}
+      disabled={!$query.hasNextPage || $query.isFetchingNextPage}
+    >
+      {#if $query.isFetchingNextPage}
+        Loading more...
+      {:else if $query.hasNextPage}
+        Load More
+      {:else}Nothing more to load{/if}
+    </Button>
+  </div>
 {/if}

--- a/packages/webapp/src/lib/constants.ts
+++ b/packages/webapp/src/lib/constants.ts
@@ -1,2 +1,2 @@
 export const REGISTRY_URL =
-  "https://raw.githubusercontent.com/rainlanguage/rain.strategies/57a40d4f5d83e1faea9bb9570aa80d83260ff7c7/registry";
+  "https://raw.githubusercontent.com/rainlanguage/rain.strategies/1a4cd6e3f30b3a66d30501743d4282054d5c66fd/registry";


### PR DESCRIPTION
## Summary
- add `derived_vault_deltas` as a pipeline-maintained read model for the existing `vault_deltas` view output
- refresh derived vault deltas in the apply transaction before `vault_balance_changes` / `running_vault_balances`
- switch vault balance maintenance SQL to read `derived_vault_deltas` instead of recomputing the view
- include the table in required schema, clear/reset paths, export/import, and bump local DB schema version from 3 to 4

This PR is standalone on `main` and does not depend on the derived-trades stack.

## Benchmarks
Measured with `nix develop` on a copied Base ST0x local DB, not the live DB.

Before this PR, the same balance maintenance path measured:
- recent 10k window: ~13.38s combined vault upsert batch
- busy window: `upsert running_vault_balances` alone hit ~184.54s

With `derived_vault_deltas` backfilled on the copy:
- one-time full derived backfill: ~6.65s for 29,682 rows
- recent 10k window: insert changes ~2.19ms, update running balances ~4.53ms
- densest 10k window found: 644 derived rows, insert changes ~91.33ms, update running balances ~56.28ms

## Tests
- `COMMIT_SHA=local nix develop -c cargo test -p raindex_common local_db::query --lib`
- `COMMIT_SHA=local nix develop -c cargo test -p raindex_common local_db::pipeline::adapters::apply --lib`
- `COMMIT_SHA=local nix develop -c cargo test -p raindex_common local_db::export --lib`
- `COMMIT_SHA=local nix develop -c cargo test -p raindex_common raindex_client::local_db::pipeline::bootstrap --lib`
- `COMMIT_SHA=local nix develop -c cargo test -p raindex_app_settings local_db_manifest --lib`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a derived vault-deltas read model with windowed refreshes; pipeline now refreshes it during processing.

* **Bug Fixes / Behavior**
  * Balance upserts now use derived deltas for consistent running balances and correct incremental updates.
  * Clear/reset operations now include derived deltas.
  * Sync scheduler marks chains as ready even when not leader.

* **Chores**
  * Bumped DB schema to v4; tests/fixtures updated.
  * UI table shows an initial loading skeleton.
  * Updated registry URL.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rainlanguage/raindex/pull/2592?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->