### PR TITLE
test(core): mutation-validated coverage

### DIFF
--- a/test/abstract/RaindexV6FlashLender.mockSuccess.t.sol
+++ b/test/abstract/RaindexV6FlashLender.mockSuccess.t.sol
@@ -31,4 +31,34 @@ contract RaindexV6FlashLenderMockSuccessTest is RaindexV6ExternalMockTest {
         );
         assertTrue(iRaindex.flashLoan(IERC3156FlashBorrower(receiver), address(iToken0), amount, data));
     }
+
+    /// The `onFlashLoan` callback MUST receive exactly the loan initiator
+    /// (`msg.sender`), the loaned token, the loaned amount, the flash fee (which
+    /// is always 0 for Raindex), and the verbatim data. Pinning every argument
+    /// catches mutations that swap the initiator, the token, the amount, or the
+    /// fee passed to the borrower.
+    function testFlashLoanCallbackArgs(address initiator, uint256 amount, bytes memory data) public {
+        vm.assume(initiator != address(0));
+
+        vm.mockCall(address(iToken0), abi.encodeWithSelector(IERC20.transfer.selector), abi.encode(true));
+        vm.mockCall(address(iToken0), abi.encodeWithSelector(IERC20.transferFrom.selector), abi.encode(true));
+
+        address receiver = address(0xDEADBEEF);
+        vm.etch(receiver, hex"FE");
+        vm.mockCall(
+            receiver,
+            abi.encodeWithSelector(IERC3156FlashBorrower.onFlashLoan.selector),
+            abi.encode(ON_FLASH_LOAN_CALLBACK_SUCCESS)
+        );
+
+        // The fee MUST be 0 and the initiator MUST be the caller of `flashLoan`.
+        vm.expectCall(
+            receiver,
+            abi.encodeWithSelector(
+                IERC3156FlashBorrower.onFlashLoan.selector, initiator, address(iToken0), amount, uint256(0), data
+            )
+        );
+        vm.prank(initiator);
+        assertTrue(iRaindex.flashLoan(IERC3156FlashBorrower(receiver), address(iToken0), amount, data));
+    }
 }

--- a/test/concrete/raindex/RaindexV6.clear.deadOrder.t.sol
+++ b/test/concrete/raindex/RaindexV6.clear.deadOrder.t.sol
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Vm} from "forge-std-1.16.1/src/Test.sol";
+import {RaindexV6ExternalRealTest} from "test/util/abstract/RaindexV6ExternalRealTest.sol";
+import {LibTestAddOrder} from "test/util/lib/LibTestAddOrder.sol";
+import {LibTestTakeOrder} from "test/util/lib/LibTestTakeOrder.sol";
+import {LibOrder} from "../../../src/lib/LibOrder.sol";
+import {OrderConfigV4, OrderV4, ClearConfigV2, TaskV2} from "raindex-interface-0.1.1/src/interface/IRaindexV6.sol";
+import {SignedContextV1} from "rain-interpreter-interface-0.1.0/src/interface/deprecated/v1/IInterpreterCallerV2.sol";
+
+/// @title RaindexV6ClearDeadOrderTest
+/// If either order passed to `clear3` is dead (never added, or removed) the
+/// clear is a no-op: it emits `OrderNotFound` for the dead order, returns
+/// without reverting (so a bulk Multicall clear is not aborted), and makes no
+/// vault state change. This is distinct from the take-orders dead path and was
+/// previously untested for `clear3`.
+contract RaindexV6ClearDeadOrderTest is RaindexV6ExternalRealTest {
+    using LibOrder for OrderV4;
+
+    /// Build two token-compatible orders for alice and bob, returning their
+    /// configs. Tokens are wired so the clear passes the TokenMismatch and
+    /// TokenSelfTrade guards and reaches the dead-order checks.
+    function buildConfigs(OrderConfigV4 memory configAlice, OrderConfigV4 memory configBob) internal view {
+        LibTestAddOrder.conformConfig(configAlice, iInterpreter, iStore);
+        LibTestAddOrder.conformConfig(configBob, iInterpreter, iStore);
+        configAlice.validOutputs[0].token = address(iToken0);
+        configAlice.validInputs[0].token = address(iToken1);
+        configBob.validOutputs[0].token = address(iToken1);
+        configBob.validInputs[0].token = address(iToken0);
+    }
+
+    function addOrder(address owner, OrderConfigV4 memory config) internal returns (OrderV4 memory) {
+        vm.prank(owner);
+        vm.recordLogs();
+        iRaindex.addOrder4(config, new TaskV2[](0));
+        return LibTestTakeOrder.extractOrderFromLogs(vm.getRecordedLogs());
+    }
+
+    /// Alice's order is dead (never added). Bob's order is irrelevant because
+    /// the alice check comes first: clear3 emits OrderNotFound for alice's hash
+    /// and returns, with no other logs and no revert.
+    /// forge-config: default.fuzz.runs = 10
+    function testClearAliceDead(
+        address alice,
+        address bob,
+        OrderConfigV4 memory configAlice,
+        OrderConfigV4 memory configBob
+    ) external {
+        vm.assume(alice != bob);
+        assumeEtchable(alice);
+        assumeEtchable(bob);
+        buildConfigs(configAlice, configBob);
+
+        OrderV4 memory orderAlice =
+            OrderV4(alice, configAlice.evaluable, configAlice.validInputs, configAlice.validOutputs, configAlice.nonce);
+        OrderV4 memory orderBob =
+            OrderV4(bob, configBob.evaluable, configBob.validInputs, configBob.validOutputs, configBob.nonce);
+
+        assertFalse(iRaindex.orderExists(orderAlice.hash()));
+
+        vm.expectEmit(address(iRaindex));
+        emit OrderNotFound(address(this), alice, orderAlice.hash());
+        vm.recordLogs();
+        iRaindex.clear3(
+            orderAlice, orderBob, ClearConfigV2(0, 0, 0, 0, 0, 0), new SignedContextV1[](0), new SignedContextV1[](0)
+        );
+
+        // Exactly one log: the OrderNotFound for alice. No ClearV3, no
+        // AfterClearV2, no revert.
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        assertEq(logs.length, 1, "only OrderNotFound emitted");
+        assertEq(logs[0].topics[0], bytes32(uint256(keccak256("OrderNotFound(address,address,bytes32)"))));
+        (address sender, address owner, bytes32 orderHash) = abi.decode(logs[0].data, (address, address, bytes32));
+        assertEq(sender, address(this), "sender");
+        assertEq(owner, alice, "owner");
+        assertEq(orderHash, orderAlice.hash(), "hash");
+    }
+
+    /// Alice's order is live, Bob's order is dead (never added). clear3 passes
+    /// the alice liveness check and then emits OrderNotFound for bob's hash and
+    /// returns. This pins that the SECOND (bob) dead-order check exists and uses
+    /// bob's owner/hash, not alice's.
+    /// forge-config: default.fuzz.runs = 10
+    function testClearBobDead(
+        address alice,
+        address bob,
+        OrderConfigV4 memory configAlice,
+        OrderConfigV4 memory configBob
+    ) external {
+        vm.assume(alice != bob);
+        assumeEtchable(alice);
+        assumeEtchable(bob);
+        buildConfigs(configAlice, configBob);
+
+        // Alice is added (live); bob is not.
+        OrderV4 memory orderAlice = addOrder(alice, configAlice);
+        OrderV4 memory orderBob =
+            OrderV4(bob, configBob.evaluable, configBob.validInputs, configBob.validOutputs, configBob.nonce);
+        // The two orders must not collide as the same hash.
+        vm.assume(orderAlice.hash() != orderBob.hash());
+
+        assertTrue(iRaindex.orderExists(orderAlice.hash()));
+        assertFalse(iRaindex.orderExists(orderBob.hash()));
+
+        vm.expectEmit(address(iRaindex));
+        emit OrderNotFound(address(this), bob, orderBob.hash());
+        vm.recordLogs();
+        iRaindex.clear3(
+            orderAlice, orderBob, ClearConfigV2(0, 0, 0, 0, 0, 0), new SignedContextV1[](0), new SignedContextV1[](0)
+        );
+
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        assertEq(logs.length, 1, "only OrderNotFound emitted");
+        assertEq(logs[0].topics[0], bytes32(uint256(keccak256("OrderNotFound(address,address,bytes32)"))));
+        (address sender, address owner, bytes32 orderHash) = abi.decode(logs[0].data, (address, address, bytes32));
+        assertEq(sender, address(this), "sender");
+        assertEq(owner, bob, "owner");
+        assertEq(orderHash, orderBob.hash(), "hash");
+    }
+}

--- a/test/concrete/raindex/RaindexV6.vaultBalanceVault0.t.sol
+++ b/test/concrete/raindex/RaindexV6.vaultBalanceVault0.t.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {RaindexV6ExternalMockTest} from "test/util/abstract/RaindexV6ExternalMockTest.sol";
+import {IERC20} from "@openzeppelin-contracts-5.6.1/token/ERC20/IERC20.sol";
+import {LibDecimalFloat, Float} from "rain-math-float-0.1.1/src/lib/LibDecimalFloat.sol";
+
+/// @title RaindexV6VaultBalanceVault0Test
+/// @notice Vault ID 0 has no internal balance; its effective balance is the
+/// MINIMUM of the owner's wallet token balance and their approval to Raindex
+/// (the most Raindex could ever pull). Existing maximum-input/output tests that
+/// exercise vault 0 mock `balanceOf` and `allowance` to the SAME value, so a
+/// bug that returned only the balance, only the approval, or the max of the two
+/// would survive them. These pin the `min(balance, approval)` selection by
+/// making the two differ.
+contract RaindexV6VaultBalanceVault0Test is RaindexV6ExternalMockTest {
+    using LibDecimalFloat for Float;
+
+    /// When the approval is smaller than the wallet balance, the effective
+    /// vault-0 balance is the approval (Raindex can't pull more than approved).
+    function testVaultBalanceVault0ApprovalLimits(address owner, uint256 balance18, uint256 approval18) external {
+        // iToken0 decimals are mocked to 18 by the base.
+        balance18 = bound(balance18, 1, uint256(int256(type(int224).max)));
+        approval18 = bound(approval18, 0, balance18 - 1);
+
+        vm.mockCall(address(iToken0), abi.encodeWithSelector(IERC20.balanceOf.selector, owner), abi.encode(balance18));
+        vm.mockCall(
+            address(iToken0),
+            abi.encodeWithSelector(IERC20.allowance.selector, owner, address(iRaindex)),
+            abi.encode(approval18)
+        );
+
+        Float effective = iRaindex.vaultBalance2(owner, address(iToken0), bytes32(0));
+        // The smaller of the two (approval) is returned, not the balance.
+        assertTrue(effective.eq(LibDecimalFloat.fromFixedDecimalLosslessPacked(approval18, 18)), "approval limits");
+    }
+
+    /// When the wallet balance is smaller than the approval, the effective
+    /// vault-0 balance is the balance (Raindex can't pull tokens the owner
+    /// doesn't hold).
+    function testVaultBalanceVault0BalanceLimits(address owner, uint256 balance18, uint256 approval18) external {
+        approval18 = bound(approval18, 1, uint256(int256(type(int224).max)));
+        balance18 = bound(balance18, 0, approval18 - 1);
+
+        vm.mockCall(address(iToken0), abi.encodeWithSelector(IERC20.balanceOf.selector, owner), abi.encode(balance18));
+        vm.mockCall(
+            address(iToken0),
+            abi.encodeWithSelector(IERC20.allowance.selector, owner, address(iRaindex)),
+            abi.encode(approval18)
+        );
+
+        Float effective = iRaindex.vaultBalance2(owner, address(iToken0), bytes32(0));
+        // The smaller of the two (balance) is returned, not the approval.
+        assertTrue(effective.eq(LibDecimalFloat.fromFixedDecimalLosslessPacked(balance18, 18)), "balance limits");
+    }
+}


### PR DESCRIPTION
## test(core): mutation-validated coverage

Adversarial mutation testing of the **core** group — `src/concrete/raindex/RaindexV6.sol` and its priority abstract base `src/abstract/RaindexV6FlashLender.sol`. For each behavior the exact source line was broken and the whole suite re-run: existing tests that killed the mutant are credited; only **surviving** mutants (real gaps) got a new discriminating test. This is the same style as the libs group PR #2632.

**Test-only and additive.** No `src/` or `src/generated/*.pointers.sol` changes. Both units are **etched** in their external tests (they execute `RaindexV6.pointers.sol` RUNTIME_CODE, not freshly-compiled source), so every probe regenerated pointers via `script/BuildPointers.sol` to make the mutation live before re-running — confirmed by a changed pointer file each time.

### Gaps found and filled

1. **`RaindexV6FlashLender.flashLoan` callback arguments** — `test/abstract/RaindexV6FlashLender.mockSuccess.t.sol`
   - The grief/mockSuccess tests mock `onFlashLoan` with a selector-only `vm.mockCall`, so mutations swapping the `initiator` (msg.sender), the `fee`, the token, or the amount forwarded to the borrower **survived**.
   - Added `testFlashLoanCallbackArgs` (`vm.expectCall` pinning the exact callback calldata: `initiator == msg.sender`, token, amount, `fee == 0`, verbatim data). Passes on baseline; fails when the initiator arg is mutated to `address(this)`.

2. **`RaindexV6.clear3` dead-order no-op** — `test/concrete/raindex/RaindexV6.clear.deadOrder.t.sol` (new)
   - Every existing clear test adds both orders live first, so dropping either dead-order `return;` (letting a dead order fall through to evaluation) **survived**. Clearing must no-op, not revert, when an order is dead so bulk Multicall clears aren't aborted.
   - Added `testClearAliceDead` and `testClearBobDead`: assert exactly one `OrderNotFound` is emitted with the dead order's owner/hash and no revert/state change. Both pass on baseline; both fail when the dead-order `return;` statements are dropped.

3. **`RaindexV6._vaultBalance` vault-0 = `min(balance, approval)`** — `test/concrete/raindex/RaindexV6.vaultBalanceVault0.t.sol` (new)
   - Existing vault-0 tests mock `balanceOf` and `allowance` to the **same** value, so returning only the balance, only the approval, or the max of the two **survived**.
   - Added `testVaultBalanceVault0ApprovalLimits` (approval < balance → returns approval) and `testVaultBalanceVault0BalanceLimits` (balance < approval → returns balance). Both pass on baseline; ApprovalLimits fails when the source returns only the balance, BalanceLimits fails when it returns only the approval — each side of the `min` independently pinned.

### Coverage ledger (mutation → killer)

| unit.behavior | mutation | result |
| --- | --- | --- |
| FlashLender.supportsInterface | `==`→`!=`/`&&` | existing `testRaindexV6FlashLenderIERC165` ✓ |
| FlashLender.flashLoan callback args | initiator → `address(this)` | **GAP** → new `testFlashLoanCallbackArgs` ✓ |
| FlashLender.flashFee `==0` guard | `==`→`!=` | existing fee tests (3) ✓ |
| FlashLender.maxFlashLoan | `return balanceOf`→`return 0` | existing `testFlashMaxLoan` ✓ |
| RaindexV6.clear3 alice dead return | drop `return;` | **GAP** → new `testClearAliceDead` ✓ |
| RaindexV6.clear3 bob dead return | drop `return;` | **GAP** → new `testClearBobDead` ✓ |
| RaindexV6._vaultBalance vault0 min (approval side) | return only balance | **GAP** → new `testVaultBalanceVault0ApprovalLimits` ✓ |
| RaindexV6._vaultBalance vault0 min (balance side) | return only approval | **GAP** → new `testVaultBalanceVault0BalanceLimits` ✓ |

Existing tests additionally surveyed and confirmed adequate (left unchanged): `takeOrders4` IOIsInput input/output branches (maximumInput/maximumOutput suites + minimumIOOutput audit tests), `OrderExceedsMaxRatio`, `OrderZeroAmount`, `OrderNotFound` take-orders path, `MinimumIO`, `NegativeBounty`, `ClearZeroAmount`, `SameOwner`/`TokenMismatch`/`TokenSelfTrade` guards, `quote2` dead-order, `addOrder` no-inputs/no-outputs, `withdraw4` `min(target, balance)` cap, and the vault-balance negative guards (`NegativeVaultBalance`, `NegativeVaultBalanceChange`, `NegativePull`, `NegativePush`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
