### PR TITLE
test(lib): mutation-validated coverage for src/lib libraries

### DIFF
--- a/test/lib/LibGenericPoolExchange.spenderPool.t.sol
+++ b/test/lib/LibGenericPoolExchange.spenderPool.t.sol
@@ -82,4 +82,19 @@ contract LibGenericPoolExchangeSpenderPoolTest is Test {
         assertTrue(pool.called(), "empty call still reaches the pool");
         assertEq(token.allowance(address(iHarness), spender), 0, "approval revoked after the call");
     }
+
+    /// The call to the pool forwards the exchanger's *entire* ETH balance, not a
+    /// fixed or zero amount. Fund the harness with a fuzzed balance and assert
+    /// the whole balance lands at the pool and none is left behind.
+    function testForwardsEntireEthBalanceToPool(address spender, uint256 balance) external {
+        MockToken token = new MockToken("Token", "TKN", 18);
+        FallbackPool pool = new FallbackPool();
+        vm.assume(spender != address(0));
+        vm.deal(address(iHarness), balance);
+
+        iHarness.exchange(address(token), abi.encode(spender, address(pool), bytes("")));
+
+        assertEq(address(pool).balance, balance, "entire balance forwarded to pool");
+        assertEq(address(iHarness).balance, 0, "no ETH left at the exchanger");
+    }
 }

--- a/test/lib/LibOrder.t.sol
+++ b/test/lib/LibOrder.t.sol
@@ -5,6 +5,8 @@ pragma solidity =0.8.25;
 import {Test} from "forge-std-1.16.1/src/Test.sol";
 
 import {LibOrder, OrderV4} from "../../src/lib/LibOrder.sol";
+import {EvaluableV4} from "rain-interpreter-interface-0.1.0/src/interface/IInterpreterCallerV4.sol";
+import {IOV2} from "raindex-interface-0.1.1/src/interface/deprecated/v5/IOrderBookV5.sol";
 
 /// @title LibOrderTest
 /// Exercises the LibOrder library.
@@ -50,6 +52,54 @@ contract LibOrderTest is Test {
             validInputs: a.validInputs,
             validOutputs: a.validOutputs,
             nonce: otherNonce
+        });
+        assertTrue(LibOrder.hash(a) != LibOrder.hash(b));
+    }
+
+    /// Mutating only the evaluable should always produce a different hash. The
+    /// evaluable binds the order to a specific interpreter/store/bytecode, so it
+    /// must be part of the hash preimage.
+    /// forge-config: default.fuzz.runs = 100
+    function testHashNotEqualMutatedEvaluable(OrderV4 memory a, EvaluableV4 memory otherEvaluable) public pure {
+        vm.assume(keccak256(abi.encode(a.evaluable)) != keccak256(abi.encode(otherEvaluable)));
+        OrderV4 memory b = OrderV4({
+            owner: a.owner,
+            evaluable: otherEvaluable,
+            validInputs: a.validInputs,
+            validOutputs: a.validOutputs,
+            nonce: a.nonce
+        });
+        assertTrue(LibOrder.hash(a) != LibOrder.hash(b));
+    }
+
+    /// Mutating only the valid inputs should always produce a different hash.
+    /// The input vaults/tokens are part of the order's identity, so they must be
+    /// bound into the hash.
+    /// forge-config: default.fuzz.runs = 100
+    function testHashNotEqualMutatedValidInputs(OrderV4 memory a, IOV2[] memory otherInputs) public pure {
+        vm.assume(keccak256(abi.encode(a.validInputs)) != keccak256(abi.encode(otherInputs)));
+        OrderV4 memory b = OrderV4({
+            owner: a.owner,
+            evaluable: a.evaluable,
+            validInputs: otherInputs,
+            validOutputs: a.validOutputs,
+            nonce: a.nonce
+        });
+        assertTrue(LibOrder.hash(a) != LibOrder.hash(b));
+    }
+
+    /// Mutating only the valid outputs should always produce a different hash.
+    /// The output vaults/tokens are part of the order's identity, so they must
+    /// be bound into the hash.
+    /// forge-config: default.fuzz.runs = 100
+    function testHashNotEqualMutatedValidOutputs(OrderV4 memory a, IOV2[] memory otherOutputs) public pure {
+        vm.assume(keccak256(abi.encode(a.validOutputs)) != keccak256(abi.encode(otherOutputs)));
+        OrderV4 memory b = OrderV4({
+            owner: a.owner,
+            evaluable: a.evaluable,
+            validInputs: a.validInputs,
+            validOutputs: otherOutputs,
+            nonce: a.nonce
         });
         assertTrue(LibOrder.hash(a) != LibOrder.hash(b));
     }

--- a/test/lib/LibRaindex.doPost.t.sol
+++ b/test/lib/LibRaindex.doPost.t.sol
@@ -7,6 +7,7 @@ import {LibRaindex} from "src/lib/LibRaindex.sol";
 import {TaskV2} from "raindex-interface-0.1.1/src/interface/IRaindexV6.sol";
 import {IInterpreterV4, StackItem} from "rain-interpreter-interface-0.1.0/src/interface/IInterpreterV4.sol";
 import {IInterpreterStoreV3} from "rain-interpreter-interface-0.1.0/src/interface/IInterpreterStoreV3.sol";
+import {StateNamespace} from "rain-interpreter-interface-0.1.0/src/interface/deprecated/v2/IInterpreterStoreV2.sol";
 import {EvaluableV4} from "rain-interpreter-interface-0.1.0/src/interface/IInterpreterCallerV4.sol";
 import {SignedContextV1} from "rain-interpreter-interface-0.1.0/src/interface/deprecated/v1/IInterpreterCallerV2.sol";
 
@@ -81,10 +82,17 @@ contract LibRaindexDoPostTest is Test {
         vm.mockCall(
             interpreter, abi.encodeWithSelector(IInterpreterV4.eval4.selector), abi.encode(new StackItem[](0), writes)
         );
-        // Pin the full path: eval4 runs, returns writes, and store.set receives them.
+        // Pin the full path: eval4 runs, returns writes, and store.set receives
+        // them. The expectCall pins the FULL calldata — the namespace
+        // (derived from msg.sender == this test) and the exact writes — so a
+        // mutation forwarding different writes or a different namespace to
+        // store.set is caught, not just any call to the selector.
         vm.expectCall(interpreter, abi.encodeWithSelector(IInterpreterV4.eval4.selector));
         vm.mockCall(store, abi.encodeWithSelector(IInterpreterStoreV3.set.selector), bytes(""));
-        vm.expectCall(store, abi.encodeWithSelector(IInterpreterStoreV3.set.selector));
+        vm.expectCall(
+            store,
+            abi.encodeCall(IInterpreterStoreV3.set, (StateNamespace.wrap(uint256(uint160(address(this)))), writes))
+        );
 
         TaskV2[] memory post = new TaskV2[](1);
         post[0] = TaskV2({

--- a/test/lib/LibRaindexArb.finalizeArbTaskContext.t.sol
+++ b/test/lib/LibRaindexArb.finalizeArbTaskContext.t.sol
@@ -53,4 +53,51 @@ contract LibRaindexArbFinalizeArbTaskContextTest is Test {
         assertEq(result.inputToken.balanceOf(address(result.arb)), 0, "arb inputToken");
         assertEq(result.outputToken.balanceOf(address(result.arb)), 0, "arb outputToken");
     }
+
+    /// Companion to the above: the output (context<1 1>) and gas (context<1 2>)
+    /// columns must carry the correct NON-ZERO Floats, not just zero. The
+    /// sibling test only ever sees zero output/gas, so a mutation zeroing either
+    /// column would survive it. Here input profit is zero while output profit is
+    /// 20 and gas is 1 ether, pinning all three columns at distinct values.
+    function testFinalizeArbContextNonZeroOutputAndGas() external {
+        LibInterpreterDeploy.etchRainlang(vm);
+
+        IParserV2 parser = IParserV2(LibInterpreterDeploy.EXPRESSION_DEPLOYER_DEPLOYED_ADDRESS);
+
+        // 0 input profit → Float(0); 20e18 output profit (18 dp) → Float(20);
+        // 1 ether gas swept (packed at -18) → Float(1).
+        bytes memory taskBytecode = parser.parse2(
+            bytes(
+                string.concat(
+                    ":ensure(equal-to(context<1 0>() 0) \"input\"),",
+                    ":ensure(equal-to(context<1 1>() 20) \"output\"),",
+                    ":ensure(equal-to(context<1 2>() 1) \"gas\");"
+                )
+            )
+        );
+
+        TaskV2 memory task = TaskV2({
+            evaluable: EvaluableV4(
+                IInterpreterV4(LibInterpreterDeploy.INTERPRETER_DEPLOYED_ADDRESS),
+                IInterpreterStoreV3(LibInterpreterDeploy.STORE_DEPLOYED_ADDRESS),
+                taskBytecode
+            ),
+            signedContext: new SignedContextV1[](0)
+        });
+
+        // Raindex has 100e18 output, pulls 80e18 input. Exchange has 80e18 input.
+        // Arb swaps 80e18 output → 80e18 input, all pulled by raindex (0 input
+        // profit), leaving 20e18 output profit; 1 ether is returned and swept.
+        // Task expression reverts if any context value is wrong.
+        ArbResult memory result = LibTestArb.setupAndArb(vm, 80e18, 100e18, 80e18, 80e18, task, 1 ether);
+
+        // Sanity check balances.
+        assertEq(result.inputToken.balanceOf(address(this)), 0, "no input profit");
+        assertEq(result.outputToken.balanceOf(address(this)), 20e18, "sender outputToken profit");
+        assertEq(result.inputToken.balanceOf(address(result.arb)), 0, "arb inputToken");
+        assertEq(result.outputToken.balanceOf(address(result.arb)), 0, "arb outputToken");
+    }
+
+    /// Needed to receive the swept gas in the non-zero gas scenario.
+    receive() external payable {}
 }


### PR DESCRIPTION
## Test hardening — `src/lib` (mutation-validated)

Adversarial mutation-testing pass over the `src/lib` libraries. Each behavior
was validated by deliberately breaking the exact line it claims to cover and
confirming a test fails; surviving mutants (real coverage gaps) were then
killed by adding a discriminating test or strengthening an existing one.

**Test-only and additive** — no source changes, so it is independent and
CI-safe.

### What changed

- **LibOrder** — the hash suite only proved `owner` and `nonce` were in the
  `keccak256(abi.encode(order))` preimage. Dropping `evaluable`, `validInputs`
  or `validOutputs` left the suite green (the `testHashNotEqual` fuzz compares
  two fully-arbitrary orders and never isolates a single field). Added three
  field-binding tests; each validated by dropping exactly its field.

- **LibGenericPoolExchange** — the exchange call forwards the contract's entire
  ETH balance via `functionCallWithValue(call, address(this).balance)`, but no
  test funded the harness, so mutating that amount to `0` survived. Added
  `testForwardsEntireEthBalanceToPool`. The approve-spender, approve-amount,
  drop-revoke and both zero-address guards were mutation-validated against the
  existing tests.

- **LibRaindexArb** — `finalizeArb` writes input/output/gas context Floats, but
  output (`col[1]`) and gas (`col[2]`) were only ever asserted at zero, so
  zeroing either column survived. Added
  `testFinalizeArbContextNonZeroOutputAndGas` (0 input profit, 20 output, 1
  ether gas). Input column and all three token/gas sweeps were
  mutation-validated against the existing tests.

- **LibRaindex.doPost** — `testDoPostStoreSetWhenWrites` only `expectCall`'d the
  `store.set` *selector*, so forwarding different writes or a different
  namespace survived. Strengthened the assertion to pin the full calldata
  (`abi.encodeCall(set, (namespace, writes))`). Loop-bound, empty-bytecode-skip
  and writes-guard behaviors were mutation-validated against the existing tests.

### Coverage ledger (unit.behavior → mutation → killer)

```
LibOrder.hash-binds-{evaluable,inputs,outputs}: drop field -> added field-binding tests
LibGenericPoolExchange.forward-eth:  address(this).balance -> 0 -> added testForwardsEntireEthBalanceToPool
LibRaindexArb.col1-output-float / col2-gas-float: col -> 0 -> added testFinalizeArbContextNonZeroOutputAndGas
LibRaindex.doPost-set-{writes,namespace}: set(ns, empty)/ns->0 -> strengthened testDoPostStoreSetWhenWrites
```
All other behaviors in these units were confirmed already-covered by existing
tests (each existing test was credited only after actually killing its mutant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
