### PR TITLE
ci: fix nix crate vendoring

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -39,11 +39,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -57,11 +57,11 @@
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -90,75 +90,6 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_6": {
-      "inputs": {
-        "systems": "systems_5"
-      },
-      "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_7": {
-      "inputs": {
-        "systems": "systems_6"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_8": {
-      "locked": {
-        "lastModified": 1644229661,
-        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_9": {
-      "inputs": {
-        "systems": "systems_7"
-      },
-      "locked": {
         "lastModified": 1731533236,
         "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
@@ -175,34 +106,16 @@
     "foundry": {
       "inputs": {
         "flake-utils": "flake-utils_4",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
-        "lastModified": 1714727549,
-        "narHash": "sha256-CWXRTxxcgMfQubJugpeg3yVWIfm70MYTtgaKWKgD60U=",
+        "lastModified": 1778486972,
+        "narHash": "sha256-iuy/TbK9AbghEld2VSFuxyAF30LkOGUUdtrvixLfE7M=",
         "owner": "shazow",
         "repo": "foundry.nix",
-        "rev": "47cf189ec395eda4b3e0623179d1075c8027ca97",
-        "type": "github"
-      },
-      "original": {
-        "owner": "shazow",
-        "ref": "monthly",
-        "repo": "foundry.nix",
-        "type": "github"
-      }
-    },
-    "foundry_2": {
-      "inputs": {
-        "flake-utils": "flake-utils_8",
-        "nixpkgs": "nixpkgs_5"
-      },
-      "locked": {
-        "lastModified": 1773213477,
-        "narHash": "sha256-Pv1Z3QqGkSGEUV+9pM5vYIiI7VJo7Tfm6ZmR+JSp1zo=",
-        "owner": "shazow",
-        "repo": "foundry.nix",
-        "rev": "3c73daa86c823d706824fd9bbcb85aa23fd0f668",
+        "rev": "db117ae95a77b9ead24137c3ccb28896ae4fa4ec",
         "type": "github"
       },
       "original": {
@@ -215,14 +128,16 @@
       "inputs": {
         "flake-compat": "flake-compat",
         "gitignore": "gitignore",
-        "nixpkgs": "nixpkgs_6"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
-        "lastModified": 1774104215,
-        "narHash": "sha256-EAtviqz0sEAxdHS4crqu7JGR5oI3BwaqG0mw7CmXkO8=",
+        "lastModified": 1778507602,
+        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "f799ae951fde0627157f40aec28dec27b22076d0",
+        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
         "type": "github"
       },
       "original": {
@@ -255,154 +170,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1666753130,
-        "narHash": "sha256-Wff1dGPFSneXJLI2c0kkdWTgxnQ416KE6X4KnFkgPYQ=",
+        "lastModified": 1779963766,
+        "narHash": "sha256-Y6Tuk9aewk+HpKGoB+YfbpxCmKoq/g5sWkpYC5OT7ww=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f540aeda6f677354f1e7144ab04352f61aaa0118",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs-old": {
-      "locked": {
-        "lastModified": 1749104371,
-        "narHash": "sha256-m2NmOPd6XgBiskmUq/BS9Xxuf3z0ebnGVfSKNAO5NEM=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "48975d7f9b9960ed33c4e8561bcce20cc0c2de5b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "48975d7f9b9960ed33c4e8561bcce20cc0c2de5b",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1714764285,
-        "narHash": "sha256-oeevp27kMeDjKdxaTyXyS14TLjJrpJhXp7UVEUdYqYs=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "d121ce778b2609ae9e749a711295ffca013a82c4",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_3": {
-      "locked": {
-        "lastModified": 1706487304,
-        "narHash": "sha256-LE8lVX28MV2jWJsidW13D2qrHU/RUUONendL2Q/WlJg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "90f456026d284c22b3e3497be980b2e47d0b28ac",
+        "rev": "d556754720159ad11fea22549c0e990bd2df8b5a",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_4": {
-      "locked": {
-        "lastModified": 1708564076,
-        "narHash": "sha256-KKkqoxlgx9n3nwST7O2kM8tliDOijiSSNaWuSkiozdQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "98b00b6947a9214381112bdb6f89c25498db4959",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_5": {
-      "locked": {
-        "lastModified": 1666753130,
-        "narHash": "sha256-Wff1dGPFSneXJLI2c0kkdWTgxnQ416KE6X4KnFkgPYQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "f540aeda6f677354f1e7144ab04352f61aaa0118",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_6": {
-      "locked": {
-        "lastModified": 1770073757,
-        "narHash": "sha256-Vy+G+F+3E/Tl+GMNgiHl9Pah2DgShmIUBJXmbiQPHbI=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "47472570b1e607482890801aeaf29bfb749884f6",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_7": {
-      "locked": {
-        "lastModified": 1776017067,
-        "narHash": "sha256-oEp8fqJweZd5doqvH/aBAtc6NzZh+fh0tOhR09gQXck=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "a5a7cf16648d79134eb4da0e3354b08913917b2f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_8": {
-      "locked": {
-        "lastModified": 1744536153,
-        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_9": {
-      "locked": {
-        "lastModified": 1771923393,
-        "narHash": "sha256-Fy0+UXELv9hOE8WjYhJt8fMDLYTU2Dqn3cX4BwoGBos=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "ea7f1f06811ce7fcc81d6c6fd4213150c23edcf2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -410,14 +187,16 @@
     "rain": {
       "inputs": {
         "flake-utils": "flake-utils_2",
-        "rainix": "rainix"
+        "rainix": [
+          "rainix"
+        ]
       },
       "locked": {
-        "lastModified": 1714768001,
-        "narHash": "sha256-Vv5FZx6AFaHsJWQl5bsuhLbY8NWGeD0JHbAdceVZMqo=",
+        "lastModified": 1778746225,
+        "narHash": "sha256-AwCvQF3zlhjO8eQWBrkjMy6buhNXDabN6/DeHq5En+A=",
         "owner": "rainlanguage",
         "repo": "rain.cli",
-        "rev": "dc7ffe3b905ca57e92be6f294426f32fcf8005eb",
+        "rev": "bbf79984f43aae3ef8f72f60a2ca46108f27f12f",
         "type": "github"
       },
       "original": {
@@ -430,40 +209,19 @@
       "inputs": {
         "flake-utils": "flake-utils_3",
         "foundry": "foundry",
-        "nixpkgs": "nixpkgs_2",
+        "git-hooks-nix": "git-hooks-nix",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
         "rust-overlay": "rust-overlay",
         "solc": "solc"
       },
       "locked": {
-        "lastModified": 1714764843,
-        "narHash": "sha256-7ae0pHvjlInc1V3QxjW5iNhXAYerO1/fhLgzQnPNPjE=",
+        "lastModified": 1779911589,
+        "narHash": "sha256-X9JdcM7gIB9hEyBz0mW2RPaIF37L2X25NPMZmODaQMk=",
         "owner": "rainlanguage",
         "repo": "rainix",
-        "rev": "f3bdb28f353f8cba28b2bba86f79c362dd65ee53",
-        "type": "github"
-      },
-      "original": {
-        "owner": "rainlanguage",
-        "repo": "rainix",
-        "type": "github"
-      }
-    },
-    "rainix_2": {
-      "inputs": {
-        "flake-utils": "flake-utils_7",
-        "foundry": "foundry_2",
-        "git-hooks-nix": "git-hooks-nix",
-        "nixpkgs": "nixpkgs_7",
-        "nixpkgs-old": "nixpkgs-old",
-        "rust-overlay": "rust-overlay_2",
-        "solc": "solc_2"
-      },
-      "locked": {
-        "lastModified": 1777887852,
-        "narHash": "sha256-1AXVZpY1okCogZKt0CslqP06FG5HldcY+RmjEfct1rc=",
-        "owner": "rainlanguage",
-        "repo": "rainix",
-        "rev": "620c4d3604ba7967004afce6ffacd2ae9ef2c1a1",
+        "rev": "15b98f435a122237556fb5778f774c1123fb7c51",
         "type": "github"
       },
       "original": {
@@ -475,39 +233,23 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
         "rain": "rain",
-        "rainix": "rainix_2"
+        "rainix": "rainix"
       }
     },
     "rust-overlay": {
       "inputs": {
-        "flake-utils": "flake-utils_5",
-        "nixpkgs": "nixpkgs_3"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
-        "lastModified": 1714702555,
-        "narHash": "sha256-/NoUbE5S5xpK1FU3nlHhQ/tL126+JcisXdzy3Ng4pDU=",
+        "lastModified": 1778642276,
+        "narHash": "sha256-bhk4lawR4ZnFhPtamB5WkCyvfgyZmsEUbWfT/3FRxFY=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "7f0e3ef7b7fbed78e12e5100851175d28af4b7c6",
-        "type": "github"
-      },
-      "original": {
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "type": "github"
-      }
-    },
-    "rust-overlay_2": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_8"
-      },
-      "locked": {
-        "lastModified": 1773216618,
-        "narHash": "sha256-iZlowevS+xKLGOXtZwpIrz3SWe7PtoGUfEeVZNib+WE=",
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "rev": "07d7dc6fcc5eae76b4fb0e19d4afd939437bec97",
+        "rev": "77265d2dc1e61b2abfd3b1d6609dbb66fe75e0a5",
         "type": "github"
       },
       "original": {
@@ -518,15 +260,18 @@
     },
     "solc": {
       "inputs": {
-        "flake-utils": "flake-utils_6",
-        "nixpkgs": "nixpkgs_4"
+        "flake-utils": "flake-utils_5",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "solc-macos-amd64-list-json": "solc-macos-amd64-list-json"
       },
       "locked": {
-        "lastModified": 1711538161,
-        "narHash": "sha256-rETVdEIQ2PyEcNgzXXFSiYAYl0koCeGDIWp9XYBTxoQ=",
+        "lastModified": 1777817996,
+        "narHash": "sha256-iI71iUhD7THLibl3w1JcQEhHmTwZMxChi70RTe33BAo=",
         "owner": "hellwolf",
         "repo": "solc.nix",
-        "rev": "a995838545a7383a0b37776e969743b1346d5479",
+        "rev": "e3cf898cb804d5c0e5474b378a300fe8942e67d6",
         "type": "github"
       },
       "original": {
@@ -538,33 +283,13 @@
     "solc-macos-amd64-list-json": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-oEiXc95EghuYCudzkPA9XBFOnMdgWFfTO2/4XUfSTpc=",
+        "narHash": "sha256-zzwwHA2qPotv7yp8mK7+y9BZhm7ytuFeCJVvKBBdBn4=",
         "type": "file",
-        "url": "https://github.com/argotorg/solc-bin/raw/83cb756/macosx-amd64/list.json"
+        "url": "https://github.com/argotorg/solc-bin/raw/902dfaf/macosx-amd64/list.json"
       },
       "original": {
         "type": "file",
-        "url": "https://github.com/argotorg/solc-bin/raw/83cb756/macosx-amd64/list.json"
-      }
-    },
-    "solc_2": {
-      "inputs": {
-        "flake-utils": "flake-utils_9",
-        "nixpkgs": "nixpkgs_9",
-        "solc-macos-amd64-list-json": "solc-macos-amd64-list-json"
-      },
-      "locked": {
-        "lastModified": 1772085240,
-        "narHash": "sha256-+NEcuhT2A0QQumVx9Ze6g2iuNicyuW028Jq/HUJHGh4=",
-        "owner": "hellwolf",
-        "repo": "solc.nix",
-        "rev": "d3cc119973e484ea366f4b997b404bb00d7829ca",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hellwolf",
-        "repo": "solc.nix",
-        "type": "github"
+        "url": "https://github.com/argotorg/solc-bin/raw/902dfaf/macosx-amd64/list.json"
       }
     },
     "systems": {
@@ -613,51 +338,6 @@
       }
     },
     "systems_4": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_5": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_6": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_7": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -2,8 +2,15 @@
   description = "Flake for development workflows.";
 
   inputs = {
-    rainix.url = "github:rainlanguage/rainix";
-    rain.url = "github:rainlanguage/rain.cli";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    rainix = {
+      url = "github:rainlanguage/rainix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    rain = {
+      url = "github:rainlanguage/rain.cli";
+      inputs.rainix.follows = "rainix";
+    };
     flake-utils.url = "github:numtide/flake-utils";
   };
 
@@ -18,9 +25,94 @@
       system:
       let
         pkgs = rainix.pkgs.${system};
+        wasm-bindgen-cli = pkgs.wasm-bindgen-cli_0_2_100;
       in
       rec {
-        packages = rec {
+        packages = rainix.packages.${system} // rec {
+          rainix-sol-prelude = rainix.mkTask.${system} {
+            name = "rainix-sol-prelude";
+            additionalBuildInputs = rainix.sol-build-inputs.${system};
+            body = ''
+              set -euxo pipefail
+              forge install
+              forge build
+            '';
+          };
+
+          rainix-sol-static = rainix.mkTask.${system} {
+            name = "rainix-sol-static";
+            additionalBuildInputs = rainix.sol-build-inputs.${system};
+            body = ''
+              set -euxo pipefail
+              slither .
+              forge fmt --check
+            '';
+          };
+
+          rainix-sol-legal = rainix.mkTask.${system} {
+            name = "rainix-sol-legal";
+            additionalBuildInputs = rainix.sol-build-inputs.${system};
+            body = ''
+              set -euxo pipefail
+              reuse lint
+            '';
+          };
+
+          rainix-sol-test = rainix.mkTask.${system} {
+            name = "rainix-sol-test";
+            additionalBuildInputs = rainix.sol-build-inputs.${system};
+            body = ''
+              set -euxo pipefail
+              forge test -vvv
+            '';
+          };
+
+          rainix-rs-prelude = rainix.mkTask.${system} {
+            name = "rainix-rs-prelude";
+            additionalBuildInputs = rainix.rust-build-inputs.${system};
+            body = ''
+              set -euxo pipefail
+            '';
+          };
+
+          rainix-rs-static = rainix.mkTask.${system} {
+            name = "rainix-rs-static";
+            additionalBuildInputs = rainix.rust-build-inputs.${system};
+            body = ''
+              set -euxo pipefail
+              cargo fmt --all -- --check
+              cargo clippy --all-targets --all-features -- -D clippy::all
+            '';
+          };
+
+          rainix-rs-artifacts = rainix.mkTask.${system} {
+            name = "rainix-rs-artifacts";
+            additionalBuildInputs = rainix.rust-build-inputs.${system};
+            body = ''
+              set -euxo pipefail
+              cargo build --release
+            '';
+          };
+
+          rainlang-prelude = rainix.mkTask.${system} {
+            name = "rainlang-prelude";
+            body = ''
+              set -euxo pipefail
+
+              mkdir -p deployments/latest;
+
+              mkdir -p meta;
+              forge script --silent ./script/BuildAuthoringMeta.sol;
+              rain meta build \
+                -i <(cat ./meta/AuthoringMeta.rain.meta) \
+                -m authoring-meta-v2 \
+                -t cbor \
+                -e deflate \
+                -l none \
+                -o meta/RainlangExpressionDeployer.rain.meta \
+              ;
+            '';
+          };
 
           raindex-prelude = rainix.mkTask.${system} {
             name = "raindex-prelude";
@@ -57,10 +149,9 @@
               cd packages/ui-components && npm i && npm run lint
             '';
             additionalBuildInputs = [
-              pkgs.wasm-bindgen-cli
+              wasm-bindgen-cli
               rainix.rust-toolchain.${system}
-              rainix.rust-build-inputs.${system}
-            ];
+            ] ++ rainix.rust-build-inputs.${system};
           };
 
           raindex-cli-artifact = rainix.mkTask.${system} {
@@ -107,6 +198,9 @@
 
           rainix-wasm-test = rainix.mkTask.${system} {
             name = "rainix-wasm-test";
+            additionalBuildInputs = [
+              wasm-bindgen-cli
+            ];
             body = ''
               set -euxo pipefail
 
@@ -142,6 +236,9 @@
 
           build-js-bindings = rainix.mkTask.${system} {
             name = "build-js-bindings";
+            additionalBuildInputs = [
+              wasm-bindgen-cli
+            ];
             body = ''
               set -euxo pipefail
               cd packages/raindex
@@ -151,6 +248,9 @@
 
           test-js-bindings = rainix.mkTask.${system} {
             name = "test-js-bindings";
+            additionalBuildInputs = [
+              wasm-bindgen-cli
+            ];
             body = ''
               set -euxo pipefail
               cd packages/raindex
@@ -160,11 +260,19 @@
             '';
           };
 
-        }
-        // rainix.packages.${system};
+        };
 
         devShells.default = pkgs.mkShell {
           packages = [
+            wasm-bindgen-cli
+            packages.rainix-sol-prelude
+            packages.rainix-sol-static
+            packages.rainix-sol-legal
+            packages.rainix-sol-test
+            packages.rainix-rs-prelude
+            packages.rainix-rs-static
+            packages.rainix-rs-artifacts
+            packages.rainlang-prelude
             packages.raindex-prelude
             packages.raindex-rs-test
             packages.rainix-wasm-artifacts
@@ -181,7 +289,10 @@
           inherit (rainix.devShells.${system}.default) shellHook buildInputs nativeBuildInputs;
         };
         devShells.webapp-shell = pkgs.mkShell {
-          packages = with pkgs; [ nodejs_20 ];
+          packages = [
+            pkgs.nodejs_22
+            wasm-bindgen-cli
+          ];
           inherit (rainix.devShells.${system}.default) buildInputs nativeBuildInputs;
         };
       }

--- a/pointers.sh
+++ b/pointers.sh
@@ -2,14 +2,14 @@
 
 set -euxo pipefail
 
-(cd lib/rain.interpreter/lib/rain.interpreter.interface/lib/rain.math.float && nix develop -c rainix-sol-prelude)
-(cd lib/rain.interpreter/lib/rain.interpreter.interface/lib/rain.math.float && nix develop -c rainix-rs-prelude)
-(cd lib/rain.interpreter && nix develop -c rainix-sol-prelude)
-(cd lib/rain.interpreter && nix develop -c rainix-rs-prelude)
-(cd lib/rain.interpreter && nix develop -c rainlang-prelude)
-(cd lib/rain.interpreter/lib/rain.metadata && nix develop -c rainix-sol-prelude)
-(cd lib/rain.interpreter/lib/rain.metadata && nix develop -c rainix-rs-prelude)
-(cd lib/rain.interpreter/lib/rain.tofu.erc20-decimals && nix develop -c forge build)
+nix develop -c bash -c '(cd lib/rain.interpreter/lib/rain.interpreter.interface/lib/rain.math.float && rainix-sol-prelude)'
+nix develop -c bash -c '(cd lib/rain.interpreter/lib/rain.interpreter.interface/lib/rain.math.float && rainix-rs-prelude)'
+nix develop -c bash -c '(cd lib/rain.interpreter && rainix-sol-prelude)'
+nix develop -c bash -c '(cd lib/rain.interpreter && rainix-rs-prelude)'
+nix develop -c bash -c '(cd lib/rain.interpreter && rainlang-prelude)'
+nix develop -c bash -c '(cd lib/rain.interpreter/lib/rain.metadata && rainix-sol-prelude)'
+nix develop -c bash -c '(cd lib/rain.interpreter/lib/rain.metadata && rainix-rs-prelude)'
+nix develop -c bash -c '(cd lib/rain.interpreter/lib/rain.tofu.erc20-decimals && forge build)'
 
 nix develop -c rainix-sol-prelude
 nix develop -c rainix-rs-prelude

--- a/prep-base.sh
+++ b/prep-base.sh
@@ -41,12 +41,13 @@ nix develop -i ${keep[@]} -c bash \
   -c '(cd lib/rain.interpreter/lib/rain.interpreter.interface/lib/rain.math.float && rainix-rs-prelude)'
 
 echo "Setting up rain.tofu.erc20-decimals..."
-(cd lib/rain.interpreter/lib/rain.tofu.erc20-decimals && nix develop -c forge build)
+nix develop -i ${keep[@]} -c bash \
+  -c '(cd lib/rain.interpreter/lib/rain.tofu.erc20-decimals && forge build)'
 
 echo "Setting up rain.interpreter..."
 nix develop -i ${keep[@]} -c bash -c '(cd lib/rain.interpreter && rainix-sol-prelude)'
 nix develop -i ${keep[@]} -c bash -c '(cd lib/rain.interpreter && rainix-rs-prelude)'
-(cd lib/rain.interpreter && nix develop -i ${keep[@]} -c bash -c rainlang-prelude)
+nix develop -i ${keep[@]} -c bash -c '(cd lib/rain.interpreter && rainlang-prelude)'
 
 echo "Setting up rain.metadata..."
 nix develop -i ${keep[@]} -c bash -c '(cd lib/rain.interpreter/lib/rain.metadata && rainix-sol-prelude)'


### PR DESCRIPTION
## Motivation

`st0x.rest.api` CI runs `cd lib/rain.orderbook && ./prep-base.sh`. That path was still using rain.orderbook's older Nix graph, which attempted to fetch `alloy-json-abi-0.5.4` directly from crates.io and failed with HTTP 403.

The follow-up CI failures came from the same pattern in `pointers.sh`, plus the webapp shell still evaluating insecure `nodejs_20` on the updated nixpkgs pin.

After `pointers.sh` started passing, CI exposed the next layer:

- Updated Rainix no longer exports some task names that this repo's workflows still call.
- Updated Rainix's `rainix-rs-static` adds `-D warnings`, which turns existing dead-code warnings into CI failures unrelated to this Nix pin.
- The shell provided `wasm-bindgen-cli 0.2.122`, while the Rust crates still use wasm-bindgen schema `0.2.100`.

## Solution

- Add a root `nixpkgs` input pinned to the same `d556754720159ad11fea22549c0e990bd2df8b5a` revision used by the deploy-tooling fix.
- Make Rainix itself follow the root `nixpkgs` pin, matching the deploy-tooling pattern without overriding Rainix's nested child inputs.
- Update Rainix and `rain.cli`, with `rain.cli` following the repo Rainix input.
- Restore compatibility `rainix-sol-prelude`, `rainix-rs-prelude`, and `rainlang-prelude` tasks from the root flake so scripts stay on one fixed Nix graph.
- Restore repo-local compatibility tasks for `rainix-sol-static`, `rainix-sol-test`, `rainix-sol-legal`, `rainix-rs-static`, and `rainix-rs-artifacts` so existing workflow task names keep working.
- Pin `wasm-bindgen-cli` to `0.2.100` for JS and wasm tasks so the CLI schema matches the Rust dependency graph.
- Stop `prep-base.sh` and `pointers.sh` from entering nested submodule flakes.
- Move the webapp shell from `nodejs_20` to `nodejs_22` so nixpkgs no longer refuses evaluation for an insecure Node package.

## Checks

- `nix develop -c rainix-rs-prelude`
- `./prep-base.sh`
- `nix flake check --no-build`
- `nix eval .#devShells.x86_64-linux.webapp-shell.drvPath`
- `nix develop -c bash -c '(cd lib/rain.interpreter/lib/rain.interpreter.interface/lib/rain.math.float && rainix-sol-prelude)'`
- `./pointers.sh`
- `nix eval .#packages.x86_64-linux.build-js-bindings.name`
- `nix eval .#packages.x86_64-linux.test-js-bindings.name`
- `nix eval .#packages.x86_64-linux.rainix-rs-artifacts.name`
- `nix eval .#packages.x86_64-linux.rainix-sol-static.name`
- `nix eval .#devShells.x86_64-linux.default.drvPath`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added three new prelude packages to the development environment: rainix-sol-prelude, rainix-rs-prelude, rainlang-prelude.
  * Pinned and surfaced a specific wasm-bindgen-cli for JS build/test tasks to stabilize builds.
  * Upgraded the webapp dev shell Node.js from v20 to v22.
  * Harmonized dev/build script invocations to preserve environment passthrough and working-directory handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rainlanguage/raindex/pull/2598?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
