### PR TITLE
ci: install soldeer deps before subgraph-deploy

### DIFF
--- a/.github/workflows/deploy-subgraph.yaml
+++ b/.github/workflows/deploy-subgraph.yaml
@@ -31,6 +31,10 @@ jobs:
           primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-
           gc-max-store-size-linux: 1G
+      # subgraph-deploy runs a forge build, which needs the soldeer dependencies
+      # installed. Without this every import fails to resolve and the build aborts.
+      - run: nix develop -c forge soldeer install
+      - run: nix develop -c forge build
       - run: nix develop -c subgraph-deploy
       # forwards status to telegram chat if this ci fails or gets canceled, only runs for default branch
       - name: Forward CI Status


### PR DESCRIPTION
The `Deploy subgraph` workflow (`deploy-subgraph.yaml`) failed on `main`: `subgraph-deploy` runs a `forge build`, but the workflow never installs the soldeer dependencies, so every import (`forge-std`, `@openzeppelin`, `rain-*`, `raindex-interface`, …) resolves to a missing file — >256 errors, aborting, exit 1.

Pre-existing breakage from the soldeer migration that never updated this workflow (last successful subgraph deploy was Mar 24, pre-migration). Fix: run `forge soldeer install` + `forge build` before `subgraph-deploy`, matching the README/AGENTS bootstrap.

Validated by dispatching the deploy from this branch (carries main's contracts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)