### PR TITLE
ci: autopublish raindex to Soldeer (rainix standard)

### DIFF
--- a/.github/workflows/package-release.yaml
+++ b/.github/workflows/package-release.yaml
@@ -1,0 +1,11 @@
+name: Package Release
+on:
+  push:
+    branches:
+      - main
+jobs:
+  release:
+    uses: rainlanguage/rainix/.github/workflows/rainix-autopublish.yaml@main
+    with:
+      soldeer-package: raindex
+    secrets: inherit

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,3 +1,7 @@
+[package]
+name = "raindex"
+version = "0.1.0"
+
 [profile.default]
 src = 'src'
 out = 'out'


### PR DESCRIPTION
Sets up Soldeer autopublishing for the raindex contracts using the rainix standard reusable — same pattern as rain.vats.

## Changes
- `foundry.toml`: add a `[package]` block (`name = "raindex"`, `version = "0.1.0"`).
- `.github/workflows/package-release.yaml`: on push to `main`, calls `rainlanguage/rainix/.github/workflows/rainix-autopublish.yaml@main` with `soldeer-package: raindex`, `secrets: inherit`.

The reusable reads the version from `foundry.toml [package].version` and pushes to Soldeer **only when it diverges** from the latest registry entry. There is **no auto-bump** — the version is managed explicitly here.

## Please confirm before merge
- **Starting version `0.1.0`** — `raindex` is not yet on the Soldeer registry (the interface `raindex-interface` is at `0.1.1`). I picked `0.1.0` as a conservative default; set whatever canonical version you want — the first merge to `main` publishes exactly this.
- **First publish creates the project.** A non-existent project returns an empty registry result, so the gate sees divergence and publishes, creating `raindex` on Soldeer under the CI account. If Soldeer requires the project name to be pre-registered, the first run may need a one-time manual `forge soldeer push raindex~0.1.0` bootstrap.

Note: this is Soldeer-only; the existing npm (`npm-package-release.yml`) and Rust (`manual-rs-release.yml`) releases are unchanged.