### PR TITLE
test(core): mutation-validated RaindexV6 coverage (partial pass, 125/284)

### DIFF
--- a/test/concrete/raindex/RaindexV6.addOrder.mock.t.sol
+++ b/test/concrete/raindex/RaindexV6.addOrder.mock.t.sol
@@ -113,6 +113,36 @@ contract RaindexV6AddOrderMockTest is RaindexV6ExternalMockTest {
         (orderHash);
     }
 
+    /// The `MetaV1_2` event emitted by a successful add MUST carry the EXACT
+    /// data: sender = order owner, subject = order hash, meta = the config meta.
+    /// `addOrderWithChecks` only checks that some `MetaV1_2` is emitted (its
+    /// `expectEmit(false,false,true,false)` does not pin the non-indexed
+    /// subject/meta data), so this asserts all three fields are correct.
+    /// forge-config: default.fuzz.runs = 100
+    function testAddOrderMetaV1EventExactData(address owner, OrderConfigV4 memory config) public {
+        config.evaluable.bytecode = hex"02000000040000000000000000";
+        vm.assume(config.validInputs.length > 0);
+        vm.assume(config.validOutputs.length > 0);
+        vm.assume(config.meta.length > 0);
+
+        // Make the meta self-describe as a rain meta document so it passes the
+        // `checkMetaUnhashedV1` guard.
+        config.meta = abi.encodePacked(META_MAGIC_NUMBER_V1, config.meta);
+
+        (OrderV4 memory order, bytes32 orderHash) = LibTestAddOrder.expectedOrder(owner, config);
+        (order);
+
+        // Full-data check on every field of the event, pinned to the raindex
+        // emitter.
+        vm.expectEmit(true, true, true, true, address(iRaindex));
+        emit MetaV1_2(owner, orderHash, config.meta);
+
+        vm.prank(owner);
+        assertTrue(iRaindex.addOrder4(config, new TaskV2[](0)));
+
+        assertTrue(iRaindex.orderExists(orderHash));
+    }
+
     /// Alice and Bob can add orders with the same config. The resulting orders
     /// MUST be different.
     /// forge-config: default.fuzz.runs = 100

--- a/test/concrete/raindex/RaindexV6.deposit.t.sol
+++ b/test/concrete/raindex/RaindexV6.deposit.t.sol
@@ -47,6 +47,26 @@ contract RaindexV6DepositTest is RaindexV6ExternalMockTest {
         iRaindex.deposit4(address(iToken0), vaultId, LibDecimalFloat.packLossless(0, 0), new TaskV2[](0));
     }
 
+    /// Depositing a negative amount is caught by the same non-positive guard as
+    /// zero and reverts ZeroDepositAmount (NOT NegativePull from pullTokens). The
+    /// guard is `!depositAmount.gt(0)` which is true for both zero and negatives,
+    /// so a negative deposit never reaches the token pull.
+    /// forge-config: default.fuzz.runs = 100
+    function testDepositNegative(address depositor, bytes32 vaultId, uint256 magnitude18) external {
+        vm.assume(vaultId != bytes32(0));
+        magnitude18 = bound(magnitude18, 1, uint256(int256(type(int224).max)) / 10);
+        // A strictly negative deposit amount.
+        // magnitude18 is bound above so safe to typecast.
+        // forge-lint: disable-next-line(unsafe-typecast)
+        Float amount = LibDecimalFloat.packLossless(-int256(magnitude18), -18);
+        assertTrue(amount.lt(Float.wrap(0)));
+        vm.prank(depositor);
+        vm.expectRevert(
+            abi.encodeWithSelector(IRaindexV6.ZeroDepositAmount.selector, address(depositor), address(iToken0), vaultId)
+        );
+        iRaindex.deposit4(address(iToken0), vaultId, amount, new TaskV2[](0));
+    }
+
     /// Depositing vaultID of zero should revert.
     function testDepositZeroVaultId(address depositor, address token, Float amount) external {
         vm.assume(amount.gt(Float.wrap(0)));

--- a/test/concrete/raindex/RaindexV6.quote.sameToken.t.sol
+++ b/test/concrete/raindex/RaindexV6.quote.sameToken.t.sol
@@ -3,9 +3,17 @@
 pragma solidity =0.8.25;
 
 import {RaindexV6ExternalRealTest} from "test/util/abstract/RaindexV6ExternalRealTest.sol";
-import {QuoteV2, OrderConfigV4, TaskV2} from "raindex-interface-0.1.1/src/interface/IRaindexV6.sol";
+import {
+    QuoteV2,
+    OrderConfigV4,
+    OrderV4,
+    IOV2,
+    SignedContextV1,
+    TaskV2
+} from "raindex-interface-0.1.1/src/interface/IRaindexV6.sol";
 import {TokenSelfTrade} from "../../../src/concrete/raindex/RaindexV6.sol";
 import {Float} from "rain-math-float-0.1.1/src/lib/LibDecimalFloat.sol";
+import {LibTestAddOrder} from "test/util/lib/LibTestAddOrder.sol";
 
 /// @title RaindexV6QuoteSameTokenTest
 contract RaindexV6QuoteSameTokenTest is RaindexV6ExternalRealTest {
@@ -29,6 +37,52 @@ contract RaindexV6QuoteSameTokenTest is RaindexV6ExternalRealTest {
             }),
             new TaskV2[](0)
         );
+        vm.expectRevert(abi.encodeWithSelector(TokenSelfTrade.selector));
+        (bool success, Float maxOutput, Float ioRatio) = iRaindex.quote2(quoteConfig);
+        (success, maxOutput, ioRatio);
+    }
+
+    /// The self-trade check must compare `validInputs[inputIOIndex]` against
+    /// `validOutputs[outputIOIndex]`, i.e. the input array is indexed with
+    /// `inputIOIndex` and the output array with `outputIOIndex`. This test pins
+    /// the index pairing: the self-trade only exists at the (inputIOIndex=0,
+    /// outputIOIndex=1) pairing, NOT at (0, 0). Any mutation that reuses a single
+    /// index for both lookups, or swaps which array each index addresses, fails
+    /// to detect the self-trade and so does NOT revert TokenSelfTrade.
+    /// forge-config: default.fuzz.runs = 10
+    function testQuoteSameTokenIndexPairing(address owner, OrderConfigV4 memory config) external {
+        // Build explicit two-element input and output arrays where the self-trade
+        // is only visible when input index 0 is compared against output index 1.
+        // tokenA appears at validInputs[0] and validOutputs[1].
+        // tokenB at validInputs[1], tokenC at validOutputs[0] are all distinct.
+        address tokenA = address(0xAAAA);
+        address tokenB = address(0xBBBB);
+        address tokenC = address(0xCCCC);
+
+        config.validInputs = new IOV2[](2);
+        config.validInputs[0] = IOV2(tokenA, bytes32(uint256(0x11)));
+        config.validInputs[1] = IOV2(tokenB, bytes32(uint256(0x12)));
+        config.validOutputs = new IOV2[](2);
+        config.validOutputs[0] = IOV2(tokenC, bytes32(uint256(0x13)));
+        config.validOutputs[1] = IOV2(tokenA, bytes32(uint256(0x14)));
+
+        // conformConfig sets a valid bytecode + interpreter/store and only
+        // rewrites token addresses if validInputs[0].token == validOutputs[0].token
+        // (tokenA != tokenC here, so our token layout is preserved).
+        LibTestAddOrder.conformConfig(config, iInterpreter, iStore);
+        assertTrue(config.validInputs[0].token == tokenA, "input0 preserved");
+        assertTrue(config.validOutputs[1].token == tokenA, "output1 preserved");
+        assertTrue(config.validOutputs[0].token == tokenC, "output0 preserved");
+
+        OrderV4 memory order = OrderV4(owner, config.evaluable, config.validInputs, config.validOutputs, config.nonce);
+
+        vm.prank(owner);
+        iRaindex.addOrder4(config, new TaskV2[](0));
+
+        QuoteV2 memory quoteConfig =
+            QuoteV2({order: order, inputIOIndex: 0, outputIOIndex: 1, signedContext: new SignedContextV1[](0)});
+
+        // validInputs[0] (tokenA) == validOutputs[1] (tokenA): self-trade.
         vm.expectRevert(abi.encodeWithSelector(TokenSelfTrade.selector));
         (bool success, Float maxOutput, Float ioRatio) = iRaindex.quote2(quoteConfig);
         (success, maxOutput, ioRatio);

--- a/test/concrete/raindex/RaindexV6.vaultBalanceRevert.t.sol
+++ b/test/concrete/raindex/RaindexV6.vaultBalanceRevert.t.sol
@@ -11,6 +11,7 @@ import {
     NegativePush
 } from "src/concrete/raindex/RaindexV6.sol";
 import {Float, LibDecimalFloat} from "rain-math-float-0.1.1/src/lib/LibDecimalFloat.sol";
+import {IERC20} from "@openzeppelin-contracts-5.6.1/token/ERC20/IERC20.sol";
 import {MockToken} from "test/util/concrete/MockToken.sol";
 import {LibRainDeploy} from "rain-deploy-0.1.2/src/lib/LibRainDeploy.sol";
 import {LibTOFUTokenDecimals} from "rain-tofu-erc20-decimals-0.1.1/src/lib/LibTOFUTokenDecimals.sol";
@@ -101,6 +102,118 @@ contract RaindexV6VaultBalanceRevertTest is Test {
         MockToken realToken = new MockToken("Token", "TKN", 18);
         vm.expectRevert(NegativePush.selector);
         harness.exposedPush(owner, address(realToken), LibDecimalFloat.packLossless(-1, 0));
+    }
+
+    /// Pulling an amount that does NOT divide evenly into the token's fixed
+    /// decimals rounds the truncated fixed-decimal amount UP by one base unit
+    /// (favouring the dex, never the counterparty). With a 6-decimal token and a
+    /// Float of 15e-7 (= 0.0000015), the lossy conversion truncates to 1 base
+    /// unit (0.000001) but the lost remainder forces a round-up to 2 base units.
+    /// The harness pulls exactly 2 base units from the owner and reports 2 as the
+    /// fixed-decimal amount. Pins the `if (!lossless) { ++amount18; }` rounding:
+    /// a mutation that drops the increment pulls 1 instead of 2.
+    function testPullRoundsUpOnLoss() external {
+        MockToken realToken = new MockToken("Token", "TKN", 6);
+        // Owner holds and approves enough to cover the rounded-up pull.
+        realToken.mint(owner, 10);
+        vm.prank(owner);
+        realToken.approve(address(harness), 10);
+
+        // 15e-7 at 6 decimals: 15 * 10^(-7+6) = 15 / 10 = 1, remainder 5 lost.
+        (uint256 amount, uint8 decimals) =
+            harness.exposedPull(owner, address(realToken), LibDecimalFloat.packLossless(15, -7));
+
+        assertEq(decimals, 6, "decimals");
+        assertEq(amount, 2, "rounded-up fixed-decimal amount is 2 not 1");
+        // The contract actually pulled the rounded-up 2 base units.
+        assertEq(realToken.balanceOf(owner), 8, "owner balance after pull");
+        assertEq(realToken.balanceOf(address(harness)), 2, "harness balance after pull");
+    }
+
+    /// Pulling an amount that DOES divide evenly into the token's fixed decimals
+    /// is lossless and is NOT rounded up. With a 6-decimal token and a Float of
+    /// 3e-6 (= 0.000003) the conversion yields exactly 3 base units with no loss,
+    /// so no increment happens. Pins the `!lossless` predicate guarding the
+    /// round-up: a mutation that always increments (or inverts the predicate)
+    /// would pull 4 instead of 3.
+    function testPullNoRoundWhenLossless() external {
+        MockToken realToken = new MockToken("Token", "TKN", 6);
+        realToken.mint(owner, 10);
+        vm.prank(owner);
+        realToken.approve(address(harness), 10);
+
+        // 3e-6 at 6 decimals: 3 * 10^(-6+6) = 3, lossless.
+        (uint256 amount, uint8 decimals) =
+            harness.exposedPull(owner, address(realToken), LibDecimalFloat.packLossless(3, -6));
+
+        assertEq(decimals, 6, "decimals");
+        assertEq(amount, 3, "lossless amount is 3 not rounded to 4");
+        assertEq(realToken.balanceOf(owner), 7, "owner balance after pull");
+        assertEq(realToken.balanceOf(address(harness)), 3, "harness balance after pull");
+    }
+
+    /// Pulling an amount that converts to zero fixed-decimal units skips the
+    /// token transfer entirely (the `if (amount18 > 0)` guard). A zero Float
+    /// passes the negative guard, converts losslessly to 0 base units, and
+    /// `transferFrom` is NEVER invoked. Asserted with an `expectCall(..., 0)`:
+    /// a zero-value ERC20 transfer succeeds (does not revert), so the discriminator
+    /// is the call-count, not a revert. A mutation forcing the transfer on a zero
+    /// amount makes exactly one `transferFrom(owner, harness, 0)` call and fails
+    /// the zero-count expectation.
+    function testPullZeroSkipsTransfer() external {
+        MockToken realToken = new MockToken("Token", "TKN", 6);
+        // Assert transferFrom is NOT called for a zero amount.
+        vm.expectCall(
+            address(realToken),
+            abi.encodeWithSelector(IERC20.transferFrom.selector, owner, address(harness), uint256(0)),
+            0
+        );
+        (uint256 amount, uint8 decimals) = harness.exposedPull(owner, address(realToken), Float.wrap(0));
+
+        assertEq(decimals, 6, "decimals");
+        assertEq(amount, 0, "zero amount returned");
+        assertEq(realToken.balanceOf(owner), 0, "owner untouched");
+        assertEq(realToken.balanceOf(address(harness)), 0, "harness untouched");
+    }
+
+    /// Pushing an amount that does NOT divide evenly into the token's fixed
+    /// decimals TRUNCATES the fixed-decimal amount (rounds DOWN), the OPPOSITE of
+    /// pull which rounds up. With a 6-decimal token and a Float of 15e-7 the
+    /// lossy conversion yields 1 base unit and push transfers exactly 1 (NOT 2).
+    /// Pins that push has no round-up: a mutation copying pull's `++amount`
+    /// rounding into push would transfer 2 instead of 1.
+    function testPushTruncatesOnLoss() external {
+        MockToken realToken = new MockToken("Token", "TKN", 6);
+        // The harness holds tokens to push out.
+        realToken.mint(address(harness), 10);
+
+        // 15e-7 at 6 decimals truncates to 1 (push does NOT round up).
+        (uint256 amount, uint8 decimals) =
+            harness.exposedPush(owner, address(realToken), LibDecimalFloat.packLossless(15, -7));
+
+        assertEq(decimals, 6, "decimals");
+        assertEq(amount, 1, "truncated fixed-decimal amount is 1 not 2");
+        assertEq(realToken.balanceOf(owner), 1, "owner received truncated 1");
+        assertEq(realToken.balanceOf(address(harness)), 9, "harness balance after push");
+    }
+
+    /// Pushing an amount that converts to zero fixed-decimal units skips the
+    /// token transfer entirely (the `if (amount > 0)` guard). A zero Float
+    /// converts losslessly to 0 base units, and `transfer` is NEVER invoked.
+    /// Asserted with an `expectCall(..., 0)` since a zero-value ERC20 transfer
+    /// succeeds rather than reverts: a mutation forcing the transfer on a zero
+    /// amount makes exactly one `transfer(owner, 0)` call and fails the
+    /// zero-count expectation.
+    function testPushZeroSkipsTransfer() external {
+        MockToken realToken = new MockToken("Token", "TKN", 6);
+        // Assert transfer is NOT called for a zero amount.
+        vm.expectCall(address(realToken), abi.encodeWithSelector(IERC20.transfer.selector, owner, uint256(0)), 0);
+        (uint256 amount, uint8 decimals) = harness.exposedPush(owner, address(realToken), Float.wrap(0));
+
+        assertEq(decimals, 6, "decimals");
+        assertEq(amount, 0, "zero amount returned");
+        assertEq(realToken.balanceOf(owner), 0, "owner untouched");
+        assertEq(realToken.balanceOf(address(harness)), 0, "harness untouched");
     }
 
     /// Increasing a vault-0 balance ALWAYS returns (0, 0): vault 0 holds no

--- a/test/concrete/raindex/RaindexV6.vaultBalanceRevert.t.sol
+++ b/test/concrete/raindex/RaindexV6.vaultBalanceRevert.t.sol
@@ -122,4 +122,61 @@ contract RaindexV6VaultBalanceRevertTest is Test {
         // The owner actually received the pushed tokens.
         assertEq(realToken.balanceOf(owner), 1e18, "owner balance");
     }
+
+    /// Decreasing a non-zero vault SUBTRACTS the amount from the old balance:
+    /// it returns (oldBalance, oldBalance - amount), persists the new balance to
+    /// storage, and a follow-up read reflects the reduced balance. Pins the
+    /// `.sub` arithmetic, the (old, new) return tuple ordering, and the storage
+    /// write — a mutation that adds instead of subtracts, returns the amount or
+    /// both-new, or skips the write is caught.
+    function testDecreaseNonZeroSubtracts() external {
+        // Seed the vault with 10 via an increase from the zero balance.
+        (Float seedOld, Float seedNew) =
+            harness.exposedIncrease(owner, token, VAULT, LibDecimalFloat.packLossless(10, 0));
+        assertTrue(seedOld.eq(Float.wrap(0)), "seed old");
+        assertTrue(seedNew.eq(LibDecimalFloat.packLossless(10, 0)), "seed new");
+
+        // Decrease by 3: returns (10, 7).
+        (Float oldBalance, Float newBalance) =
+            harness.exposedDecrease(owner, token, VAULT, LibDecimalFloat.packLossless(3, 0));
+        assertTrue(oldBalance.eq(LibDecimalFloat.packLossless(10, 0)), "old balance is pre-decrease 10");
+        assertTrue(newBalance.eq(LibDecimalFloat.packLossless(7, 0)), "new balance is 10 - 3 = 7");
+
+        // The reduced balance is persisted: reading the vault returns 7.
+        assertTrue(
+            harness.vaultBalance2(owner, token, VAULT).eq(LibDecimalFloat.packLossless(7, 0)), "stored balance is 7"
+        );
+
+        // A second decrease compounds off the stored 7, not the original 10:
+        // returns (7, 5) and persists 5.
+        (Float old2, Float new2) = harness.exposedDecrease(owner, token, VAULT, LibDecimalFloat.packLossless(2, 0));
+        assertTrue(old2.eq(LibDecimalFloat.packLossless(7, 0)), "second old reads stored 7");
+        assertTrue(new2.eq(LibDecimalFloat.packLossless(5, 0)), "second new is 7 - 2 = 5");
+        assertTrue(
+            harness.vaultBalance2(owner, token, VAULT).eq(LibDecimalFloat.packLossless(5, 0)), "stored balance is 5"
+        );
+    }
+
+    /// Decreasing a vault-0 balance ALWAYS returns (0, 0) and PULLS tokens from
+    /// the owner into the contract (vault 0 holds no internal balance, every
+    /// decrease is a compound matching deposit). Pins both the (0, 0) return and
+    /// the pull side-effect (owner's tokens move to the harness) so a mutation
+    /// echoing the amount back, or pushing instead of pulling, or storing a
+    /// balance, is caught.
+    function testDecreaseVaultZeroPullsAndReturnsZero() external {
+        MockToken realToken = new MockToken("Token", "TKN", 18);
+        // The owner holds tokens and has approved the harness so the pull works.
+        realToken.mint(owner, 5e18);
+        vm.prank(owner);
+        realToken.approve(address(harness), 5e18);
+
+        (Float oldBalance, Float newBalance) =
+            harness.exposedDecrease(owner, address(realToken), bytes32(0), LibDecimalFloat.packLossless(2, 0));
+
+        assertTrue(oldBalance.eq(Float.wrap(0)), "vault-0 old balance not zero");
+        assertTrue(newBalance.eq(Float.wrap(0)), "vault-0 new balance not zero");
+        // Two whole tokens were pulled from the owner into the harness.
+        assertEq(realToken.balanceOf(owner), 3e18, "owner balance after pull");
+        assertEq(realToken.balanceOf(address(harness)), 2e18, "harness balance after pull");
+    }
 }

--- a/test/concrete/raindex/RaindexV6.vaultBalanceRevert.t.sol
+++ b/test/concrete/raindex/RaindexV6.vaultBalanceRevert.t.sol
@@ -216,6 +216,64 @@ contract RaindexV6VaultBalanceRevertTest is Test {
         assertEq(realToken.balanceOf(address(harness)), 0, "harness untouched");
     }
 
+    /// Pulling a positive amount SMALLER than one base unit (the sub-unit
+    /// "almost zero" range, 0 < x < 1 base unit) must round UP to exactly 1 base
+    /// unit and pull it — it must NOT truncate to zero and skip the transfer,
+    /// which would let a non-zero credit be funded by a zero pull. With a
+    /// 6-decimal token and a Float of 1e-7 (= 0.1 base units) the lossy
+    /// conversion truncates to 0, but because it is lossy the round-up forces 1.
+    /// This pins the 0->1 ceil boundary specifically: testPullRoundsUpOnLoss
+    /// exercises 1.5 -> 2 (already >= 1) and testPullZeroSkipsTransfer exercises
+    /// exactly 0, so a mutation that only increments an already-non-zero
+    /// truncation (`if (!lossless && amount18 != 0)`) survives both of those but
+    /// is killed here.
+    function testPullSubUnitRoundsUpToOne() external {
+        MockToken realToken = new MockToken("Token", "TKN", 6);
+        realToken.mint(owner, 10);
+        vm.prank(owner);
+        realToken.approve(address(harness), 10);
+
+        // The contract pulls exactly 1 base unit (not 0) for the sub-unit amount.
+        vm.expectCall(
+            address(realToken),
+            abi.encodeWithSelector(IERC20.transferFrom.selector, owner, address(harness), uint256(1)),
+            1
+        );
+        // 1e-7 at 6 decimals: 1 * 10^(-7+6) = 0.1, truncates to 0 but lossy -> ++ -> 1.
+        (uint256 amount, uint8 decimals) =
+            harness.exposedPull(owner, address(realToken), LibDecimalFloat.packLossless(1, -7));
+
+        assertEq(decimals, 6, "decimals");
+        assertEq(amount, 1, "sub-unit amount rounds up to 1 not 0");
+        assertEq(realToken.balanceOf(owner), 9, "owner balance after sub-unit pull");
+        assertEq(realToken.balanceOf(address(harness)), 1, "harness pulled exactly 1");
+    }
+
+    /// Pushing a positive amount SMALLER than one base unit (sub-unit "almost
+    /// zero") TRUNCATES to zero and skips the transfer — push rounds DOWN, so the
+    /// residual stays in the contract rather than paying out a base unit of dust.
+    /// With a 6-decimal token and a Float of 1e-7 (= 0.1 base units) push
+    /// transfers nothing. Pins that push does NOT lift a sub-unit amount to 1
+    /// (the over-pay direction): testPushTruncatesOnLoss exercises 1.5 -> 1
+    /// (>= 1) and testPushZeroSkipsTransfer exercises exactly 0, so a mutation
+    /// paying out 1 base unit for a sub-unit amount survives both but is killed
+    /// here.
+    function testPushSubUnitTruncatesToZero() external {
+        MockToken realToken = new MockToken("Token", "TKN", 6);
+        realToken.mint(address(harness), 10);
+
+        // No transfer at all for a sub-unit (truncated-to-zero) push.
+        vm.expectCall(address(realToken), abi.encodeWithSelector(IERC20.transfer.selector, owner, uint256(0)), 0);
+        // 1e-7 at 6 decimals: 0.1 base units, push truncates DOWN to 0 -> skip.
+        (uint256 amount, uint8 decimals) =
+            harness.exposedPush(owner, address(realToken), LibDecimalFloat.packLossless(1, -7));
+
+        assertEq(decimals, 6, "decimals");
+        assertEq(amount, 0, "sub-unit amount truncates to 0 not 1");
+        assertEq(realToken.balanceOf(owner), 0, "owner received nothing");
+        assertEq(realToken.balanceOf(address(harness)), 10, "harness untouched");
+    }
+
     /// Increasing a vault-0 balance ALWAYS returns (0, 0): vault 0 holds no
     /// internal balance, it pushes tokens straight out to the owner, so the
     /// reported old and new balances are both exactly zero regardless of the

--- a/test/concrete/raindex/RaindexV6.vaultBalanceRevert.t.sol
+++ b/test/concrete/raindex/RaindexV6.vaultBalanceRevert.t.sol
@@ -45,6 +45,8 @@ contract RaindexV6VaultBalanceHarness is RaindexV6 {
 /// negative `amount` (`NegativeVaultBalanceChange`) and a decrease that would
 /// drive the balance below zero (`NegativeVaultBalance`).
 contract RaindexV6VaultBalanceRevertTest is Test {
+    using LibDecimalFloat for Float;
+
     RaindexV6VaultBalanceHarness internal harness;
     address internal owner = makeAddr("owner");
     address internal token = makeAddr("token");
@@ -99,5 +101,25 @@ contract RaindexV6VaultBalanceRevertTest is Test {
         MockToken realToken = new MockToken("Token", "TKN", 18);
         vm.expectRevert(NegativePush.selector);
         harness.exposedPush(owner, address(realToken), LibDecimalFloat.packLossless(-1, 0));
+    }
+
+    /// Increasing a vault-0 balance ALWAYS returns (0, 0): vault 0 holds no
+    /// internal balance, it pushes tokens straight out to the owner, so the
+    /// reported old and new balances are both exactly zero regardless of the
+    /// amount. Pins the return values so a mutation echoing the amount back is
+    /// caught.
+    function testIncreaseVaultZeroReturnsZero() external {
+        MockToken realToken = new MockToken("Token", "TKN", 18);
+        // The harness pushes tokens out to the owner for vault 0, so it needs a
+        // balance to transfer.
+        realToken.mint(address(harness), 1e18);
+
+        (Float oldBalance, Float newBalance) =
+            harness.exposedIncrease(owner, address(realToken), bytes32(0), LibDecimalFloat.packLossless(1, 0));
+
+        assertTrue(oldBalance.eq(Float.wrap(0)), "old balance not zero");
+        assertTrue(newBalance.eq(Float.wrap(0)), "new balance not zero");
+        // The owner actually received the pushed tokens.
+        assertEq(realToken.balanceOf(owner), 1e18, "owner balance");
     }
 }

--- a/test/concrete/raindex/RaindexV6.vaultBalanceVault0.t.sol
+++ b/test/concrete/raindex/RaindexV6.vaultBalanceVault0.t.sol
@@ -4,7 +4,11 @@ pragma solidity =0.8.25;
 
 import {RaindexV6ExternalMockTest} from "test/util/abstract/RaindexV6ExternalMockTest.sol";
 import {IERC20} from "@openzeppelin-contracts-5.6.1/token/ERC20/IERC20.sol";
+import {IERC20Metadata} from "@openzeppelin-contracts-5.6.1/token/ERC20/extensions/IERC20Metadata.sol";
 import {LibDecimalFloat, Float} from "rain-math-float-0.1.1/src/lib/LibDecimalFloat.sol";
+import {TaskV2} from "raindex-interface-0.1.1/src/interface/IRaindexV6.sol";
+import {TOFUOutcome} from "rain-tofu-erc20-decimals-0.1.1/src/lib/LibTOFUTokenDecimals.sol";
+import {ITOFUTokenDecimals} from "rain-tofu-erc20-decimals-0.1.1/src/interface/ITOFUTokenDecimals.sol";
 
 /// @title RaindexV6VaultBalanceVault0Test
 /// @notice Vault ID 0 has no internal balance; its effective balance is the
@@ -53,5 +57,78 @@ contract RaindexV6VaultBalanceVault0Test is RaindexV6ExternalMockTest {
         Float effective = iRaindex.vaultBalance2(owner, address(iToken0), bytes32(0));
         // The smaller of the two (balance) is returned, not the approval.
         assertTrue(effective.eq(LibDecimalFloat.fromFixedDecimalLosslessPacked(balance18, 18)), "balance limits");
+    }
+
+    /// Deposits to a non-zero vault to seed the TOFU store with the token's
+    /// decimals (18). The deposit makes `pullTokens` persist the decimals via the
+    /// mutating TOFU read so subsequent read-only reads have a stored value to
+    /// compare against.
+    function _seedTofuDecimals(address depositor) internal {
+        vm.mockCall(
+            address(iToken0),
+            abi.encodeWithSelector(IERC20.transferFrom.selector, depositor, address(iRaindex), 1),
+            abi.encode(true)
+        );
+        vm.prank(depositor);
+        iRaindex.deposit4(address(iToken0), bytes32(uint256(1)), LibDecimalFloat.packLossless(1, -18), new TaskV2[](0));
+    }
+
+    /// A vault-0 balance read MUST revert `TokenDecimalsReadFailure` when the
+    /// token's decimals have become inconsistent with the previously stored TOFU
+    /// value. Without the guard, the stale stored decimals would be used to scale
+    /// the balance and approval, silently misreporting the effective balance.
+    function testVaultBalanceVault0TofuInconsistentReverts(address depositor) external {
+        _seedTofuDecimals(depositor);
+
+        // The token now reports a DIFFERENT number of decimals than was stored.
+        vm.mockCall(address(iToken0), abi.encodeWithSelector(IERC20Metadata.decimals.selector), abi.encode(uint8(6)));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ITOFUTokenDecimals.TokenDecimalsReadFailure.selector, address(iToken0), TOFUOutcome.Inconsistent
+            )
+        );
+        iRaindex.vaultBalance2(depositor, address(iToken0), bytes32(0));
+    }
+
+    /// A vault-0 balance read MUST revert `TokenDecimalsReadFailure` when the
+    /// token can no longer be read for decimals at all (read failure) after a
+    /// value was previously stored.
+    function testVaultBalanceVault0TofuReadFailureReverts(address depositor) external {
+        _seedTofuDecimals(depositor);
+
+        // The token now reverts on `decimals()` (REVERTING_MOCK_BYTECODE under
+        // the cleared mock), producing a ReadFailure outcome.
+        vm.clearMockedCalls();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ITOFUTokenDecimals.TokenDecimalsReadFailure.selector, address(iToken0), TOFUOutcome.ReadFailure
+            )
+        );
+        iRaindex.vaultBalance2(depositor, address(iToken0), bytes32(0));
+    }
+
+    /// Positive control: when the token's decimals remain CONSISTENT with the
+    /// stored TOFU value, a vault-0 read does NOT revert and returns the
+    /// effective balance (min of balance and approval).
+    function testVaultBalanceVault0TofuConsistentOk(address depositor, uint256 balance18, uint256 approval18) external {
+        _seedTofuDecimals(depositor);
+
+        balance18 = bound(balance18, 1, uint256(int256(type(int224).max)));
+        approval18 = bound(approval18, 0, balance18 - 1);
+
+        // decimals() still returns 18 (consistent with the stored value).
+        vm.mockCall(
+            address(iToken0), abi.encodeWithSelector(IERC20.balanceOf.selector, depositor), abi.encode(balance18)
+        );
+        vm.mockCall(
+            address(iToken0),
+            abi.encodeWithSelector(IERC20.allowance.selector, depositor, address(iRaindex)),
+            abi.encode(approval18)
+        );
+
+        Float effective = iRaindex.vaultBalance2(depositor, address(iToken0), bytes32(0));
+        assertTrue(effective.eq(LibDecimalFloat.fromFixedDecimalLosslessPacked(approval18, 18)), "consistent ok");
     }
 }


### PR DESCRIPTION
## Test hardening — `RaindexV6` core (mutation-validated, partial pass)

Adversarial mutation-testing pass over `src/concrete/raindex/RaindexV6.sol` (the orderbook). Each behavior was validated by breaking the exact line it claims to cover and confirming a test fails; existing tests that already killed their mutant are credited, and surviving mutants (real gaps) got a new discriminating test. **Test-only and additive** — no source changes.

`RaindexV6` is etched, so every probe regenerated `src/generated/RaindexV6.pointers.sol` to make the mutation live in the executed bytecode before running the suite.

### Coverage so far

`RaindexV6` enumerated to **284 behaviors**; **125 probed** this pass — **109 credited to existing tests** (mutation-confirmed) and **16 gaps filled** with new tests. The remaining **~159 behaviors are documented as `[TODO]`** in the campaign checklist and are **not yet covered** by this PR.

> **This is a deliberate partial pass.** RaindexV6's full surface is large; this run was stopped at 125/284 rather than chasing the tail at a poor wall-clock rate. The remainder will be completed by a follow-up run that loops to true dry. This PR ships the proven layer now.

### New tests

- `RaindexV6.deposit.t.sol` — `deposit4` negative-amount guard reverts `ZeroDepositAmount`.
- `RaindexV6.vaultBalanceVault0.t.sol` — vault-0 balance TOFU-decimals guard + `min(balance, approval)`.
- `RaindexV6.vaultBalanceRevert.t.sol` — vault-balance revert paths.
- `RaindexV6.quote.sameToken.t.sol` — `checkTokenSelfTrade` index pairing in `quote2`.
- `RaindexV6.addOrder.mock.t.sol` — exact `MetaV1_2` event data on `addOrder4`.

Plus mutation-validated `increase`/`decreaseVaultBalance` arithmetic/storage/returns and `pullTokens`/`pushTokens` rounding + zero-skip behaviors against existing tests.

### Note for review

The branch is based on a `main` predating the latest `RaindexV6` refactors (`LibTakeOrdersOverlay` extraction etc.); it will be re-synced with current `main` and re-validated before merge. The PR diff itself is test-only (5 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive validation tests for order metadata events, deposit validation, quote self-trade detection, vault balance operations, and token decimal consistency checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->