### PR TITLE
test: RouteProcessor arb receive()/fallback() accept ETH (audit A07-2)

### DIFF
--- a/test/concrete/arb/RouteProcessorRaindexV6ArbOrderTaker.ethReceipt.t.sol
+++ b/test/concrete/arb/RouteProcessorRaindexV6ArbOrderTaker.ethReceipt.t.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {RouteProcessorRaindexV6ArbOrderTaker} from "src/concrete/arb/RouteProcessorRaindexV6ArbOrderTaker.sol";
+
+/// @title RouteProcessorRaindexV6ArbOrderTakerEthReceiptTest
+/// @notice Audit A07-2 (#2534): the arb's payable `receive()` / `fallback()`
+/// accept ETH (so a route processor can refund native gas; `finalizeArb` later
+/// sweeps it to `msg.sender`). Nothing covered the bare ETH-receipt paths.
+contract RouteProcessorRaindexV6ArbOrderTakerEthReceiptTest is Test {
+    /// Empty calldata routes to `receive()`, which accepts the ETH.
+    function testReceiveAcceptsEth(uint256 amount) external {
+        amount = bound(amount, 0, 1e24);
+        RouteProcessorRaindexV6ArbOrderTaker arb = new RouteProcessorRaindexV6ArbOrderTaker();
+        vm.deal(address(this), amount);
+
+        (bool ok,) = address(arb).call{value: amount}("");
+        assertTrue(ok, "receive() accepted ETH");
+        assertEq(address(arb).balance, amount, "arb holds the ETH");
+    }
+
+    /// Non-empty calldata matching no function selector routes to `fallback()`,
+    /// which also accepts the ETH.
+    function testFallbackAcceptsEth(uint256 amount) external {
+        amount = bound(amount, 0, 1e24);
+        RouteProcessorRaindexV6ArbOrderTaker arb = new RouteProcessorRaindexV6ArbOrderTaker();
+        vm.deal(address(this), amount);
+
+        // A one-byte payload can't match a 4-byte selector, so it hits fallback.
+        (bool ok,) = address(arb).call{value: amount}(hex"01");
+        assertTrue(ok, "fallback() accepted ETH");
+        assertEq(address(arb).balance, amount, "arb holds the ETH");
+    }
+}


### PR DESCRIPTION
Audit **#2534** A07-2 (`RouteProcessorRaindexV6ArbOrderTaker`), test-only.

The arb has `receive() external payable {}` and `fallback() external payable {}` (so a route processor can refund native gas, which `finalizeArb` later sweeps), but the bare ETH-receipt paths had no coverage.

- `testReceiveAcceptsEth` — empty calldata → `receive()` accepts ETH; arb holds it. (fuzzed amount)
- `testFallbackAcceptsEth` — one-byte (non-selector) calldata → `fallback()` accepts ETH; arb holds it. (fuzzed amount)

A07-3 (fuzz of the full `onTakeOrders2`/`arb5` cycle) is a follow-up — it needs careful Float/wei handling and is left for a separate change.

Addresses #2534 (A07-2).