### PR TITLE
feat: add trade route tracing

### DIFF
--- a/crates/common/src/raindex_client/trades/get_all.rs
+++ b/crates/common/src/raindex_client/trades/get_all.rs
@@ -9,6 +9,7 @@ use raindex_subgraph_client::types::common::{
     SgTradesTokensFilterArgs,
 };
 use raindex_subgraph_client::MultiRaindexSubgraphClient;
+use tracing::{debug, error, info, info_span, Instrument};
 use tsify::Tsify;
 use wasm_bindgen_utils::impl_wasm_traits;
 
@@ -132,6 +133,37 @@ fn local_trades_pagination(
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct TradeFilterTraceSummary {
+    owners_count: usize,
+    takers_count: usize,
+    input_tokens_count: usize,
+    output_tokens_count: usize,
+    raindexes_count: usize,
+    has_order_hash_filter: bool,
+    has_time_filter: bool,
+}
+
+fn summarize_trade_filters(filters: &GetTradesFilters) -> TradeFilterTraceSummary {
+    TradeFilterTraceSummary {
+        owners_count: filters.owners.len(),
+        takers_count: filters.takers.len(),
+        input_tokens_count: filters
+            .tokens
+            .as_ref()
+            .and_then(|tokens| tokens.inputs.as_ref())
+            .map_or(0, Vec::len),
+        output_tokens_count: filters
+            .tokens
+            .as_ref()
+            .and_then(|tokens| tokens.outputs.as_ref())
+            .map_or(0, Vec::len),
+        raindexes_count: filters.raindex_addresses.as_ref().map_or(0, Vec::len),
+        has_order_hash_filter: filters.order_hash.is_some(),
+        has_time_filter: filters.time_filter.is_some(),
+    }
+}
+
 pub(super) fn normalize_trade_tokens(
     mut tokens: SgTradesTokensFilterArgs,
 ) -> SgTradesTokensFilterArgs {
@@ -204,234 +236,294 @@ impl RaindexClient {
         let page_size = page_size.unwrap_or(DEFAULT_PAGE_SIZE).max(1);
         let ids = chain_ids.map(|ChainIds(ids)| ids);
         let requested_chain_ids_count = ids.as_ref().map_or(0, Vec::len);
-        let (local_db, local_ids, sg_ids) = self.classify_chains(ids)?;
-        let local_chain_ids_count = local_ids.len();
-        let subgraph_chain_ids_count = sg_ids.len();
-        let input_tokens_count = filters
-            .tokens
-            .as_ref()
-            .and_then(|tokens| tokens.inputs.as_ref())
-            .map_or(0, Vec::len);
-        let output_tokens_count = filters
-            .tokens
-            .as_ref()
-            .and_then(|tokens| tokens.outputs.as_ref())
-            .map_or(0, Vec::len);
-        let takers_count = filters.takers.len();
-        let raindexes_count = filters.raindex_addresses.as_ref().map_or(0, Vec::len);
-
-        let mut all_trades = Vec::new();
-        let mut total_count: u64 = 0;
-        let mut local_fetch_ms = None;
-        let mut local_count_ms = None;
-        let mut local_rows = 0usize;
-        let mut local_total_count = 0u64;
-        let mut local_query_paginated = false;
-        let mut subgraph_fetch_ms = None;
-        let mut subgraph_rows_before_token_filter = 0usize;
-        let mut subgraph_rows_after_token_filter = 0usize;
-
-        if let Some(db) = local_db {
-            let (local_pagination, is_local_query_paginated) =
-                local_trades_pagination(!sg_ids.is_empty(), page_number, page_size);
-            local_query_paginated = is_local_query_paginated;
-            let local_tokens = filters
-                .tokens
-                .clone()
-                .map(|tokens| FetchTradesTokensFilter {
-                    inputs: tokens.inputs.unwrap_or_default(),
-                    outputs: tokens.outputs.unwrap_or_default(),
-                })
-                .unwrap_or_default();
-            let local_fetch_started = Timing::now();
-            let local_trades = match fetch_trades(
-                &db,
-                FetchTradesArgs {
-                    chain_ids: local_ids.clone(),
-                    raindex_addresses: filters.raindex_addresses.clone().unwrap_or_default(),
-                    owners: filters.owners.clone(),
-                    takers: filters.takers.clone(),
-                    order_hash: filters.order_hash,
-                    order_hashes: Vec::new(),
-                    tokens: local_tokens.clone(),
-                    time_filter: filters.time_filter.clone().unwrap_or_default(),
-                    pagination: local_pagination,
-                },
-            )
-            .await
-            {
-                Ok(trades) => trades,
-                Err(err) => {
-                    tracing::error!(
-                        elapsed_ms = local_fetch_started.elapsed_ms(),
-                        local_chain_ids_count,
-                        error = %err,
-                        "getTrades local DB fetch failed"
-                    );
-                    return Err(err.into());
-                }
-            };
-            local_fetch_ms = Some(local_fetch_started.elapsed_ms());
-            local_rows = local_trades.len();
-
-            let local_count_started = Timing::now();
-            let count_rows = match fetch_trades_count(
-                &db,
-                FetchTradesArgs {
-                    chain_ids: local_ids,
-                    raindex_addresses: filters.raindex_addresses.clone().unwrap_or_default(),
-                    owners: filters.owners.clone(),
-                    takers: filters.takers.clone(),
-                    order_hash: filters.order_hash,
-                    order_hashes: Vec::new(),
-                    tokens: local_tokens,
-                    time_filter: filters.time_filter.clone().unwrap_or_default(),
-                    pagination: PaginationParams::default(),
-                },
-            )
-            .await
-            {
-                Ok(count_rows) => count_rows,
-                Err(err) => {
-                    tracing::error!(
-                        elapsed_ms = local_count_started.elapsed_ms(),
-                        local_chain_ids_count,
-                        error = %err,
-                        "getTrades local DB count failed"
-                    );
-                    return Err(err.into());
-                }
-            };
-            local_count_ms = Some(local_count_started.elapsed_ms());
-            local_total_count = extract_trades_count(&count_rows);
-            total_count += local_total_count;
-            all_trades.extend(
-                local_trades
-                    .into_iter()
-                    .map(RaindexTrade::try_from_local_db_trade)
-                    .collect::<Result<Vec<_>, _>>()?,
-            );
-            tracing::debug!(
-                local_chain_ids_count,
-                rows = local_rows,
-                total_count = local_total_count,
-                fetch_ms = local_fetch_ms,
-                count_ms = local_count_ms,
-                "getTrades local DB completed"
-            );
-        }
-
-        if !sg_ids.is_empty() {
-            let multi_subgraph_args = self.get_multi_subgraph_args(Some(sg_ids))?;
-            let sg_filters: SgTradesListQueryFilters = filters.clone().into();
-            let sg_token_filter = filters
-                .tokens
-                .clone()
-                .and_then(Option::<SgTradesTokensFilterArgs>::from)
-                .map(normalize_trade_tokens);
-            let name_to_chain_id: std::collections::HashMap<&str, u32> = multi_subgraph_args
-                .iter()
-                .flat_map(|(chain_id, args)| args.iter().map(|arg| (arg.name.as_str(), *chain_id)))
-                .collect();
-            let client = MultiRaindexSubgraphClient::new(
-                multi_subgraph_args.values().flatten().cloned().collect(),
-            );
-            let subgraph_fetch_started = Timing::now();
-            let sg_trades = match client.trades_list_all(sg_filters).await {
-                Ok(trades) => trades,
-                Err(err) => {
-                    tracing::error!(
-                        elapsed_ms = subgraph_fetch_started.elapsed_ms(),
-                        subgraph_chain_ids_count,
-                        error = %err,
-                        "getTrades subgraph fetch failed"
-                    );
-                    return Err(err.into());
-                }
-            };
-            subgraph_fetch_ms = Some(subgraph_fetch_started.elapsed_ms());
-            subgraph_rows_before_token_filter = sg_trades.len();
-            let sg_trades: Vec<_> = if let Some(tokens) = sg_token_filter {
-                let filtered_trades: Vec<_> = sg_trades
-                    .into_iter()
-                    .filter(|trade| sg_trade_matches_token_filter(&trade.trade, &tokens))
-                    .collect();
-                total_count += filtered_trades.len() as u64;
-                subgraph_rows_after_token_filter = filtered_trades.len();
-                filtered_trades
-            } else {
-                total_count += sg_trades.len() as u64;
-                subgraph_rows_after_token_filter = sg_trades.len();
-                sg_trades
-            };
-            for trade_with_name in sg_trades {
-                let chain_id = name_to_chain_id
-                    .get(trade_with_name.subgraph_name.as_str())
-                    .copied()
-                    .ok_or(RaindexError::SubgraphNotFound(
-                        trade_with_name.subgraph_name.clone(),
-                        trade_with_name.trade.id.0.clone(),
-                    ))?;
-                all_trades.push(RaindexTrade::try_from_sg_trade(
-                    chain_id,
-                    trade_with_name.trade,
-                )?);
-            }
-            tracing::debug!(
-                subgraph_chain_ids_count,
-                rows_before_token_filter = subgraph_rows_before_token_filter,
-                rows_after_token_filter = subgraph_rows_after_token_filter,
-                fetch_ms = subgraph_fetch_ms,
-                "getTrades subgraph completed"
-            );
-        }
-
-        let merge_started = Timing::now();
-        all_trades.sort_by(|a, b| b.timestamp.cmp(&a.timestamp).then_with(|| a.id.cmp(&b.id)));
-        let offset = if local_query_paginated && subgraph_chain_ids_count == 0 {
-            0
-        } else {
-            ((page_number - 1) as usize) * (page_size as usize)
-        };
-        let limit = page_size as usize;
-        let merged_rows_before_pagination = all_trades.len();
-        let trades: Vec<_> = all_trades.into_iter().skip(offset).take(limit).collect();
-        let returned_rows = trades.len();
-        let summary = RaindexPairSummary::from_trades(&trades)?;
-        let merge_sort_page_ms = merge_started.elapsed_ms();
-        tracing::debug!(
+        let filter_summary = summarize_trade_filters(&filters);
+        let span = info_span!(
+            "get_trades",
+            requested_chain_ids_count,
             page = page_number,
             page_size,
-            requested_chain_ids_count,
-            local_chain_ids_count,
-            subgraph_chain_ids_count,
-            owners_count = filters.owners.len(),
-            takers_count,
-            raindexes_count,
-            has_order_hash = filters.order_hash.is_some(),
-            has_time_filter = filters.time_filter.is_some(),
-            input_tokens_count,
-            output_tokens_count,
-            local_fetch_ms,
-            local_count_ms,
-            local_query_paginated,
-            local_rows,
-            local_total_count,
-            subgraph_fetch_ms,
-            subgraph_rows_before_token_filter,
-            subgraph_rows_after_token_filter,
-            merged_rows_before_pagination,
-            returned_rows,
-            total_count,
-            merge_sort_page_ms,
-            total_ms = route_started.elapsed_ms(),
-            "getTrades completed"
+            owners_count = filter_summary.owners_count,
+            takers_count = filter_summary.takers_count,
+            input_tokens_count = filter_summary.input_tokens_count,
+            output_tokens_count = filter_summary.output_tokens_count,
+            raindexes_count = filter_summary.raindexes_count,
+            has_order_hash_filter = filter_summary.has_order_hash_filter,
+            has_time_filter = filter_summary.has_time_filter,
         );
-        Ok(RaindexTradesListResult {
-            trades,
-            total_count,
-            summary: Some(summary),
-        })
+
+        async move {
+            let (local_db, local_ids, sg_ids) = self.classify_chains(ids)?;
+            let local_chain_ids_count = local_ids.len();
+            let subgraph_chain_ids_count = sg_ids.len();
+
+            info!(
+                local_chain_ids_count,
+                subgraph_chain_ids_count, "fetching trades"
+            );
+
+            let mut all_trades = Vec::new();
+            let mut total_count: u64 = 0;
+            let mut local_fetch_ms = None;
+            let mut local_count_ms = None;
+            let mut local_rows = 0usize;
+            let mut local_total_count = 0u64;
+            let mut local_query_paginated = false;
+            let mut subgraph_fetch_ms = None;
+            let mut subgraph_rows_before_token_filter = 0usize;
+            let mut subgraph_rows_after_token_filter = 0usize;
+
+            if let Some(db) = local_db {
+                let (local_pagination, is_local_query_paginated) =
+                    local_trades_pagination(!sg_ids.is_empty(), page_number, page_size);
+                local_query_paginated = is_local_query_paginated;
+                let local_tokens = filters
+                    .tokens
+                    .clone()
+                    .map(|tokens| FetchTradesTokensFilter {
+                        inputs: tokens.inputs.unwrap_or_default(),
+                        outputs: tokens.outputs.unwrap_or_default(),
+                    })
+                    .unwrap_or_default();
+                let local_fetch_started = Timing::now();
+                let local_trades = match fetch_trades(
+                    &db,
+                    FetchTradesArgs {
+                        chain_ids: local_ids.clone(),
+                        raindex_addresses: filters.raindex_addresses.clone().unwrap_or_default(),
+                        owners: filters.owners.clone(),
+                        takers: filters.takers.clone(),
+                        order_hash: filters.order_hash,
+                        order_hashes: Vec::new(),
+                        tokens: local_tokens.clone(),
+                        time_filter: filters.time_filter.clone().unwrap_or_default(),
+                        pagination: local_pagination,
+                    },
+                )
+                .await
+                {
+                    Ok(trades) => trades,
+                    Err(err) => {
+                        error!(
+                            duration_ms = local_fetch_started.elapsed_ms(),
+                            local_chain_ids_count,
+                            error = %err,
+                            "getTrades local DB fetch failed"
+                        );
+                        return Err(err.into());
+                    }
+                };
+                local_fetch_ms = Some(local_fetch_started.elapsed_ms());
+                local_rows = local_trades.len();
+
+                let local_count_started = Timing::now();
+                let count_rows = match fetch_trades_count(
+                    &db,
+                    FetchTradesArgs {
+                        chain_ids: local_ids,
+                        raindex_addresses: filters.raindex_addresses.clone().unwrap_or_default(),
+                        owners: filters.owners.clone(),
+                        takers: filters.takers.clone(),
+                        order_hash: filters.order_hash,
+                        order_hashes: Vec::new(),
+                        tokens: local_tokens,
+                        time_filter: filters.time_filter.clone().unwrap_or_default(),
+                        pagination: PaginationParams::default(),
+                    },
+                )
+                .await
+                {
+                    Ok(count_rows) => count_rows,
+                    Err(err) => {
+                        error!(
+                            duration_ms = local_count_started.elapsed_ms(),
+                            local_chain_ids_count,
+                            error = %err,
+                            "getTrades local DB count failed"
+                        );
+                        return Err(err.into());
+                    }
+                };
+                local_count_ms = Some(local_count_started.elapsed_ms());
+                local_total_count = extract_trades_count(&count_rows);
+                total_count += local_total_count;
+                all_trades.extend(
+                    local_trades
+                        .into_iter()
+                        .map(RaindexTrade::try_from_local_db_trade)
+                        .collect::<Result<Vec<_>, _>>()?,
+                );
+                debug!(
+                    local_chain_ids_count,
+                    rows = local_rows,
+                    total_count = local_total_count,
+                    fetch_ms = local_fetch_ms,
+                    count_ms = local_count_ms,
+                    "getTrades local DB completed"
+                );
+                info!(
+                    source = "local_db",
+                    local_chain_ids_count,
+                    rows = local_rows,
+                    total_count = local_total_count,
+                    fetch_ms = local_fetch_ms,
+                    count_ms = local_count_ms,
+                    local_query_paginated,
+                    "fetched trades"
+                );
+            }
+
+            if !sg_ids.is_empty() {
+                let multi_subgraph_args = self.get_multi_subgraph_args(Some(sg_ids))?;
+                let sg_filters: SgTradesListQueryFilters = filters.clone().into();
+                let sg_token_filter = filters
+                    .tokens
+                    .clone()
+                    .and_then(Option::<SgTradesTokensFilterArgs>::from)
+                    .map(normalize_trade_tokens);
+                let name_to_chain_id: std::collections::HashMap<&str, u32> = multi_subgraph_args
+                    .iter()
+                    .flat_map(|(chain_id, args)| {
+                        args.iter().map(|arg| (arg.name.as_str(), *chain_id))
+                    })
+                    .collect();
+                let client = MultiRaindexSubgraphClient::new(
+                    multi_subgraph_args.values().flatten().cloned().collect(),
+                );
+                let subgraph_fetch_started = Timing::now();
+                let sg_trades = match client.trades_list_all(sg_filters).await {
+                    Ok(trades) => trades,
+                    Err(err) => {
+                        error!(
+                            duration_ms = subgraph_fetch_started.elapsed_ms(),
+                            subgraph_chain_ids_count,
+                            error = %err,
+                            "getTrades subgraph fetch failed"
+                        );
+                        return Err(err.into());
+                    }
+                };
+                subgraph_fetch_ms = Some(subgraph_fetch_started.elapsed_ms());
+                subgraph_rows_before_token_filter = sg_trades.len();
+                let sg_trades: Vec<_> = if let Some(tokens) = sg_token_filter {
+                    let filtered_trades: Vec<_> = sg_trades
+                        .into_iter()
+                        .filter(|trade| sg_trade_matches_token_filter(&trade.trade, &tokens))
+                        .collect();
+                    total_count += filtered_trades.len() as u64;
+                    subgraph_rows_after_token_filter = filtered_trades.len();
+                    filtered_trades
+                } else {
+                    total_count += sg_trades.len() as u64;
+                    subgraph_rows_after_token_filter = sg_trades.len();
+                    sg_trades
+                };
+                for trade_with_name in sg_trades {
+                    let chain_id = name_to_chain_id
+                        .get(trade_with_name.subgraph_name.as_str())
+                        .copied()
+                        .ok_or(RaindexError::SubgraphNotFound(
+                            trade_with_name.subgraph_name.clone(),
+                            trade_with_name.trade.id.0.clone(),
+                        ))?;
+                    all_trades.push(RaindexTrade::try_from_sg_trade(
+                        chain_id,
+                        trade_with_name.trade,
+                    )?);
+                }
+                debug!(
+                    subgraph_chain_ids_count,
+                    rows_before_token_filter = subgraph_rows_before_token_filter,
+                    rows_after_token_filter = subgraph_rows_after_token_filter,
+                    fetch_ms = subgraph_fetch_ms,
+                    "getTrades subgraph completed"
+                );
+                info!(
+                    source = "subgraph",
+                    subgraph_chain_ids_count,
+                    rows_before_token_filter = subgraph_rows_before_token_filter,
+                    rows_after_token_filter = subgraph_rows_after_token_filter,
+                    fetch_ms = subgraph_fetch_ms,
+                    "fetched trades"
+                );
+            }
+
+            let merge_started = Timing::now();
+            all_trades.sort_by(|a, b| b.timestamp.cmp(&a.timestamp).then_with(|| a.id.cmp(&b.id)));
+            let offset = if local_query_paginated && subgraph_chain_ids_count == 0 {
+                0
+            } else {
+                ((page_number - 1) as usize) * (page_size as usize)
+            };
+            let limit = page_size as usize;
+            let merged_rows_before_pagination = all_trades.len();
+            let trades: Vec<_> = all_trades.into_iter().skip(offset).take(limit).collect();
+            let returned_rows = trades.len();
+            let summary = RaindexPairSummary::from_trades(&trades)?;
+            let merge_sort_page_ms = merge_started.elapsed_ms();
+            debug!(
+                page = page_number,
+                page_size,
+                requested_chain_ids_count,
+                local_chain_ids_count,
+                subgraph_chain_ids_count,
+                owners_count = filter_summary.owners_count,
+                takers_count = filter_summary.takers_count,
+                raindexes_count = filter_summary.raindexes_count,
+                has_order_hash = filter_summary.has_order_hash_filter,
+                has_time_filter = filter_summary.has_time_filter,
+                input_tokens_count = filter_summary.input_tokens_count,
+                output_tokens_count = filter_summary.output_tokens_count,
+                local_fetch_ms,
+                local_count_ms,
+                local_query_paginated,
+                local_rows,
+                local_total_count,
+                subgraph_fetch_ms,
+                subgraph_rows_before_token_filter,
+                subgraph_rows_after_token_filter,
+                merged_rows_before_pagination,
+                returned_rows,
+                total_count,
+                merge_sort_page_ms,
+                total_ms = route_started.elapsed_ms(),
+                "getTrades completed"
+            );
+            info!(
+                page = page_number,
+                page_size,
+                requested_chain_ids_count,
+                local_chain_ids_count,
+                subgraph_chain_ids_count,
+                owners_count = filter_summary.owners_count,
+                takers_count = filter_summary.takers_count,
+                raindexes_count = filter_summary.raindexes_count,
+                has_order_hash = filter_summary.has_order_hash_filter,
+                has_time_filter = filter_summary.has_time_filter,
+                input_tokens_count = filter_summary.input_tokens_count,
+                output_tokens_count = filter_summary.output_tokens_count,
+                local_fetch_ms,
+                local_count_ms,
+                local_query_paginated,
+                local_rows,
+                local_total_count,
+                subgraph_fetch_ms,
+                subgraph_rows_before_token_filter,
+                subgraph_rows_after_token_filter,
+                merged_rows_before_pagination,
+                returned_rows,
+                total_count,
+                merge_sort_page_ms,
+                duration_ms = route_started.elapsed_ms(),
+                "completed get_trades"
+            );
+            Ok(RaindexTradesListResult {
+                trades,
+                total_count,
+                summary: Some(summary),
+            })
+        }
+        .instrument(span)
+        .await
     }
 }
 
@@ -444,6 +536,42 @@ mod tests {
         SgTradeStructPartialOrder, SgTradeVaultBalanceChange, SgTransaction,
         SgVaultBalanceChangeVault,
     };
+
+    #[test]
+    fn trade_filter_trace_summary_counts_optional_filters() {
+        let filters = GetTradesFilters {
+            owners: vec![address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")],
+            takers: vec![
+                address!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+                address!("0xcccccccccccccccccccccccccccccccccccccccc"),
+            ],
+            order_hash: Some(b256!(
+                "0x0000000000000000000000000000000000000000000000000000000000abcdef"
+            )),
+            tokens: Some(GetTradesTokenFilter {
+                inputs: Some(vec![address!("0x1111111111111111111111111111111111111111")]),
+                outputs: Some(vec![address!("0x2222222222222222222222222222222222222222")]),
+            }),
+            raindex_addresses: Some(vec![address!("0xdddddddddddddddddddddddddddddddddddddddd")]),
+            time_filter: Some(TimeFilter {
+                start: Some(10),
+                end: Some(20),
+            }),
+        };
+
+        assert_eq!(
+            summarize_trade_filters(&filters),
+            TradeFilterTraceSummary {
+                owners_count: 1,
+                takers_count: 2,
+                input_tokens_count: 1,
+                output_tokens_count: 1,
+                raindexes_count: 1,
+                has_order_hash_filter: true,
+                has_time_filter: true,
+            }
+        );
+    }
 
     #[test]
     fn local_trades_pagination_is_applied_for_local_only_queries() {

--- a/crates/common/src/raindex_client/trades/get_by_tx.rs
+++ b/crates/common/src/raindex_client/trades/get_by_tx.rs
@@ -1,9 +1,27 @@
 use super::*;
 use crate::local_db::query::fetch_trades_by_tx::FetchTradesByTxArgs;
 use crate::raindex_client::local_db::query::fetch_trades_by_tx::fetch_trades_by_tx;
+use crate::utils::timing::Timing;
 use alloy::primitives::{Address, B256};
 use raindex_subgraph_client::MultiRaindexSubgraphClient;
 use std::str::FromStr;
+use tracing::{error, info, info_span, Instrument};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct TransactionTradeTraceSummary {
+    requested_chain_ids_count: usize,
+    raindexes_count: usize,
+}
+
+fn summarize_transaction_trade_filters(
+    chain_ids: &Option<Vec<u32>>,
+    raindex_addresses: &Option<Vec<Address>>,
+) -> TransactionTradeTraceSummary {
+    TransactionTradeTraceSummary {
+        requested_chain_ids_count: chain_ids.as_ref().map_or(0, Vec::len),
+        raindexes_count: raindex_addresses.as_ref().map_or(0, Vec::len),
+    }
+}
 
 #[wasm_export]
 impl RaindexClient {
@@ -52,75 +70,147 @@ impl RaindexClient {
         raindex_addresses: Option<Vec<Address>>,
         tx_hash: B256,
     ) -> Result<RaindexTradesListResult, RaindexError> {
+        let started_at = Timing::now();
         let ids = chain_ids.map(|ChainIds(ids)| ids);
-        let (local_db, local_ids, sg_ids) = self.classify_chains(ids)?;
-        let raindex_addresses_for_local_db = raindex_addresses.clone().unwrap_or_default();
+        let filter_summary = summarize_transaction_trade_filters(&ids, &raindex_addresses);
+        let span = info_span!(
+            "get_trades_for_transaction",
+            tx_hash = %tx_hash,
+            requested_chain_ids_count = filter_summary.requested_chain_ids_count,
+            raindexes_count = filter_summary.raindexes_count,
+        );
 
-        let mut all_trades = Vec::new();
+        async move {
+            let (local_db, local_ids, sg_ids) = self.classify_chains(ids)?;
+            let local_chain_ids_count = local_ids.len();
+            let subgraph_chain_ids_count = sg_ids.len();
+            let raindex_addresses_for_local_db = raindex_addresses.clone().unwrap_or_default();
 
-        if let Some(db) = local_db.filter(|_| !local_ids.is_empty()) {
-            let trades = fetch_trades_by_tx(
-                &db,
-                FetchTradesByTxArgs {
-                    chain_ids: local_ids,
-                    raindex_addresses: raindex_addresses_for_local_db,
-                    tx_hash,
-                },
-            )
-            .await?;
-            let raindex_trades: Vec<RaindexTrade> = trades
-                .into_iter()
-                .map(RaindexTrade::try_from_local_db_trade)
-                .collect::<Result<_, _>>()?;
-            all_trades.extend(raindex_trades);
-        }
+            info!(
+                local_chain_ids_count,
+                subgraph_chain_ids_count, "fetching trades for transaction"
+            );
 
-        if !sg_ids.is_empty() {
-            let multi_subgraph_args = self.get_multi_subgraph_args(Some(sg_ids))?;
-            let raindex_in = raindex_addresses
-                .as_deref()
-                .filter(|addresses| !addresses.is_empty())
-                .map(|addresses| {
-                    addresses
-                        .iter()
-                        .map(|address| address.to_string().to_lowercase())
-                        .collect::<Vec<_>>()
-                });
-            if !multi_subgraph_args.is_empty() {
-                let name_to_chain_id: std::collections::HashMap<&str, u32> = multi_subgraph_args
-                    .iter()
-                    .flat_map(|(chain_id, args)| {
-                        args.iter().map(|arg| (arg.name.as_str(), *chain_id))
-                    })
-                    .collect();
-                let client = MultiRaindexSubgraphClient::new(
-                    multi_subgraph_args.values().flatten().cloned().collect(),
+            let mut all_trades = Vec::new();
+            let mut local_rows = 0usize;
+            let mut subgraph_rows = 0usize;
+
+            if let Some(db) = local_db.filter(|_| !local_ids.is_empty()) {
+                let local_started_at = Timing::now();
+                let trades = fetch_trades_by_tx(
+                    &db,
+                    FetchTradesByTxArgs {
+                        chain_ids: local_ids,
+                        raindex_addresses: raindex_addresses_for_local_db,
+                        tx_hash,
+                    },
+                )
+                .await
+                .map_err(|err| {
+                    error!(
+                        source = "local_db",
+                        local_chain_ids_count,
+                        duration_ms = local_started_at.elapsed_ms(),
+                        error = %err,
+                        "failed fetching trades for transaction"
+                    );
+                    RaindexError::from(err)
+                })?;
+                let raindex_trades: Vec<RaindexTrade> = trades
+                    .into_iter()
+                    .map(RaindexTrade::try_from_local_db_trade)
+                    .collect::<Result<_, _>>()?;
+                local_rows = raindex_trades.len();
+                all_trades.extend(raindex_trades);
+                info!(
+                    source = "local_db",
+                    local_chain_ids_count,
+                    rows = local_rows,
+                    duration_ms = local_started_at.elapsed_ms(),
+                    "fetched trades for transaction"
                 );
-                let sg_trades = client
-                    .trades_by_transaction(tx_hash.to_string(), raindex_in)
-                    .await?;
-                for trade_with_name in sg_trades {
-                    let chain_id = name_to_chain_id
-                        .get(trade_with_name.subgraph_name.as_str())
-                        .copied()
-                        .ok_or(RaindexError::SubgraphNotFound(
-                            trade_with_name.subgraph_name.clone(),
-                            trade_with_name.trade.id.0.clone(),
-                        ))?;
-                    let trade = RaindexTrade::try_from_sg_trade(chain_id, trade_with_name.trade)?;
-                    all_trades.push(trade);
+            }
+
+            if !sg_ids.is_empty() {
+                let subgraph_started_at = Timing::now();
+                let multi_subgraph_args = self.get_multi_subgraph_args(Some(sg_ids))?;
+                let raindex_in = raindex_addresses
+                    .as_deref()
+                    .filter(|addresses| !addresses.is_empty())
+                    .map(|addresses| {
+                        addresses
+                            .iter()
+                            .map(|address| address.to_string().to_lowercase())
+                            .collect::<Vec<_>>()
+                    });
+                if !multi_subgraph_args.is_empty() {
+                    let name_to_chain_id: std::collections::HashMap<&str, u32> =
+                        multi_subgraph_args
+                            .iter()
+                            .flat_map(|(chain_id, args)| {
+                                args.iter().map(|arg| (arg.name.as_str(), *chain_id))
+                            })
+                            .collect();
+                    let client = MultiRaindexSubgraphClient::new(
+                        multi_subgraph_args.values().flatten().cloned().collect(),
+                    );
+                    let sg_trades = client
+                        .trades_by_transaction(tx_hash.to_string(), raindex_in)
+                        .await
+                        .map_err(|err| {
+                            error!(
+                                source = "subgraph",
+                                subgraph_chain_ids_count,
+                                duration_ms = subgraph_started_at.elapsed_ms(),
+                                error = %err,
+                                "failed fetching trades for transaction"
+                            );
+                            RaindexError::from(err)
+                        })?;
+                    subgraph_rows = sg_trades.len();
+                    for trade_with_name in sg_trades {
+                        let chain_id = name_to_chain_id
+                            .get(trade_with_name.subgraph_name.as_str())
+                            .copied()
+                            .ok_or(RaindexError::SubgraphNotFound(
+                                trade_with_name.subgraph_name.clone(),
+                                trade_with_name.trade.id.0.clone(),
+                            ))?;
+                        let trade =
+                            RaindexTrade::try_from_sg_trade(chain_id, trade_with_name.trade)?;
+                        all_trades.push(trade);
+                    }
+                    info!(
+                        source = "subgraph",
+                        subgraph_chain_ids_count,
+                        rows = subgraph_rows,
+                        duration_ms = subgraph_started_at.elapsed_ms(),
+                        "fetched trades for transaction"
+                    );
                 }
             }
+
+            let total_count = all_trades.len() as u64;
+            let summary = RaindexPairSummary::from_trades(&all_trades)?;
+
+            info!(
+                local_chain_ids_count,
+                subgraph_chain_ids_count,
+                local_rows,
+                subgraph_rows,
+                total_count,
+                duration_ms = started_at.elapsed_ms(),
+                "completed get_trades_for_transaction"
+            );
+
+            Ok(RaindexTradesListResult {
+                trades: all_trades,
+                total_count,
+                summary: Some(summary),
+            })
         }
-
-        let total_count = all_trades.len() as u64;
-        let summary = RaindexPairSummary::from_trades(&all_trades)?;
-
-        Ok(RaindexTradesListResult {
-            trades: all_trades,
-            total_count,
-            summary: Some(summary),
-        })
+        .instrument(span)
+        .await
     }
 }
 
@@ -181,13 +271,28 @@ mod tests {
 
     #[cfg(not(target_family = "wasm"))]
     mod non_wasm {
+        use super::super::{summarize_transaction_trade_filters, TransactionTradeTraceSummary};
         use crate::raindex_client::tests::get_test_yaml;
         use crate::raindex_client::trades::test_helpers::get_sg_trade_json;
         use crate::raindex_client::{ChainIds, RaindexClient};
-        use alloy::primitives::{b256, Address, Bytes};
+        use alloy::primitives::{address, b256, Address, Bytes};
         use httpmock::MockServer;
         use serde_json::json;
         use std::str::FromStr;
+
+        #[test]
+        fn transaction_trade_trace_summary_counts_optional_filters() {
+            let chain_ids = Some(vec![1, 137]);
+            let raindexes = Some(vec![address!("0x1111111111111111111111111111111111111111")]);
+
+            assert_eq!(
+                summarize_transaction_trade_filters(&chain_ids, &raindexes),
+                TransactionTradeTraceSummary {
+                    requested_chain_ids_count: 2,
+                    raindexes_count: 1,
+                }
+            );
+        }
 
         #[tokio::test]
         async fn test_returns_trades() {


### PR DESCRIPTION
## Chained PRs

Depends on:

- #2595

## Motivation

The REST trade routes use shared SDK methods for transaction lookup and filtered trade lists, but the general trade paths did not expose enough info-level timing to diagnose slow local DB/subgraph reads, merge/pagination costs, or transaction-specific fetch failures.

## Solution

- Add an info-level `get_trades` span with page, filter-shape, and chain-source fields.
- Promote `get_trades` local DB, subgraph, and final merge/page timing summaries to info-level logs while preserving debug details.
- Add an info-level `get_trades_for_transaction` span with transaction hash and filter-shape fields.
- Add local DB/subgraph timing and error logs for transaction trade lookup.
- Add focused tests for the new trace metadata summarization helpers.

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)

Verified locally:

- `nix develop -c cargo fmt --all`
- `nix develop -c env COMMIT_SHA=local cargo check -p raindex_common`
- `nix develop -c env COMMIT_SHA=local cargo test -p raindex_common trade_filter_trace_summary_counts_optional_filters`
- `nix develop -c env COMMIT_SHA=local cargo test -p raindex_common transaction_trade_trace_summary_counts_optional_filters`
- `nix develop -c env COMMIT_SHA=local cargo test -p raindex_common get_by_tx::tests::non_wasm`
- `nix develop -c env COMMIT_SHA=local cargo test -p raindex_common get_all::tests`
