### PR TITLE
refactor: extract latestOwnerKvs into LibTakeOrdersOverlay + direct tests

### DIFF
--- a/src/concrete/raindex/RaindexV6.sol
+++ b/src/concrete/raindex/RaindexV6.sol
@@ -48,6 +48,7 @@ import {
 } from "raindex-interface-0.1.1/src/interface/IRaindexV6.sol";
 import {IRaindexV6OrderTaker} from "raindex-interface-0.1.1/src/interface/IRaindexV6OrderTaker.sol";
 import {LibOrder} from "../../lib/LibOrder.sol";
+import {LibTakeOrdersOverlay} from "../../lib/LibTakeOrdersOverlay.sol";
 import {
     CALLING_CONTEXT_COLUMNS,
     CONTEXT_CALLING_CONTEXT_COLUMN,
@@ -176,7 +177,7 @@ struct OrderIOCalculationV4 {
 /// and the taker IO still remaining to fill as the batch is processed.
 /// @param inputToken The input token every order in the batch must use.
 /// @param outputToken The output token every order in the batch must use.
-/// @param remainingTakerIO The taker IO left to fill across the io.
+/// @param remainingTakerIO The taker IO left to fill across the batch.
 struct TakeOrdersIO {
     address inputToken;
     address outputToken;
@@ -465,7 +466,7 @@ contract RaindexV6 is IRaindexV6, IMetaV1_2, ReentrancyGuard, Multicall, Raindex
             // Each evaluated order's calculation, indexed by its batch position.
             // A later same-owner order seeds its calculate eval with the most
             // recent earlier same-owner order's kvs (see `latestOwnerKvs`) so it
-            // observes earlier same-owner writes within the io.
+            // observes earlier same-owner writes within the batch.
             OrderIOCalculationV4[] memory evaluatedCalculations = new OrderIOCalculationV4[](config.orders.length);
 
             if (!io.remainingTakerIO.gt(Float.wrap(0))) {
@@ -497,7 +498,7 @@ contract RaindexV6 is IRaindexV6, IMetaV1_2, ReentrancyGuard, Multicall, Raindex
                         takeOrderConfig.outputIOIndex,
                         msg.sender,
                         takeOrderConfig.signedContext,
-                        latestOwnerKvs(evaluatedCalculations, order.owner)
+                        LibTakeOrdersOverlay.latestOwnerKvs(evaluatedCalculations, order.owner)
                     );
                     evaluatedCalculations[i] = orderIOCalculation;
 
@@ -700,33 +701,6 @@ contract RaindexV6 is IRaindexV6, IMetaV1_2, ReentrancyGuard, Multicall, Raindex
         if (clearStateChange.aliceOutput.isZero() && clearStateChange.bobOutput.isZero()) {
             revert ClearZeroAmount();
         }
-    }
-
-    /// @dev The most recently evaluated same-owner order's calculate kvs, or an
-    /// empty overlay if the owner has no earlier order in the io. Each eval
-    /// returns the full state KV (the seeded `stateOverlay` merged with new
-    /// writes), so the latest same-owner kvs already carries every earlier
-    /// same-owner write in the batch and is seeded directly with no
-    /// concatenation. Not-yet-evaluated and skipped (dead) entries are
-    /// zero-owner so they are ignored by the scan.
-    /// @param evaluatedCalculations Each evaluated order's calculation, indexed
-    /// by batch position.
-    /// @param owner The owner namespace to seed writes for.
-    function latestOwnerKvs(OrderIOCalculationV4[] memory evaluatedCalculations, address owner)
-        internal
-        pure
-        returns (bytes32[] memory)
-    {
-        for (uint256 j = evaluatedCalculations.length; j > 0;) {
-            unchecked {
-                j--;
-            }
-            OrderIOCalculationV4 memory calculation = evaluatedCalculations[j];
-            if (calculation.order.owner == owner) {
-                return calculation.kvs;
-            }
-        }
-        return new bytes32[](0);
     }
 
     /// Main entrypoint into an order calculates the amount and IO ratio. Both

--- a/src/lib/LibTakeOrdersOverlay.sol
+++ b/src/lib/LibTakeOrdersOverlay.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity ^0.8.25;
+
+import {OrderV4} from "raindex-interface-0.1.1/src/interface/IRaindexV6.sol";
+import {OrderIOCalculationV4} from "../concrete/raindex/RaindexV6.sol";
+
+/// @title LibTakeOrdersOverlay
+/// @notice Threads calculate-phase state across same-owner orders within a
+/// single `takeOrders` batch by reusing the most recent same-owner order's
+/// returned kvs as the next order's `stateOverlay`.
+library LibTakeOrdersOverlay {
+    /// @dev The most recently evaluated same-owner order's calculate kvs, or an
+    /// empty overlay if the owner has no earlier order in the batch. Each eval
+    /// returns the full state KV (the seeded `stateOverlay` merged with new
+    /// writes), so the latest same-owner kvs already carries every earlier
+    /// same-owner write in the batch and is seeded directly with no
+    /// concatenation. Not-yet-evaluated and skipped (dead) entries are
+    /// zero-owner so they are ignored by the scan.
+    /// @param evaluatedCalculations Each evaluated order's calculation, indexed
+    /// by batch position.
+    /// @param owner The owner namespace to seed writes for.
+    /// @return The latest same-owner calculate kvs, or an empty array.
+    function latestOwnerKvs(OrderIOCalculationV4[] memory evaluatedCalculations, address owner)
+        internal
+        pure
+        returns (bytes32[] memory)
+    {
+        for (uint256 j = evaluatedCalculations.length; j > 0;) {
+            unchecked {
+                j--;
+            }
+            OrderIOCalculationV4 memory calculation = evaluatedCalculations[j];
+            if (calculation.order.owner == owner) {
+                return calculation.kvs;
+            }
+        }
+        return new bytes32[](0);
+    }
+}

--- a/test/lib/LibTakeOrdersOverlay.t.sol
+++ b/test/lib/LibTakeOrdersOverlay.t.sol
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {LibTakeOrdersOverlay} from "src/lib/LibTakeOrdersOverlay.sol";
+import {OrderIOCalculationV4} from "src/concrete/raindex/RaindexV6.sol";
+
+/// @title LibTakeOrdersOverlayTest
+/// @notice Direct coverage for `latestOwnerKvs`: the backward scan that picks
+/// the most recent same-owner calculate kvs to seed the next order's overlay.
+contract LibTakeOrdersOverlayTest is Test {
+    /// Build a calculation with only the owner + kvs set (all other fields
+    /// default), mirroring how `takeOrders4` records evaluated orders.
+    function _calc(address owner, bytes32[] memory kvs) internal pure returns (OrderIOCalculationV4 memory calc) {
+        calc.order.owner = owner;
+        calc.kvs = kvs;
+    }
+
+    function _kvs(bytes32 v) internal pure returns (bytes32[] memory kvs) {
+        kvs = new bytes32[](1);
+        kvs[0] = v;
+    }
+
+    /// An empty accumulator yields an empty overlay.
+    function testEmptyArray() external {
+        OrderIOCalculationV4[] memory calcs = new OrderIOCalculationV4[](0);
+        assertEq(LibTakeOrdersOverlay.latestOwnerKvs(calcs, address(0x1234)).length, 0);
+    }
+
+    /// No entry matches the owner -> empty overlay.
+    function testNoMatch() external {
+        OrderIOCalculationV4[] memory calcs = new OrderIOCalculationV4[](3);
+        calcs[0] = _calc(address(1), _kvs(bytes32(uint256(10))));
+        calcs[1] = _calc(address(2), _kvs(bytes32(uint256(20))));
+        calcs[2] = _calc(address(3), _kvs(bytes32(uint256(30))));
+        assertEq(LibTakeOrdersOverlay.latestOwnerKvs(calcs, address(99)).length, 0);
+    }
+
+    /// A single matching entry returns exactly that entry's kvs, by reference
+    /// (not a copy) so no concatenation/allocation happens on the hot path.
+    function testSingleMatchReturnsReference() external {
+        OrderIOCalculationV4[] memory calcs = new OrderIOCalculationV4[](1);
+        calcs[0] = _calc(address(7), _kvs(bytes32(uint256(42))));
+
+        bytes32[] memory got = LibTakeOrdersOverlay.latestOwnerKvs(calcs, address(7));
+        assertEq(got.length, 1);
+        assertEq(got[0], bytes32(uint256(42)));
+
+        // Returned by reference, not copied: mutating the result is visible in
+        // the recorded entry (they alias the same memory).
+        got[0] = bytes32(uint256(999));
+        assertEq(calcs[0].kvs[0], bytes32(uint256(999)), "result must alias the recorded kvs (no copy)");
+    }
+
+    /// Multiple same-owner entries -> the most recent (highest index) wins,
+    /// because each eval's returned kvs already merges all earlier same-owner
+    /// writes.
+    function testLatestOfMultipleSameOwner() external {
+        OrderIOCalculationV4[] memory calcs = new OrderIOCalculationV4[](3);
+        calcs[0] = _calc(address(7), _kvs(bytes32(uint256(1))));
+        calcs[1] = _calc(address(7), _kvs(bytes32(uint256(2))));
+        calcs[2] = _calc(address(7), _kvs(bytes32(uint256(3))));
+        assertEq(LibTakeOrdersOverlay.latestOwnerKvs(calcs, address(7))[0], bytes32(uint256(3)));
+    }
+
+    /// Interleaved owners -> the latest matching owner, never another owner's.
+    function testInterleavedOwners() external {
+        OrderIOCalculationV4[] memory calcs = new OrderIOCalculationV4[](5);
+        calcs[0] = _calc(address(0xA), _kvs(bytes32(uint256(0xA1))));
+        calcs[1] = _calc(address(0xB), _kvs(bytes32(uint256(0xB1))));
+        calcs[2] = _calc(address(0xA), _kvs(bytes32(uint256(0xA2))));
+        calcs[3] = _calc(address(0xB), _kvs(bytes32(uint256(0xB2))));
+        calcs[4] = _calc(address(0xC), _kvs(bytes32(uint256(0xC1))));
+        assertEq(LibTakeOrdersOverlay.latestOwnerKvs(calcs, address(0xA))[0], bytes32(uint256(0xA2)));
+        assertEq(LibTakeOrdersOverlay.latestOwnerKvs(calcs, address(0xB))[0], bytes32(uint256(0xB2)));
+        assertEq(LibTakeOrdersOverlay.latestOwnerKvs(calcs, address(0xC))[0], bytes32(uint256(0xC1)));
+    }
+
+    /// Zero-owner entries (dead orders that were never recorded, and the
+    /// not-yet-evaluated tail) are skipped. Relies on `new OrderIOCalculationV4[]`
+    /// zero-initializing each element's `.order.owner` to address(0).
+    function testZeroOwnerGapsAndTailSkipped() external {
+        OrderIOCalculationV4[] memory calcs = new OrderIOCalculationV4[](5);
+        calcs[0] = _calc(address(7), _kvs(bytes32(uint256(70))));
+        // calcs[1] left zero (dead-order gap).
+        calcs[2] = _calc(address(8), _kvs(bytes32(uint256(80))));
+        // calcs[3], calcs[4] left zero (not-yet-evaluated tail).
+        assertEq(LibTakeOrdersOverlay.latestOwnerKvs(calcs, address(7))[0], bytes32(uint256(70)));
+        assertEq(LibTakeOrdersOverlay.latestOwnerKvs(calcs, address(8))[0], bytes32(uint256(80)));
+    }
+
+    /// address(0) is not special-cased: querying it matches the latest
+    /// zero-owner entry, whose kvs is empty. Order owners are never address(0)
+    /// in practice, so this never collides with a real owner.
+    function testZeroOwnerQueryReturnsEmptyGapKvs() external {
+        OrderIOCalculationV4[] memory calcs = new OrderIOCalculationV4[](3);
+        calcs[0] = _calc(address(7), _kvs(bytes32(uint256(70))));
+        // calcs[1], calcs[2] are zero-owner gaps with empty kvs.
+        assertEq(LibTakeOrdersOverlay.latestOwnerKvs(calcs, address(0)).length, 0);
+    }
+
+    /// Fuzz: the result always equals a reference backward scan over the owner
+    /// layout (kvs are deterministic per index so the match is checkable).
+    function testFuzzMatchesReference(address[] memory owners, address target) external {
+        vm.assume(owners.length <= 64);
+        OrderIOCalculationV4[] memory calcs = new OrderIOCalculationV4[](owners.length);
+        for (uint256 i = 0; i < owners.length; i++) {
+            calcs[i] = _calc(owners[i], _kvs(bytes32(i + 1)));
+        }
+
+        bytes32[] memory got = LibTakeOrdersOverlay.latestOwnerKvs(calcs, target);
+
+        bool found;
+        uint256 idx;
+        for (uint256 i = owners.length; i > 0;) {
+            unchecked {
+                i--;
+            }
+            if (owners[i] == target) {
+                found = true;
+                idx = i;
+                break;
+            }
+        }
+
+        if (found) {
+            assertEq(got.length, 1);
+            assertEq(got[0], bytes32(idx + 1));
+        } else {
+            assertEq(got.length, 0);
+        }
+    }
+}


### PR DESCRIPTION
Closes #2634.

Extracts the same-owner `stateOverlay` scan (`latestOwnerKvs`) out of `RaindexV6` into a dedicated library so it can be unit + fuzz tested directly, rather than only through the heavy `takeOrders4` path.

### Change
- New `src/lib/LibTakeOrdersOverlay.sol` with `latestOwnerKvs(OrderIOCalculationV4[] memory, address) → bytes32[]` (the backward scan that returns the most recent same-owner order's calculate kvs, or an empty overlay).
- `RaindexV6` calls `LibTakeOrdersOverlay.latestOwnerKvs(...)`; the local copy is removed.
- The function is `internal`, so it inlines identically — **RaindexV6 bytecode and the deterministic deploy address (`0xb05D73E6…`) are unchanged, no redeploy and no artifact drift** (pointers/test_fixtures regenerated to a no-op).
- Drive-by: fixes three comment typos where an earlier struct rename's `sed` turned the prose word `batch.` into `io.`.

### Tests — `test/lib/LibTakeOrdersOverlay.t.sol`
Direct unit + fuzz coverage of the scan's edge cases:
- empty accumulator → empty overlay
- no matching owner → empty overlay
- single match → that entry's kvs, asserted **by reference** (mutating the result aliases the recorded kvs — no copy)
- multiple same-owner → the most recent (highest index) wins
- interleaved owners → the latest matching owner, never another's
- zero-owner gap entries (dead orders) **and** the not-yet-evaluated tail are skipped (asserts the `new OrderIOCalculationV4[]` zero-init contract)
- `address(0)` is not special-cased (documents it matches the latest zero-owner gap, whose kvs is empty)
- fuzz: result always equals a reference backward scan over a random owner layout

All 8 pass; the 10 H01 threading tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)