### PR TITLE
fix: scope Soldeer package to src (.soldeerignore)

### DIFF
--- a/.soldeerignore
+++ b/.soldeerignore
@@ -1,0 +1,53 @@
+# Publish only the Solidity source (src/) to Soldeer. raindex is a large
+# multi-language repo; without this the push zips the whole tree (crates/,
+# packages/, subgraph/, lib/, target/, node_modules/, audit/ ...) and fails.
+# Same syntax as .gitignore.
+
+# Tooling / repo files
+.DS_Store
+.cargo
+.coderabbit.yaml
+.devcontainer.json
+.envrc
+.gas-snapshot
+.git
+.github
+.gitignore
+.gitmodules
+.pre-commit-config.yaml
+.prettierignore
+.soldeerignore
+.vscode
+AGENTS.md
+CLAUDE.md
+Cargo.lock
+Cargo.toml
+package.json
+package-lock.json
+slither.config.json
+
+# Non-Solidity / non-source trees and build output
+/ai_commands
+/audit
+/broadcast
+/cache
+/crates
+/dependencies
+/deployments
+/flake.lock
+/flake.nix
+/foundry.lock
+/foundry.toml
+/lib
+/meta
+/node_modules
+/out
+/packages
+/remappings.txt
+/REUSE.toml
+/script
+/soldeer.lock
+/subgraph
+/target
+/test
+/test-resources

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -6,6 +6,7 @@ path = [
   ".gas-snapshot",
   ".github/**/",
   ".gitignore",
+  ".soldeerignore",
   ".prettierignore",
   ".vscode/**/",
   ".cargo/**/",


### PR DESCRIPTION
## Problem
The first raindex Soldeer autopublish (from #2629, on push to `main`) **failed**:
```
Run: forge soldeer push "raindex~0.1.0"
Error: Failed to run soldeer: error during publishing: error during IO operation for "": not connected
```
The `raindex` Soldeer project exists and is owned by the same account that publishes `rain-vats` fine, so it isn't auth / ownership / missing-project. The cause: raindex has **no `.soldeerignore`**, so `soldeer push` zips the entire multi-language repo — `subgraph/` (223M), `lib/` (474M), `crates/`, `packages/`, `audit/`, `target/`, `node_modules/`, … — and the upload dies.

## Fix
Add a `.soldeerignore` (same syntax as `.gitignore`) that ships **only the Solidity source**.

Verified with a dry-run (no upload, no credentials needed):
```
forge soldeer push raindex~0.1.0 --dry-run
→ Zip file created … raindex.zip   (120K)
   contents: src/  LICENSE  LICENSES  README.md  .env.example
```
i.e. 120 KB instead of the whole 10 GB+ tree.

Merging this re-fires the **Package Release** workflow on `main`, which should now publish `raindex@0.1.0` successfully (the project already exists and the package is now small/clean).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package distribution configuration to streamline published artifacts, ensuring only essential Solidity source files are included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->