### PR TITLE
test(deploy): exhaustive mutation-validated coverage

### DIFF
--- a/test/lib/deploy/LibRouteProcessor4CreationCode.t.sol
+++ b/test/lib/deploy/LibRouteProcessor4CreationCode.t.sol
@@ -10,10 +10,27 @@ import {ROUTE_PROCESSOR_4_CREATION_CODE} from "../../../src/lib/deploy/LibRouteP
 bytes32 constant KNOWN_ROUTE_PROCESSOR_4_CODEHASH =
     bytes32(0xeb3745a79c6ba48e8767b9c355b8e7b79f9d6edeca004e4bb91be4de515a7eeb);
 
+/// @dev Known keccak256 of the exact RouteProcessor4 creation code bytes taken
+/// from the Sushi deployment. This pins the full creation-code identity, not
+/// just the runtime result, so that a change to any creation-code byte — even
+/// one in init-only code that is never executed on deployment (e.g. the
+/// privileged-user loop body, dead when the constructor's user array is empty)
+/// and therefore leaves the deployed runtime bytecode unchanged — is caught.
+bytes32 constant KNOWN_ROUTE_PROCESSOR_4_CREATION_CODEHASH =
+    bytes32(0x79d8a59bafcb6b1d413ed7ed81896ecbd18ceacf3da75541e8dff26990afcbb1);
+
 /// @title LibRouteProcessor4CreationCodeTest
 /// @notice Deploys RouteProcessor4 from the stored creation code and verifies
 /// that the resulting runtime bytecode hash matches the known Sushi deployment.
 contract LibRouteProcessor4CreationCodeTest is Test {
+    /// The stored creation code bytes MUST hash to the known creation-code hash
+    /// of the Sushi RouteProcessor4 deployment. This anchors the full creation
+    /// code, catching any byte change — including init-only code that does not
+    /// alter the deployed runtime and so slips past the runtime codehash check.
+    function testRouteProcessor4CreationCodehash() external pure {
+        assertEq(keccak256(ROUTE_PROCESSOR_4_CREATION_CODE), KNOWN_ROUTE_PROCESSOR_4_CREATION_CODEHASH);
+    }
+
     /// Deploying the stored creation code MUST produce runtime bytecode whose
     /// hash matches the known Sushi RouteProcessor4 codehash.
     function testRouteProcessor4Codehash() external {


### PR DESCRIPTION
## test(deploy): exhaustive mutation-validated coverage

Test-only / additive hardening of the **deploy** group:
`src/lib/deploy/LibRaindexDeploy.sol` and
`src/lib/deploy/LibRouteProcessor4CreationCode.sol`. No `src/` changes. Every
behavior in these two units was driven with a targeted source mutation, the
whole touched suite re-run, and the killing test recorded; surviving mutants
(real gaps) were filled with new discriminating tests that pass on baseline and
fail under their mutation.

### Per-unit gaps filled

- **LibRouteProcessor4CreationCode — creation-code identity gap (FILLED).**
  A mutation to an init-only / never-executed byte of
  `ROUTE_PROCESSOR_4_CREATION_CODE` (the privileged-user loop body, dead when
  the constructor's user array is empty) leaves the deployed *runtime* bytecode
  byte-identical, so the pre-existing `testRouteProcessor4Codehash` (which only
  hashes the deployed runtime) SURVIVED it. Added
  `testRouteProcessor4CreationCodehash`, which pins
  `keccak256(ROUTE_PROCESSOR_4_CREATION_CODE)` to the exact known Sushi
  creation-code hash
  `0x79d8a59bafcb6b1d413ed7ed81896ecbd18ceacf3da75541e8dff26990afcbb1`. This
  anchors the full creation-code identity (every init byte), catching changes
  that slip past the runtime codehash check. Validated: passes on baseline;
  fails under the dead-init-byte mutation (`6001`->`6002`) while
  `testRouteProcessor4Codehash` still passes (confirming the gap was real).

- **LibRaindexDeploy — no gaps.** All 16 constants (6 deployed addresses, 6
  runtime codehashes, 4 per-network start blocks) were already mutation-killed
  by existing tests; each was probed and credited (see ledger). 0 new tests
  required.

### Coverage ledger (mutation -> killer)

Constants (each address `+1` / each codehash `^1`, each start block `+1`):

| Constant | Killing test(s) |
| --- | --- |
| `RAINDEX_DEPLOYED_ADDRESS` | testDeployAddressRaindex, testGeneratedDeployedAddressRaindex, testNetworksJsonAddresses |
| `RAINDEX_DEPLOYED_CODEHASH` | testExpectedCodeHashRaindex, testDeployAddressRaindex, testEtchRaindex, testEtchRaindexIdempotent |
| `SUB_PARSER_DEPLOYED_ADDRESS` | testDeployAddressSubParser, testGeneratedDeployedAddressSubParser |
| `SUB_PARSER_DEPLOYED_CODEHASH` | testExpectedCodeHashSubParser, testDeployAddressSubParser, testEtchRaindex |
| `ROUTE_PROCESSOR_DEPLOYED_ADDRESS` | testDeployAddressRouteProcessor, testGeneratedDeployedAddressRouteProcessor |
| `ROUTE_PROCESSOR_DEPLOYED_CODEHASH` | testDeployAddressRouteProcessor, testGeneratedCodehashRouteProcessor, testEtchRaindex |
| `GENERIC_POOL_ARB_OT_ADDRESS` | testDeployAddressGenericPoolArbOrderTaker, testGeneratedDeployedAddressGenericPoolArbOrderTaker |
| `GENERIC_POOL_ARB_OT_CODEHASH` | testExpectedCodeHashGenericPoolArbOrderTaker, testGeneratedCodehashGenericPoolArbOrderTaker, testDeployAddressGenericPoolArbOrderTaker |
| `RP_ARB_OT_ADDRESS` | testDeployAddressRouteProcessorArbOrderTaker, testGeneratedDeployedAddressRouteProcessorArbOrderTaker |
| `RP_ARB_OT_CODEHASH` | testExpectedCodeHashRouteProcessorArbOrderTaker, testGeneratedCodehashRouteProcessorArbOrderTaker, testDeployAddressRouteProcessorArbOrderTaker |
| `GENERIC_POOL_FB_ADDRESS` | testDeployAddressGenericPoolFlashBorrower, testGeneratedDeployedAddressGenericPoolFlashBorrower |
| `GENERIC_POOL_FB_CODEHASH` | testExpectedCodeHashGenericPoolFlashBorrower, testGeneratedCodehashGenericPoolFlashBorrower, testDeployAddressGenericPoolFlashBorrower |
| `RAINDEX_START_BLOCK_ARBITRUM` | testNetworksJsonStartBlockArbitrum |
| `RAINDEX_START_BLOCK_BASE` | testNetworksJsonStartBlockBase |
| `RAINDEX_START_BLOCK_FLARE` | testNetworksJsonStartBlockFlare |
| `RAINDEX_START_BLOCK_POLYGON` | testNetworksJsonStartBlockPolygon (key `matic`) |

`LibRouteProcessor4CreationCode.ROUTE_PROCESSOR_4_CREATION_CODE`:

| Mutation | Killing test(s) |
| --- | --- |
| runtime byte (`locked`->`lockee`) | testRouteProcessor4Codehash, testRuntimeCodeRouteProcessor, testDeployAddressRouteProcessor |
| last-byte truncation / ctor-arg tail | testRouteProcessor4Codehash (deploy reverts), testRouteProcessor4CreationCodehash |
| **dead init-only loop-body byte (`6001`->`6002`)** | **testRouteProcessor4CreationCodehash (NEW)** — sole isolated killer |

Cross-cutting behaviors also validated: `networks.json` iterates every network
key; the POLYGON start block maps via the `matic` key; all six deployed
addresses are mutually distinct; idempotent etch takes the codehash-match skip
branch.

### Notes on environment

`LibRaindexDeploy.t.sol` (31), `LibRouteProcessor4CreationCode.t.sol` (2), and
the `NetworksJson*` suites (5) are GREEN at clean baseline and are where
mutations were killed. The fork suites (`LibRaindexDeployProd`,
`StartBlock{Base,Flare,Polygon}`, `IsStartBlock{Base,Flare,Polygon}`) and the
`yq`-FFI `SubgraphYamlAddress` suite only fail in CI/sandbox for lack of RPC
endpoints / the `yq` binary — they are not baseline-broken and exercise the same
in-scope constants killed locally; they add stronger on-chain ground-truth
claims when RPC is wired.

Test-only / additive: no production source changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test to verify RouteProcessor4 creation code hash and ensure contract bytecode integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->