### PR TITLE
test: LibRaindex.doPost edge paths (audit GAP-A11-1/2/3)

### DIFF
--- a/test/lib/LibRaindex.doPost.t.sol
+++ b/test/lib/LibRaindex.doPost.t.sol
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {LibRaindex} from "src/lib/LibRaindex.sol";
+import {TaskV2} from "raindex-interface-0.1.1/src/interface/IRaindexV6.sol";
+import {IInterpreterV4, StackItem} from "rain-interpreter-interface-0.1.0/src/interface/IInterpreterV4.sol";
+import {IInterpreterStoreV3} from "rain-interpreter-interface-0.1.0/src/interface/IInterpreterStoreV3.sol";
+import {EvaluableV4} from "rain-interpreter-interface-0.1.0/src/interface/IInterpreterCallerV4.sol";
+import {SignedContextV1} from "rain-interpreter-interface-0.1.0/src/interface/deprecated/v1/IInterpreterCallerV2.sol";
+
+/// @dev Exposes the internal `LibRaindex.doPost` for direct testing.
+contract LibRaindexDoPostHarness {
+    function doPost(bytes32[][] memory context, TaskV2[] memory post) external {
+        LibRaindex.doPost(context, post);
+    }
+}
+
+/// @title LibRaindexDoPostTest
+/// @notice Audit GAP-A11-1/2/3 (#2536): `doPost` skips work for an empty post
+/// array, skips tasks with empty bytecode, and only calls `store.set` when the
+/// evaluation produced writes.
+contract LibRaindexDoPostTest is Test {
+    LibRaindexDoPostHarness internal immutable iHarness = new LibRaindexDoPostHarness();
+
+    /// GAP-A11-1: an empty post array is a no-op (no interpreter/store calls).
+    function testDoPostEmptyPostArrayNoOp() external {
+        iHarness.doPost(new bytes32[][](0), new TaskV2[](0));
+    }
+
+    /// GAP-A11-2: a task with empty bytecode is skipped — neither `eval4` nor
+    /// `store.set` is called (both are mocked to revert if reached).
+    function testDoPostSkipsEmptyBytecodeTask() external {
+        address interpreter = makeAddr("interpreter");
+        address store = makeAddr("store");
+        vm.mockCallRevert(
+            interpreter, abi.encodeWithSelector(IInterpreterV4.eval4.selector), bytes("eval must be skipped")
+        );
+        vm.mockCallRevert(store, abi.encodeWithSelector(IInterpreterStoreV3.set.selector), bytes("set must be skipped"));
+
+        TaskV2[] memory post = new TaskV2[](1);
+        post[0] = TaskV2({
+            evaluable: EvaluableV4(IInterpreterV4(interpreter), IInterpreterStoreV3(store), hex""),
+            signedContext: new SignedContextV1[](0)
+        });
+        iHarness.doPost(new bytes32[][](0), post);
+    }
+
+    /// GAP-A11-3: when `eval4` produces no writes, `store.set` is not called
+    /// (mocked to revert if reached).
+    function testDoPostNoStoreSetWhenNoWrites() external {
+        address interpreter = makeAddr("interpreter");
+        address store = makeAddr("store");
+        vm.mockCall(
+            interpreter,
+            abi.encodeWithSelector(IInterpreterV4.eval4.selector),
+            abi.encode(new StackItem[](0), new bytes32[](0))
+        );
+        vm.mockCallRevert(store, abi.encodeWithSelector(IInterpreterStoreV3.set.selector), bytes("set must be skipped"));
+
+        TaskV2[] memory post = new TaskV2[](1);
+        post[0] = TaskV2({
+            evaluable: EvaluableV4(IInterpreterV4(interpreter), IInterpreterStoreV3(store), hex"01"),
+            signedContext: new SignedContextV1[](0)
+        });
+        iHarness.doPost(new bytes32[][](0), post);
+    }
+
+    /// Contrast for GAP-A11-3: when `eval4` produces writes, `store.set` IS
+    /// called with them.
+    function testDoPostStoreSetWhenWrites() external {
+        address interpreter = makeAddr("interpreter");
+        address store = makeAddr("store");
+        bytes32[] memory writes = new bytes32[](2);
+        writes[0] = bytes32(uint256(1));
+        writes[1] = bytes32(uint256(2));
+        vm.mockCall(
+            interpreter, abi.encodeWithSelector(IInterpreterV4.eval4.selector), abi.encode(new StackItem[](0), writes)
+        );
+        vm.mockCall(store, abi.encodeWithSelector(IInterpreterStoreV3.set.selector), bytes(""));
+        vm.expectCall(store, abi.encodeWithSelector(IInterpreterStoreV3.set.selector));
+
+        TaskV2[] memory post = new TaskV2[](1);
+        post[0] = TaskV2({
+            evaluable: EvaluableV4(IInterpreterV4(interpreter), IInterpreterStoreV3(store), hex"01"),
+            signedContext: new SignedContextV1[](0)
+        });
+        iHarness.doPost(new bytes32[][](0), post);
+    }
+}


### PR DESCRIPTION
Audit **#2536** (`LibRaindex.doPost`), test-only — covers the three guarded paths via a harness + `vm.mockCall`/`mockCallRevert`:

- **GAP-A11-1** — empty `post` array is a no-op (loop never runs).
- **GAP-A11-2** — a task with empty `bytecode` is skipped; `eval4` and `store.set` are both mocked to revert if reached, and `doPost` completes cleanly.
- **GAP-A11-3** — `store.set` is called only when `eval4` produces writes: the no-write case (set mocked to revert) completes without calling it; the with-write contrast asserts `store.set` *is* called.

No source change. All 4 pass.

Closes #2536