### PR TITLE
feat: add order route tracing

### DIFF
--- a/crates/common/src/raindex_client/order_quotes.rs
+++ b/crates/common/src/raindex_client/order_quotes.rs
@@ -11,7 +11,7 @@ use raindex_quote::{
 };
 use raindex_subgraph_client::utils::float::{F0, F1};
 use std::ops::{Div, Mul};
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, info_span, warn, Instrument};
 use wasm_bindgen_utils::impl_wasm_traits;
 
 #[derive(Serialize, Deserialize, Debug, Clone, Tsify)]
@@ -135,25 +135,8 @@ impl RaindexOrder {
         )]
         chunk_size: Option<u32>,
     ) -> Result<Vec<RaindexOrderQuote>, RaindexError> {
-        let rpcs = self.get_rpc_urls()?;
-        let sg_order = self.clone().into_sg_order()?;
-
-        let order_quotes = get_order_quotes(
-            vec![sg_order],
-            block_number,
-            rpcs.iter().map(|s| s.to_string()).collect(),
-            chunk_size.map(|v| v as usize),
-            Address::ZERO,
-            &NoopInjector,
-        )
-        .await?;
-
-        let mut result_order_quotes = vec![];
-        for order_quote in order_quotes {
-            let data = RaindexOrderQuote::try_from_batch_order_quotes_response(order_quote)?;
-            result_order_quotes.push(data);
-        }
-        Ok(result_order_quotes)
+        self.get_quotes_with_injector(block_number, chunk_size, Address::ZERO, &NoopInjector)
+            .await
     }
 }
 
@@ -171,25 +154,86 @@ impl RaindexOrder {
         counterparty: Address,
         injector: &dyn SignedContextInjector,
     ) -> Result<Vec<RaindexOrderQuote>, RaindexError> {
-        let rpcs = self.get_rpc_urls()?;
-        let sg_order = self.clone().into_sg_order()?;
+        let span = info_span!(
+            "get_order_quotes",
+            chain_id = self.chain_id(),
+            raindex = %self.raindex(),
+            order_hash = %self.order_hash(),
+            block_number = ?block_number,
+            chunk_size = ?chunk_size,
+            counterparty = %counterparty,
+        );
 
-        let order_quotes = get_order_quotes(
-            vec![sg_order],
-            block_number,
-            rpcs.iter().map(|s| s.to_string()).collect(),
-            chunk_size.map(|v| v as usize),
-            counterparty,
-            injector,
-        )
-        .await?;
+        async move {
+            let started_at = Timing::now();
+            let rpcs = self.get_rpc_urls()?;
+            let rpc_url_count = rpcs.len();
+            let sg_order = self.clone().into_sg_order()?;
 
-        let mut result_order_quotes = vec![];
-        for order_quote in order_quotes {
-            let data = RaindexOrderQuote::try_from_batch_order_quotes_response(order_quote)?;
-            result_order_quotes.push(data);
+            info!(rpc_url_count, "starting order quotes");
+
+            let quote_started_at = Timing::now();
+            let order_quotes = get_order_quotes(
+                vec![sg_order],
+                block_number,
+                rpcs.iter().map(|s| s.to_string()).collect(),
+                chunk_size.map(|v| v as usize),
+                counterparty,
+                injector,
+            )
+            .instrument(info_span!("order_quotes.executing_batch_quote"))
+            .await
+            .map_err(|err| {
+                error!(
+                    rpc_url_count,
+                    duration_ms = quote_started_at.elapsed_ms(),
+                    error = %err,
+                    "failed executing order quotes"
+                );
+                err
+            })?;
+
+            let conversion_started_at = Timing::now();
+            let result_order_quotes = order_quotes
+                .into_iter()
+                .map(RaindexOrderQuote::try_from_batch_order_quotes_response)
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|err| {
+                    error!(
+                        duration_ms = conversion_started_at.elapsed_ms(),
+                        error = %err,
+                        "failed converting order quotes"
+                    );
+                    err
+                })?;
+
+            let successful_quote_count = result_order_quotes
+                .iter()
+                .filter(|quote| quote.success)
+                .count();
+            let failed_quote_count = result_order_quotes
+                .len()
+                .saturating_sub(successful_quote_count);
+            for quote in result_order_quotes.iter().filter(|quote| !quote.success) {
+                debug!(
+                    input_index = quote.pair.input_index,
+                    output_index = quote.pair.output_index,
+                    error = ?quote.error,
+                    "order quote failed"
+                );
+            }
+            info!(
+                rpc_url_count,
+                quote_count = result_order_quotes.len(),
+                successful_quote_count,
+                failed_quote_count,
+                duration_ms = started_at.elapsed_ms(),
+                "completed order quotes"
+            );
+            Ok(result_order_quotes)
         }
-        Ok(result_order_quotes)
+        .instrument(span)
+        .await
     }
 }
 

--- a/crates/common/src/raindex_client/orders.rs
+++ b/crates/common/src/raindex_client/orders.rs
@@ -47,7 +47,7 @@ use raindex_subgraph_client::{
 };
 use serde::{Deserialize, Serialize};
 use std::{collections::HashSet, io::Cursor, str::FromStr};
-use tracing::{debug, info, warn, Level};
+use tracing::{debug, error, info, info_span, warn, Instrument, Level};
 use tsify::Tsify;
 use wasm_bindgen_utils::impl_wasm_traits;
 #[cfg(target_family = "wasm")]
@@ -57,6 +57,48 @@ const DEFAULT_PAGE_SIZE: u16 = 100;
 // Limit concurrent dotrain source fetches to avoid overwhelming the subgraph/metaboard.
 const MAX_CONCURRENT_DOTRAIN_SOURCE_FETCHES: usize = 5;
 const MAX_INFO_ORDER_INVENTORY_LOGS: usize = 50;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct OrderFilterTraceSummary {
+    owners_count: usize,
+    has_active_filter: bool,
+    has_order_hash_filter: bool,
+    input_tokens_count: usize,
+    output_tokens_count: usize,
+    raindexes_count: usize,
+    has_positive_output_vault_balance_filter: bool,
+}
+
+fn summarize_order_filters(filters: &GetOrdersFilters) -> OrderFilterTraceSummary {
+    OrderFilterTraceSummary {
+        owners_count: filters.owners.len(),
+        has_active_filter: filters.active.is_some(),
+        has_order_hash_filter: filters.order_hash.is_some(),
+        input_tokens_count: filters
+            .tokens
+            .as_ref()
+            .and_then(|tokens| tokens.inputs.as_ref())
+            .map_or(0, Vec::len),
+        output_tokens_count: filters
+            .tokens
+            .as_ref()
+            .and_then(|tokens| tokens.outputs.as_ref())
+            .map_or(0, Vec::len),
+        raindexes_count: filters.raindex_addresses.as_ref().map_or(0, Vec::len),
+        has_positive_output_vault_balance_filter: filters
+            .has_positive_output_vault_balance
+            .is_some(),
+    }
+}
+
+fn query_source_label(has_local_db: bool, has_subgraph: bool) -> &'static str {
+    match (has_local_db, has_subgraph) {
+        (true, true) => "mixed",
+        (true, false) => "local_db",
+        (false, true) => "subgraph",
+        (false, false) => "none",
+    }
+}
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -1043,43 +1085,146 @@ impl RaindexClient {
         page_size: Option<u16>,
     ) -> Result<RaindexOrdersListResult, RaindexError> {
         let filters = filters.unwrap_or_default();
+        let filter_summary = summarize_order_filters(&filters);
         let page_number = page.unwrap_or(1).max(1);
         let page_size = page_size.unwrap_or(DEFAULT_PAGE_SIZE).max(1);
         let ids = chain_ids.map(|ChainIds(ids)| ids);
+        let requested_chain_ids_count = ids.as_ref().map_or(0, Vec::len);
+        let span = info_span!(
+            "get_orders",
+            requested_chain_ids_count,
+            page = page_number,
+            page_size,
+            owners_count = filter_summary.owners_count,
+            has_active_filter = filter_summary.has_active_filter,
+            has_order_hash_filter = filter_summary.has_order_hash_filter,
+            input_tokens_count = filter_summary.input_tokens_count,
+            output_tokens_count = filter_summary.output_tokens_count,
+            raindexes_count = filter_summary.raindexes_count,
+            has_positive_output_vault_balance_filter =
+                filter_summary.has_positive_output_vault_balance_filter,
+        );
 
-        let (local_db, local_ids, sg_ids) = self.classify_chains(ids)?;
+        async move {
+            let started_at = Timing::now();
+            let (local_db, local_ids, sg_ids) = self.classify_chains(ids)?;
+            let local_chain_ids_count = local_ids.len();
+            let subgraph_chain_ids_count = sg_ids.len();
+            let query_source = query_source_label(local_db.is_some(), !sg_ids.is_empty());
 
-        let mut all_orders = Vec::new();
-        let mut total_count: u32 = 0;
+            info!(
+                query_source,
+                local_chain_ids_count, subgraph_chain_ids_count, "fetching orders"
+            );
 
-        if let Some(db) = local_db {
-            let local_source = LocalDbOrders::new(&db, ClientRef::new(self.clone()));
-            let result = local_source
-                .list(
-                    Some(local_ids),
-                    &filters,
-                    Some(page_number),
-                    Some(page_size),
-                )
-                .await?;
-            total_count += result.total_count;
-            all_orders.extend(result.orders);
+            let mut all_orders = Vec::new();
+            let mut total_count: u32 = 0;
+            let mut local_rows = 0usize;
+            let mut subgraph_rows = 0usize;
+
+            if let Some(db) = local_db {
+                let local_started_at = Timing::now();
+                let local_source = LocalDbOrders::new(&db, ClientRef::new(self.clone()));
+                let result = local_source
+                    .list(
+                        Some(local_ids),
+                        &filters,
+                        Some(page_number),
+                        Some(page_size),
+                    )
+                    .instrument(info_span!("orders.fetching_local_db"))
+                    .await
+                    .map_err(|err| {
+                        error!(
+                            source = "local_db",
+                            duration_ms = local_started_at.elapsed_ms(),
+                            error = %err,
+                            "failed fetching orders"
+                        );
+                        err
+                    })?;
+                local_rows = result.orders.len();
+                total_count += result.total_count;
+                all_orders.extend(result.orders);
+                info!(
+                    source = "local_db",
+                    returned_order_count = local_rows,
+                    total_count = result.total_count,
+                    duration_ms = local_started_at.elapsed_ms(),
+                    "fetched orders"
+                );
+            }
+
+            if !sg_ids.is_empty() {
+                let subgraph_started_at = Timing::now();
+                let subgraph_source = SubgraphOrders::new(self);
+                let result = subgraph_source
+                    .list(Some(sg_ids), &filters, Some(page_number), Some(page_size))
+                    .instrument(info_span!("orders.fetching_subgraph"))
+                    .await
+                    .map_err(|err| {
+                        error!(
+                            source = "subgraph",
+                            duration_ms = subgraph_started_at.elapsed_ms(),
+                            error = %err,
+                            "failed fetching orders"
+                        );
+                        err
+                    })?;
+                subgraph_rows = result.orders.len();
+                total_count += result.total_count;
+                all_orders.extend(result.orders);
+                info!(
+                    source = "subgraph",
+                    returned_order_count = subgraph_rows,
+                    total_count = result.total_count,
+                    duration_ms = subgraph_started_at.elapsed_ms(),
+                    "fetched orders"
+                );
+            }
+
+            let dotrain_started_at = Timing::now();
+            let orders = fetch_orders_dotrain_sources(all_orders)
+                .instrument(info_span!("orders.fetching_dotrain_sources"))
+                .await
+                .map_err(|err| {
+                    error!(
+                        local_rows,
+                        subgraph_rows,
+                        duration_ms = dotrain_started_at.elapsed_ms(),
+                        error = %err,
+                        "failed fetching order dotrain sources"
+                    );
+                    err
+                })?;
+            info!(
+                local_rows,
+                subgraph_rows,
+                returned_order_count = orders.len(),
+                total_count,
+                duration_ms = dotrain_started_at.elapsed_ms(),
+                "fetched order dotrain sources"
+            );
+
+            info!(
+                query_source,
+                local_chain_ids_count,
+                subgraph_chain_ids_count,
+                local_rows,
+                subgraph_rows,
+                returned_order_count = orders.len(),
+                total_count,
+                duration_ms = started_at.elapsed_ms(),
+                "completed get_orders"
+            );
+
+            Ok(RaindexOrdersListResult {
+                orders,
+                total_count,
+            })
         }
-
-        if !sg_ids.is_empty() {
-            let subgraph_source = SubgraphOrders::new(self);
-            let result = subgraph_source
-                .list(Some(sg_ids), &filters, Some(page_number), Some(page_size))
-                .await?;
-            total_count += result.total_count;
-            all_orders.extend(result.orders);
-        }
-
-        let orders = fetch_orders_dotrain_sources(all_orders).await?;
-        Ok(RaindexOrdersListResult {
-            orders,
-            total_count,
-        })
+        .instrument(span)
+        .await
     }
 
     /// Retrieves a specific order by its hash from a particular blockchain network
@@ -1334,45 +1479,115 @@ impl RaindexClient {
         raindex_id: &RaindexIdentifier,
         order_hash: B256,
     ) -> Result<RaindexOrder, RaindexError> {
-        let raindex_cfg = self.get_raindex_by_address(raindex_id.raindex_address)?;
-        if raindex_cfg.network.chain_id != raindex_id.chain_id {
-            return Err(RaindexError::RaindexNotFound(
-                raindex_id.raindex_address.to_string(),
-                raindex_id.chain_id,
-            ));
-        }
+        let span = info_span!(
+            "get_order_by_hash",
+            chain_id = raindex_id.chain_id,
+            raindex = %raindex_id.raindex_address,
+            order_hash = %order_hash,
+        );
 
-        match self.query_source(raindex_id.chain_id) {
-            QuerySource::LocalDb(local_db) => {
-                let local_source = LocalDbOrders::new(&local_db, ClientRef::new(self.clone()));
-                let mut order = local_source
-                    .get_by_hash(raindex_id, &order_hash)
-                    .await?
-                    .ok_or_else(|| {
-                        RaindexError::OrderNotFound(
-                            raindex_id.raindex_address.to_string(),
-                            raindex_id.chain_id,
-                            order_hash,
-                        )
-                    })?;
-                order.fetch_dotrain_source().await?;
-                Ok(order)
+        async move {
+            let started_at = Timing::now();
+            let raindex_cfg = self.get_raindex_by_address(raindex_id.raindex_address)?;
+            if raindex_cfg.network.chain_id != raindex_id.chain_id {
+                let err = RaindexError::RaindexNotFound(
+                    raindex_id.raindex_address.to_string(),
+                    raindex_id.chain_id,
+                );
+                warn!(
+                    configured_chain_id = raindex_cfg.network.chain_id,
+                    duration_ms = started_at.elapsed_ms(),
+                    error = %err,
+                    "order lookup rejected for mismatched raindex chain"
+                );
+                return Err(err);
             }
-            QuerySource::Subgraph => {
-                let mut order = SubgraphOrders::new(self)
-                    .get_by_hash(raindex_id, &order_hash)
-                    .await?
-                    .ok_or_else(|| {
-                        RaindexError::OrderNotFound(
-                            raindex_id.raindex_address.to_string(),
-                            raindex_id.chain_id,
-                            order_hash,
-                        )
-                    })?;
-                order.fetch_dotrain_source().await?;
-                Ok(order)
-            }
+
+            let mut order = match self.query_source(raindex_id.chain_id) {
+                QuerySource::LocalDb(local_db) => {
+                    let source_started_at = Timing::now();
+                    let local_source = LocalDbOrders::new(&local_db, ClientRef::new(self.clone()));
+                    let order = local_source
+                        .get_by_hash(raindex_id, &order_hash)
+                        .instrument(info_span!("order.fetching_local_db"))
+                        .await
+                        .map_err(|err| {
+                            error!(
+                                source = "local_db",
+                                duration_ms = source_started_at.elapsed_ms(),
+                                error = %err,
+                                "failed fetching order by hash"
+                            );
+                            err
+                        })?
+                        .ok_or_else(|| {
+                            RaindexError::OrderNotFound(
+                                raindex_id.raindex_address.to_string(),
+                                raindex_id.chain_id,
+                                order_hash,
+                            )
+                        })?;
+                    info!(
+                        source = "local_db",
+                        duration_ms = source_started_at.elapsed_ms(),
+                        "fetched order by hash"
+                    );
+                    order
+                }
+                QuerySource::Subgraph => {
+                    let source_started_at = Timing::now();
+                    let order = SubgraphOrders::new(self)
+                        .get_by_hash(raindex_id, &order_hash)
+                        .instrument(info_span!("order.fetching_subgraph"))
+                        .await
+                        .map_err(|err| {
+                            error!(
+                                source = "subgraph",
+                                duration_ms = source_started_at.elapsed_ms(),
+                                error = %err,
+                                "failed fetching order by hash"
+                            );
+                            err
+                        })?
+                        .ok_or_else(|| {
+                            RaindexError::OrderNotFound(
+                                raindex_id.raindex_address.to_string(),
+                                raindex_id.chain_id,
+                                order_hash,
+                            )
+                        })?;
+                    info!(
+                        source = "subgraph",
+                        duration_ms = source_started_at.elapsed_ms(),
+                        "fetched order by hash"
+                    );
+                    order
+                }
+            };
+
+            let dotrain_started_at = Timing::now();
+            order.fetch_dotrain_source().await.map_err(|err| {
+                error!(
+                    duration_ms = dotrain_started_at.elapsed_ms(),
+                    error = %err,
+                    "failed fetching order dotrain source"
+                );
+                err
+            })?;
+            info!(
+                has_dotrain_source = order.rainlang().is_some(),
+                duration_ms = dotrain_started_at.elapsed_ms(),
+                "fetched order dotrain source"
+            );
+
+            info!(
+                duration_ms = started_at.elapsed_ms(),
+                "completed get_order_by_hash"
+            );
+            Ok(order)
         }
+        .instrument(span)
+        .await
     }
 }
 
@@ -1779,6 +1994,47 @@ mod tests {
             format!("0x{}", alloy::hex::encode(encoded))
         }
         use std::str::FromStr;
+
+        #[test]
+        fn order_filter_trace_summary_counts_optional_filters() {
+            let filters = GetOrdersFilters {
+                owners: vec![address!("0000000000000000000000000000000000000001")],
+                active: Some(true),
+                order_hash: Some(b256!(
+                    "0000000000000000000000000000000000000000000000000000000000000002"
+                )),
+                tokens: Some(GetOrdersTokenFilter {
+                    inputs: Some(vec![address!("0000000000000000000000000000000000000003")]),
+                    outputs: Some(vec![
+                        address!("0000000000000000000000000000000000000004"),
+                        address!("0000000000000000000000000000000000000005"),
+                    ]),
+                }),
+                raindex_addresses: Some(vec![address!("0000000000000000000000000000000000000006")]),
+                has_positive_output_vault_balance: Some(true),
+            };
+
+            assert_eq!(
+                summarize_order_filters(&filters),
+                OrderFilterTraceSummary {
+                    owners_count: 1,
+                    has_active_filter: true,
+                    has_order_hash_filter: true,
+                    input_tokens_count: 1,
+                    output_tokens_count: 2,
+                    raindexes_count: 1,
+                    has_positive_output_vault_balance_filter: true,
+                }
+            );
+        }
+
+        #[test]
+        fn query_source_label_describes_selected_sources() {
+            assert_eq!(query_source_label(true, true), "mixed");
+            assert_eq!(query_source_label(true, false), "local_db");
+            assert_eq!(query_source_label(false, true), "subgraph");
+            assert_eq!(query_source_label(false, false), "none");
+        }
 
         async fn build_client_with_metaboard(
             metaboard_url: &str,

--- a/crates/common/src/raindex_client/remove_orders.rs
+++ b/crates/common/src/raindex_client/remove_orders.rs
@@ -5,10 +5,12 @@ use crate::raindex_client::local_db::orders::LocalDbOrders;
 use crate::raindex_client::orders::{fetch_orders_dotrain_sources, RaindexOrder};
 use crate::raindex_client::QuerySource;
 use crate::retry::{retry_with_constant_interval, RetryError};
+use crate::utils::timing::Timing;
 use alloy::primitives::{hex::decode, Bytes, B256};
 use alloy::sol_types::{SolCall, SolValue};
 use raindex_bindings::IRaindexV6::{removeOrder3Call, OrderV4};
 use raindex_subgraph_client::types::order_detail_traits::OrderDetailError;
+use tracing::{error, info, info_span};
 
 const DEFAULT_REMOVE_ORDER_POLL_ATTEMPTS: usize = 10;
 const DEFAULT_REMOVE_ORDER_POLL_INTERVAL_MS: u64 = 1_000;
@@ -198,11 +200,38 @@ impl RaindexOrder {
         unchecked_return_type = "Hex"
     )]
     pub fn get_remove_calldata(&self) -> Result<Bytes, RaindexError> {
+        let started_at = Timing::now();
+        let span = info_span!(
+            "get_remove_calldata",
+            chain_id = self.chain_id(),
+            raindex = %self.raindex(),
+            order_hash = %self.order_hash(),
+        );
+        let _entered = span.enter();
+
+        info!("building remove order calldata");
+        let order = match self.try_into() {
+            Ok(order) => order,
+            Err(err) => {
+                error!(
+                    duration_ms = started_at.elapsed_ms(),
+                    error = %err,
+                    "failed decoding order for remove calldata"
+                );
+                return Err(RaindexError::from(err));
+            }
+        };
         let remove_order_call = removeOrder3Call {
-            order: self.try_into()?,
+            order,
             tasks: vec![],
         };
-        Ok(Bytes::copy_from_slice(&remove_order_call.abi_encode()))
+        let calldata = Bytes::copy_from_slice(&remove_order_call.abi_encode());
+        info!(
+            calldata_len = calldata.len(),
+            duration_ms = started_at.elapsed_ms(),
+            "built remove order calldata"
+        );
+        Ok(calldata)
     }
 }
 

--- a/crates/common/src/raindex_client/trades/get_by_order_hashes.rs
+++ b/crates/common/src/raindex_client/trades/get_by_order_hashes.rs
@@ -9,8 +9,40 @@ use raindex_subgraph_client::types::common::{
 };
 use raindex_subgraph_client::MultiRaindexSubgraphClient;
 use std::collections::{HashMap, HashSet};
+use tracing::{info, info_span, Instrument};
 use tsify::Tsify;
 use wasm_bindgen_utils::{impl_wasm_traits, wasm_export};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct TradesByOrderHashesFilterTraceSummary {
+    owners_count: usize,
+    takers_count: usize,
+    input_tokens_count: usize,
+    output_tokens_count: usize,
+    raindexes_count: usize,
+    has_time_filter: bool,
+}
+
+fn summarize_trades_by_order_hashes_filters(
+    filters: &GetTradesByOrderHashesFilters,
+) -> TradesByOrderHashesFilterTraceSummary {
+    TradesByOrderHashesFilterTraceSummary {
+        owners_count: filters.owners.len(),
+        takers_count: filters.takers.len(),
+        input_tokens_count: filters
+            .tokens
+            .as_ref()
+            .and_then(|tokens| tokens.inputs.as_ref())
+            .map_or(0, Vec::len),
+        output_tokens_count: filters
+            .tokens
+            .as_ref()
+            .and_then(|tokens| tokens.outputs.as_ref())
+            .map_or(0, Vec::len),
+        raindexes_count: filters.raindex_addresses.as_ref().map_or(0, Vec::len),
+        has_time_filter: filters.time_filter.is_some(),
+    }
+}
 
 #[derive(Serialize, Deserialize, Debug, Clone, Tsify)]
 pub struct OrderHashes(#[tsify(type = "Hex[]")] pub Vec<B256>);
@@ -214,148 +246,198 @@ impl RaindexClient {
         let started = Timing::now();
         let requested_order_hashes_count = order_hashes.0.len();
         let order_hashes = unique_order_hashes_preserving_order(order_hashes.0);
-        if order_hashes.is_empty() {
-            return Ok(RaindexTradesByOrderHashResult {
-                trades_by_order_hash: Vec::new(),
-                total_count: 0,
-            });
-        }
-
         let filters = filters.unwrap_or_default();
-        let input_tokens_count = filters
-            .tokens
-            .as_ref()
-            .and_then(|tokens| tokens.inputs.as_ref())
-            .map_or(0, Vec::len);
-        let output_tokens_count = filters
-            .tokens
-            .as_ref()
-            .and_then(|tokens| tokens.outputs.as_ref())
-            .map_or(0, Vec::len);
-        let takers_count = filters.takers.len();
-        let owners_count = filters.owners.len();
-        let raindexes_count = filters.raindex_addresses.as_ref().map_or(0, Vec::len);
+        let filter_summary = summarize_trades_by_order_hashes_filters(&filters);
         let ids = chain_ids.map(|ChainIds(ids)| ids);
         let requested_chain_ids_count = ids.as_ref().map_or(0, Vec::len);
-        let (local_db, local_ids, sg_ids) = self.classify_chains(ids)?;
-        let local_chain_ids_count = local_ids.len();
-        let subgraph_chain_ids_count = sg_ids.len();
-
-        let mut all_trades = Vec::new();
-        let mut local_rows = 0usize;
-        let mut subgraph_rows_before_token_filter = 0usize;
-        let mut subgraph_rows_after_token_filter = 0usize;
-
-        if let Some(db) = local_db {
-            let local_tokens = filters
-                .tokens
-                .clone()
-                .map(|tokens| FetchTradesTokensFilter {
-                    inputs: tokens.inputs.unwrap_or_default(),
-                    outputs: tokens.outputs.unwrap_or_default(),
-                })
-                .unwrap_or_default();
-            let local_started = Timing::now();
-            let local_trades = fetch_trades(
-                &db,
-                FetchTradesArgs {
-                    chain_ids: local_ids,
-                    raindex_addresses: filters.raindex_addresses.clone().unwrap_or_default(),
-                    owners: filters.owners.clone(),
-                    takers: filters.takers.clone(),
-                    order_hash: None,
-                    order_hashes: order_hashes.clone(),
-                    tokens: local_tokens,
-                    time_filter: filters.time_filter.clone().unwrap_or_default(),
-                    pagination: PaginationParams::default(),
-                },
-            )
-            .await?;
-            local_rows = local_trades.len();
-            all_trades.extend(
-                local_trades
-                    .into_iter()
-                    .map(RaindexTrade::try_from_local_db_trade)
-                    .collect::<Result<Vec<_>, _>>()?,
-            );
-            tracing::debug!(
-                order_hashes_count = order_hashes.len(),
-                rows = local_rows,
-                duration_ms = local_started.elapsed_ms(),
-                "getTradesByOrderHashes local DB completed"
-            );
-        }
-
-        if !sg_ids.is_empty() {
-            let multi_subgraph_args = self.get_multi_subgraph_args(Some(sg_ids))?;
-            let sg_filters = build_sg_filters(filters.clone(), &order_hashes);
-            let sg_token_filter = filters
-                .tokens
-                .clone()
-                .and_then(Option::<SgTradesTokensFilterArgs>::from)
-                .map(normalize_trade_tokens);
-            let name_to_chain_id: HashMap<&str, u32> = multi_subgraph_args
-                .iter()
-                .flat_map(|(chain_id, args)| args.iter().map(|arg| (arg.name.as_str(), *chain_id)))
-                .collect();
-            let client = MultiRaindexSubgraphClient::new(
-                multi_subgraph_args.values().flatten().cloned().collect(),
-            );
-            let subgraph_started = Timing::now();
-            let sg_trades = client.trades_list_all(sg_filters).await?;
-            subgraph_rows_before_token_filter = sg_trades.len();
-            let sg_trades: Vec<_> = if let Some(tokens) = sg_token_filter {
-                sg_trades
-                    .into_iter()
-                    .filter(|trade| sg_trade_matches_token_filter(&trade.trade, &tokens))
-                    .collect()
-            } else {
-                sg_trades
-            };
-            subgraph_rows_after_token_filter = sg_trades.len();
-            for trade_with_name in sg_trades {
-                let chain_id = name_to_chain_id
-                    .get(trade_with_name.subgraph_name.as_str())
-                    .copied()
-                    .ok_or(RaindexError::SubgraphNotFound(
-                        trade_with_name.subgraph_name.clone(),
-                        trade_with_name.trade.id.0.clone(),
-                    ))?;
-                all_trades.push(RaindexTrade::try_from_sg_trade(
-                    chain_id,
-                    trade_with_name.trade,
-                )?);
-            }
-            tracing::debug!(
-                order_hashes_count = order_hashes.len(),
-                rows_before_token_filter = subgraph_rows_before_token_filter,
-                rows_after_token_filter = subgraph_rows_after_token_filter,
-                duration_ms = subgraph_started.elapsed_ms(),
-                "getTradesByOrderHashes subgraph completed"
-            );
-        }
-
-        let result = group_trades_by_order_hash(order_hashes, all_trades);
-        tracing::debug!(
+        let span = info_span!(
+            "get_trades_by_order_hashes",
             requested_chain_ids_count,
-            local_chain_ids_count,
-            subgraph_chain_ids_count,
             requested_order_hashes_count,
-            unique_order_hashes_count = result.trades_by_order_hash.len(),
-            owners_count,
-            takers_count,
-            raindexes_count,
-            input_tokens_count,
-            output_tokens_count,
-            local_rows,
-            subgraph_rows_before_token_filter,
-            subgraph_rows_after_token_filter,
-            total_count = result.total_count,
-            duration_ms = started.elapsed_ms(),
-            "getTradesByOrderHashes completed"
+            unique_order_hashes_count = order_hashes.len(),
+            owners_count = filter_summary.owners_count,
+            takers_count = filter_summary.takers_count,
+            input_tokens_count = filter_summary.input_tokens_count,
+            output_tokens_count = filter_summary.output_tokens_count,
+            raindexes_count = filter_summary.raindexes_count,
+            has_time_filter = filter_summary.has_time_filter,
         );
 
-        Ok(result)
+        async move {
+            if order_hashes.is_empty() {
+                info!(
+                    requested_order_hashes_count,
+                    duration_ms = started.elapsed_ms(),
+                    "skipped get_trades_by_order_hashes for empty order hash list"
+                );
+                return Ok(RaindexTradesByOrderHashResult {
+                    trades_by_order_hash: Vec::new(),
+                    total_count: 0,
+                });
+            }
+
+            let (local_db, local_ids, sg_ids) = self.classify_chains(ids)?;
+            let local_chain_ids_count = local_ids.len();
+            let subgraph_chain_ids_count = sg_ids.len();
+
+            info!(
+                local_chain_ids_count,
+                subgraph_chain_ids_count, "fetching trades by order hashes"
+            );
+
+            let mut all_trades = Vec::new();
+            let mut local_rows = 0usize;
+            let mut subgraph_rows_before_token_filter = 0usize;
+            let mut subgraph_rows_after_token_filter = 0usize;
+
+            if let Some(db) = local_db {
+                let local_tokens = filters
+                    .tokens
+                    .clone()
+                    .map(|tokens| FetchTradesTokensFilter {
+                        inputs: tokens.inputs.unwrap_or_default(),
+                        outputs: tokens.outputs.unwrap_or_default(),
+                    })
+                    .unwrap_or_default();
+                let local_started = Timing::now();
+                let local_trades = fetch_trades(
+                    &db,
+                    FetchTradesArgs {
+                        chain_ids: local_ids,
+                        raindex_addresses: filters.raindex_addresses.clone().unwrap_or_default(),
+                        owners: filters.owners.clone(),
+                        takers: filters.takers.clone(),
+                        order_hash: None,
+                        order_hashes: order_hashes.clone(),
+                        tokens: local_tokens,
+                        time_filter: filters.time_filter.clone().unwrap_or_default(),
+                        pagination: PaginationParams::default(),
+                    },
+                )
+                .await?;
+                local_rows = local_trades.len();
+                all_trades.extend(
+                    local_trades
+                        .into_iter()
+                        .map(RaindexTrade::try_from_local_db_trade)
+                        .collect::<Result<Vec<_>, _>>()?,
+                );
+                tracing::debug!(
+                    order_hashes_count = order_hashes.len(),
+                    rows = local_rows,
+                    duration_ms = local_started.elapsed_ms(),
+                    "getTradesByOrderHashes local DB completed"
+                );
+                info!(
+                    source = "local_db",
+                    order_hashes_count = order_hashes.len(),
+                    rows = local_rows,
+                    duration_ms = local_started.elapsed_ms(),
+                    "fetched trades by order hashes"
+                );
+            }
+
+            if !sg_ids.is_empty() {
+                let multi_subgraph_args = self.get_multi_subgraph_args(Some(sg_ids))?;
+                let sg_filters = build_sg_filters(filters.clone(), &order_hashes);
+                let sg_token_filter = filters
+                    .tokens
+                    .clone()
+                    .and_then(Option::<SgTradesTokensFilterArgs>::from)
+                    .map(normalize_trade_tokens);
+                let name_to_chain_id: HashMap<&str, u32> = multi_subgraph_args
+                    .iter()
+                    .flat_map(|(chain_id, args)| {
+                        args.iter().map(|arg| (arg.name.as_str(), *chain_id))
+                    })
+                    .collect();
+                let client = MultiRaindexSubgraphClient::new(
+                    multi_subgraph_args.values().flatten().cloned().collect(),
+                );
+                let subgraph_started = Timing::now();
+                let sg_trades = client.trades_list_all(sg_filters).await?;
+                subgraph_rows_before_token_filter = sg_trades.len();
+                let sg_trades: Vec<_> = if let Some(tokens) = sg_token_filter {
+                    sg_trades
+                        .into_iter()
+                        .filter(|trade| sg_trade_matches_token_filter(&trade.trade, &tokens))
+                        .collect()
+                } else {
+                    sg_trades
+                };
+                subgraph_rows_after_token_filter = sg_trades.len();
+                for trade_with_name in sg_trades {
+                    let chain_id = name_to_chain_id
+                        .get(trade_with_name.subgraph_name.as_str())
+                        .copied()
+                        .ok_or(RaindexError::SubgraphNotFound(
+                            trade_with_name.subgraph_name.clone(),
+                            trade_with_name.trade.id.0.clone(),
+                        ))?;
+                    all_trades.push(RaindexTrade::try_from_sg_trade(
+                        chain_id,
+                        trade_with_name.trade,
+                    )?);
+                }
+                tracing::debug!(
+                    order_hashes_count = order_hashes.len(),
+                    rows_before_token_filter = subgraph_rows_before_token_filter,
+                    rows_after_token_filter = subgraph_rows_after_token_filter,
+                    duration_ms = subgraph_started.elapsed_ms(),
+                    "getTradesByOrderHashes subgraph completed"
+                );
+                info!(
+                    source = "subgraph",
+                    order_hashes_count = order_hashes.len(),
+                    rows_before_token_filter = subgraph_rows_before_token_filter,
+                    rows_after_token_filter = subgraph_rows_after_token_filter,
+                    duration_ms = subgraph_started.elapsed_ms(),
+                    "fetched trades by order hashes"
+                );
+            }
+
+            let result = group_trades_by_order_hash(order_hashes, all_trades);
+            tracing::debug!(
+                requested_chain_ids_count,
+                local_chain_ids_count,
+                subgraph_chain_ids_count,
+                requested_order_hashes_count,
+                unique_order_hashes_count = result.trades_by_order_hash.len(),
+                owners_count = filter_summary.owners_count,
+                takers_count = filter_summary.takers_count,
+                raindexes_count = filter_summary.raindexes_count,
+                input_tokens_count = filter_summary.input_tokens_count,
+                output_tokens_count = filter_summary.output_tokens_count,
+                local_rows,
+                subgraph_rows_before_token_filter,
+                subgraph_rows_after_token_filter,
+                total_count = result.total_count,
+                duration_ms = started.elapsed_ms(),
+                "getTradesByOrderHashes completed"
+            );
+            info!(
+                requested_chain_ids_count,
+                local_chain_ids_count,
+                subgraph_chain_ids_count,
+                requested_order_hashes_count,
+                unique_order_hashes_count = result.trades_by_order_hash.len(),
+                owners_count = filter_summary.owners_count,
+                takers_count = filter_summary.takers_count,
+                raindexes_count = filter_summary.raindexes_count,
+                input_tokens_count = filter_summary.input_tokens_count,
+                output_tokens_count = filter_summary.output_tokens_count,
+                local_rows,
+                subgraph_rows_before_token_filter,
+                subgraph_rows_after_token_filter,
+                total_count = result.total_count,
+                duration_ms = started.elapsed_ms(),
+                "completed get_trades_by_order_hashes"
+            );
+
+            Ok(result)
+        }
+        .instrument(span)
+        .await
     }
 }
 
@@ -363,7 +445,39 @@ impl RaindexClient {
 mod tests {
     use super::*;
     use crate::local_db::query::fetch_order_trades::LocalDbOrderTrade;
-    use alloy::primitives::{b256, Bytes};
+    use alloy::primitives::{address, b256, Bytes};
+
+    #[test]
+    fn trades_by_order_hashes_filter_trace_summary_counts_optional_filters() {
+        let filters = GetTradesByOrderHashesFilters {
+            owners: vec![address!("0000000000000000000000000000000000000001")],
+            takers: vec![
+                address!("0000000000000000000000000000000000000002"),
+                address!("0000000000000000000000000000000000000003"),
+            ],
+            tokens: Some(GetTradesTokenFilter {
+                inputs: Some(vec![address!("0000000000000000000000000000000000000004")]),
+                outputs: Some(vec![address!("0000000000000000000000000000000000000005")]),
+            }),
+            raindex_addresses: Some(vec![address!("0000000000000000000000000000000000000006")]),
+            time_filter: Some(TimeFilter {
+                start: Some(1),
+                end: Some(2),
+            }),
+        };
+
+        assert_eq!(
+            summarize_trades_by_order_hashes_filters(&filters),
+            TradesByOrderHashesFilterTraceSummary {
+                owners_count: 1,
+                takers_count: 2,
+                input_tokens_count: 1,
+                output_tokens_count: 1,
+                raindexes_count: 1,
+                has_time_filter: true,
+            }
+        );
+    }
 
     fn local_trade(order_hash: B256, block_timestamp: u64, trade_id: u8) -> LocalDbOrderTrade {
         LocalDbOrderTrade {

--- a/crates/quote/src/order_quotes.rs
+++ b/crates/quote/src/order_quotes.rs
@@ -13,8 +13,46 @@ use raindex_bindings::IRaindexV6::{OrderV4, QuoteV2, SignedContextV1};
 use raindex_subgraph_client::types::common::SgOrder;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
+use tracing::{debug, info, warn};
+#[cfg(target_family = "wasm")]
+use wasm_bindgen_utils::prelude::js_sys::Date;
 #[cfg(target_family = "wasm")]
 use wasm_bindgen_utils::{impl_wasm_traits, prelude::*};
+
+struct QuoteTiming {
+    #[cfg(not(target_family = "wasm"))]
+    started_at: std::time::Instant,
+    #[cfg(target_family = "wasm")]
+    started_at_ms: f64,
+}
+
+impl QuoteTiming {
+    fn now() -> Self {
+        Self {
+            #[cfg(not(target_family = "wasm"))]
+            started_at: std::time::Instant::now(),
+            #[cfg(target_family = "wasm")]
+            started_at_ms: Date::now(),
+        }
+    }
+
+    fn elapsed_ms(&self) -> u64 {
+        #[cfg(not(target_family = "wasm"))]
+        {
+            self.started_at.elapsed().as_millis() as u64
+        }
+
+        #[cfg(target_family = "wasm")]
+        {
+            let elapsed = Date::now() - self.started_at_ms;
+            if elapsed.is_finite() && elapsed > 0.0 {
+                elapsed as u64
+            } else {
+                0
+            }
+        }
+    }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(target_family = "wasm", derive(Tsify))]
@@ -68,6 +106,17 @@ pub async fn get_order_quotes(
     counterparty: Address,
     injector: &dyn SignedContextInjector,
 ) -> Result<Vec<BatchOrderQuotesResponse>, Error> {
+    let started_at = QuoteTiming::now();
+    info!(
+        order_count = orders.len(),
+        rpc_url_count = rpcs.len(),
+        block_number = ?block_number,
+        chunk_size = ?chunk_size,
+        counterparty = %counterparty,
+        "starting quote pair sweep"
+    );
+
+    let block_started_at = QuoteTiming::now();
     let req_block_number = match block_number {
         Some(block) => block,
         None => {
@@ -83,6 +132,12 @@ pub async fn get_order_quotes(
                 .map_err(|e| Error::TransportError(e.to_string()))?
         }
     };
+    info!(
+        requested_block_number = ?block_number,
+        resolved_block_number = req_block_number,
+        duration_ms = block_started_at.elapsed_ms(),
+        "resolved quote block number"
+    );
 
     // Responses are assembled in strict iteration order. Pairs whose oracle
     // fetch failed get a failure response stored immediately; quoted pairs
@@ -96,7 +151,12 @@ pub async fn get_order_quotes(
     let mut all_quote_targets: Vec<QuoteTarget> = Vec::new();
     let mut all_signed_contexts: Vec<Vec<SignedContextV1>> = Vec::new();
     let mut quoted_slot_indices: Vec<usize> = Vec::new();
+    let mut skipped_self_trade_pair_count = 0usize;
+    let mut oracle_fetch_count = 0usize;
+    let mut oracle_fetch_failure_count = 0usize;
+    let mut injected_context_count = 0usize;
 
+    let target_build_started_at = QuoteTiming::now();
     for order in &orders {
         let order_struct: OrderV4 = order.clone().try_into()?;
         let raindex = Address::from_str(&order.raindex.id.0)?;
@@ -105,6 +165,7 @@ pub async fn get_order_quotes(
         for (input_index, input) in order_struct.validInputs.iter().enumerate() {
             for (output_index, output) in order_struct.validOutputs.iter().enumerate() {
                 if input.token == output.token {
+                    skipped_self_trade_pair_count += 1;
                     continue;
                 }
 
@@ -140,6 +201,8 @@ pub async fn get_order_quotes(
                 // for oracle-backed orders reflect current oracle prices against past chain
                 // state, which may not represent a quote that actually existed.
                 let oracle_context = if let Some(ref url) = oracle_url {
+                    oracle_fetch_count += 1;
+                    let oracle_started_at = QuoteTiming::now();
                     let body = crate::oracle::encode_oracle_body(
                         &order_struct,
                         input_index as u32,
@@ -147,11 +210,31 @@ pub async fn get_order_quotes(
                         counterparty,
                     );
                     match crate::oracle::fetch_signed_context(url, body).await {
-                        Ok(ctx) => Ok(vec![ctx]),
-                        Err(e) => Err(format!(
-                            "Oracle fetch failed for pair ({}, {}): {}",
-                            input_index, output_index, e
-                        )),
+                        Ok(ctx) => {
+                            debug!(
+                                raindex = %raindex,
+                                input_index,
+                                output_index,
+                                duration_ms = oracle_started_at.elapsed_ms(),
+                                "fetched quote oracle context"
+                            );
+                            Ok(vec![ctx])
+                        }
+                        Err(e) => {
+                            oracle_fetch_failure_count += 1;
+                            warn!(
+                                raindex = %raindex,
+                                input_index,
+                                output_index,
+                                duration_ms = oracle_started_at.elapsed_ms(),
+                                error = %e,
+                                "quote oracle context fetch failed"
+                            );
+                            Err(format!(
+                                "Oracle fetch failed for pair ({}, {}): {}",
+                                input_index, output_index, e
+                            ))
+                        }
                     }
                 } else {
                     Ok(vec![])
@@ -177,6 +260,7 @@ pub async fn get_order_quotes(
                                 counterparty,
                             )
                             .await;
+                        injected_context_count += injected.len();
                         let composed: Vec<SignedContextV1> =
                             oracle_ctx.into_iter().chain(injected).collect();
 
@@ -208,38 +292,66 @@ pub async fn get_order_quotes(
             }
         }
     }
+    info!(
+        order_count = orders.len(),
+        target_count = all_quote_targets.len(),
+        response_slot_count = all_responses.len(),
+        skipped_self_trade_pair_count,
+        oracle_fetch_count,
+        oracle_fetch_failure_count,
+        injected_context_count,
+        duration_ms = target_build_started_at.elapsed_ms(),
+        "built quote targets"
+    );
 
+    let batch_quote_started_at = QuoteTiming::now();
     let quote_results: Vec<BatchOrderQuotesResponse> = match BatchQuoteTarget(all_quote_targets)
         .do_quote(rpcs, Some(req_block_number), counterparty, chunk_size)
         .await
     {
-        Ok(quote_values) => quote_values
-            .into_iter()
-            .zip(all_pairs)
-            .zip(all_signed_contexts)
-            .map(
-                |((quote_result, pair), signed_context)| match quote_result {
-                    Ok(data) => BatchOrderQuotesResponse {
-                        pair,
-                        block_number: req_block_number,
-                        success: true,
-                        data: Some(data),
-                        error: None,
-                        signed_context,
+        Ok(quote_values) => {
+            let failed_quote_count = quote_values.iter().filter(|result| result.is_err()).count();
+            let successful_quote_count = quote_values.len().saturating_sub(failed_quote_count);
+            info!(
+                successful_quote_count,
+                failed_quote_count,
+                duration_ms = batch_quote_started_at.elapsed_ms(),
+                "completed quote batch RPC"
+            );
+            quote_values
+                .into_iter()
+                .zip(all_pairs)
+                .zip(all_signed_contexts)
+                .map(
+                    |((quote_result, pair), signed_context)| match quote_result {
+                        Ok(data) => BatchOrderQuotesResponse {
+                            pair,
+                            block_number: req_block_number,
+                            success: true,
+                            data: Some(data),
+                            error: None,
+                            signed_context,
+                        },
+                        Err(e) => BatchOrderQuotesResponse {
+                            pair,
+                            block_number: req_block_number,
+                            success: false,
+                            data: None,
+                            error: Some(e.to_string()),
+                            signed_context,
+                        },
                     },
-                    Err(e) => BatchOrderQuotesResponse {
-                        pair,
-                        block_number: req_block_number,
-                        success: false,
-                        data: None,
-                        error: Some(e.to_string()),
-                        signed_context,
-                    },
-                },
-            )
-            .collect(),
+                )
+                .collect()
+        }
         Err(e) => {
             let error = e.to_string();
+            warn!(
+                quoted_pair_count = all_pairs.len(),
+                duration_ms = batch_quote_started_at.elapsed_ms(),
+                error = %error,
+                "quote batch RPC failed"
+            );
             all_pairs
                 .into_iter()
                 .zip(all_signed_contexts)
@@ -260,7 +372,20 @@ pub async fn get_order_quotes(
         all_responses[slot_idx] = Some(response);
     }
 
-    Ok(all_responses.into_iter().map(|r| r.unwrap()).collect())
+    let responses: Vec<_> = all_responses.into_iter().map(|r| r.unwrap()).collect();
+    let successful_quote_count = responses.iter().filter(|response| response.success).count();
+    let failed_quote_count = responses.len().saturating_sub(successful_quote_count);
+    info!(
+        order_count = orders.len(),
+        response_count = responses.len(),
+        successful_quote_count,
+        failed_quote_count,
+        resolved_block_number = req_block_number,
+        duration_ms = started_at.elapsed_ms(),
+        "completed quote pair sweep"
+    );
+
+    Ok(responses)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Chained PRs

Depends on:

- #2566

## Motivation

The REST order detail and cancel routes call SDK helpers for order lookup, quote generation, trade history, and remove calldata, but those paths did not expose enough structured timing to explain slow responses or pinpoint which SDK phase failed.

## Solution

- Add top-level spans and phase timings for `get_orders` and `get_order_by_hash`, including query source, filter shape, local DB/subgraph rows, dotrain source fetch timing, and errors.
- Add single-order quote tracing around RPC resolution, quote execution, conversion, and per-quote failures.
- Add lower-level quote pair sweep tracing in `raindex_quote` for block resolution, oracle context fetches, quote target construction, batch RPC execution, and final success/failure counts.
- Promote `get_trades_by_order_hashes` summary timing to info-level while keeping the existing debug detail.
- Add remove calldata tracing around order decode, encoded calldata length, and decode failures.
- Add focused tests for trace metadata summarization helpers.

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)

Verified locally:

- `nix develop -c cargo fmt --all`
- `nix develop -c env COMMIT_SHA=local cargo check -p raindex_quote -p raindex_common`
- `nix develop -c env COMMIT_SHA=local cargo test -p raindex_common order_filter_trace_summary_counts_optional_filters`
- `nix develop -c env COMMIT_SHA=local cargo test -p raindex_common query_source_label_describes_selected_sources`
- `nix develop -c env COMMIT_SHA=local cargo test -p raindex_common get_by_order_hashes`
- `nix develop -c env COMMIT_SHA=local cargo test -p raindex_common test_get_order_quote`
- `nix develop -c env COMMIT_SHA=local cargo test -p raindex_common test_get_remove_calldata`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive tracing, timing, and enriched logs across order listings, lookups, removals, quotes, and trade fetches for better observability
  * Emitted warnings when configured chain IDs mismatch requests and more detailed error context for failures
  * Improved batch and per-source fetch metrics, durations, and success/failure counts for clearer diagnostics

* **Tests**
  * Added unit tests validating filter summarization and source-label behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->