### PR TITLE
ci: curl soldeer upload workaround

### DIFF
--- a/.github/workflows/soldeer-debug.yaml
+++ b/.github/workflows/soldeer-debug.yaml
@@ -2,30 +2,41 @@ name: Debug Soldeer Push
 on:
   workflow_dispatch: {}
 jobs:
-  token:
+  curl-upload:
     runs-on: ubuntu-latest
     steps:
-      - name: Inspect SOLDEER_API_TOKEN validity (no secret leaked)
+      - uses: actions/checkout@v4
+      - uses: nixbuild/nix-quick-install-action@v30
+        with:
+          nix_conf: |
+            keep-env-derivations = true
+            keep-outputs = true
+      - name: Build package zip + upload via curl (soldeer 0.10.0 multipart push is broken)
         env:
           SOLDEER_API_TOKEN: ${{ secrets.SOLDEER_API_TOKEN }}
         run: |
-          echo "token length: ${#SOLDEER_API_TOKEN}  segments: $(printf '%s' "$SOLDEER_API_TOKEN" | awk -F. '{print NF}')"
+          set -euo pipefail
+          VERSION=$(awk -F\" '/^version[[:space:]]*=/ { print $2; exit }' foundry.toml)
+          echo "publishing raindex~$VERSION"
 
-          echo "=== decode JWT payload exp/iat (payload is signed, not secret) ==="
-          payload=$(printf '%s' "$SOLDEER_API_TOKEN" | cut -d. -f2 | tr '_-' '/+')
-          pad=$(( (4 - ${#payload} % 4) % 4 )); [ "$pad" -gt 0 ] && payload="$payload$(printf '=%.0s' $(seq 1 $pad))"
-          decoded=$(printf '%s' "$payload" | base64 -d 2>/dev/null || true)
-          echo "claims: $(printf '%s' "$decoded" | grep -oE '"(exp|iat|nbf|type|token_type)":("?[^",}]+"?)' | tr '\n' ' ')"
-          exp=$(printf '%s' "$decoded" | grep -oE '"exp":[0-9]+' | grep -oE '[0-9]+' | head -1)
-          now=$(date +%s)
-          if [ -n "$exp" ]; then
-            echo "now=$now exp=$exp delta=$((exp-now))s -> $([ "$exp" -lt "$now" ] && echo '*** EXPIRED ***' || echo valid)"
-          else
-            echo "no exp claim (long-lived token?)"
-          fi
+          echo "=== build the package zip with soldeer (zipping works; only the upload is broken) ==="
+          nix develop github:rainlanguage/rainix#sol-shell -c forge soldeer push "raindex~$VERSION" --dry-run
+          ls -la raindex.zip
 
-          echo "=== authenticated POST to upload endpoint, no body (401 => token rejected; other 4xx => token accepted) ==="
-          code=$(curl -sS -o /tmp/resp.txt -w "%{http_code}" -X POST \
+          echo "=== resolve project id ==="
+          PROJECT_ID=$(curl -fsS "https://api.soldeer.xyz/api/v1/project?project_name=raindex" | jq -r '.data[0].id')
+          echo "project_id=$PROJECT_ID"
+
+          echo "=== multipart upload via curl (matches soldeer push.rs: project_id, revision, zip_name@application/zip) ==="
+          code=$(curl -sS -o /tmp/up.json -w "%{http_code}" -X POST \
+            "https://api.soldeer.xyz/api/v1/revision/upload" \
             -H "Authorization: Bearer $SOLDEER_API_TOKEN" \
-            "https://api.soldeer.xyz/api/v1/revision/upload" || echo "curl_err")
-          echo "http=$code  body=$(head -c 300 /tmp/resp.txt)"
+            -F "project_id=$PROJECT_ID" \
+            -F "revision=$VERSION" \
+            -F "zip_name=@raindex.zip;type=application/zip")
+          echo "http=$code"
+          echo "response: $(cat /tmp/up.json)"
+          case "$code" in
+            2*) echo "UPLOAD OK" ;;
+            *) echo "UPLOAD FAILED"; exit 1 ;;
+          esac


### PR DESCRIPTION
Tests a curl-based multipart upload to the soldeer registry, bypassing soldeer 0.10.0's broken push. If it publishes 0.1.0, this becomes the autopublish fix.