### PR TITLE
feat: pin + enforce 0.1.0 deployment constants for all raindex contracts

### DIFF
--- a/script/check-published-deploy-constants.sh
+++ b/script/check-published-deploy-constants.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: LicenseRef-DCL-1.0
+# SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+#
 # Prints "OK" iff every version published to the soldeer registry for `raindex`
 # has a full suite of pinned deploy constants in LibRaindexDeploy.sol: a
 # DEPLOYED_ADDRESS and DEPLOYED_CODEHASH (suffixed with the version) for each of

--- a/script/check-published-deploy-constants.sh
+++ b/script/check-published-deploy-constants.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Prints "OK" iff every version published to the soldeer registry for `raindex`
+# has a full suite of pinned deploy constants in LibRaindexDeploy.sol: a
+# DEPLOYED_ADDRESS and DEPLOYED_CODEHASH (suffixed with the version) for each of
+# the six deployed contracts.
+#
+# Consumed by LibRaindexDeployTaggedConstants.t.sol via FFI. Output is one of:
+#   OK                  - every published version has its full constant suite
+#   MISSING: <names...>  - one or more expected constants are absent
+#   SKIP: <reason>       - the registry could not be reached (nothing verified)
+#
+# Always exits 0 so the test sees the message rather than an ffi failure.
+
+lib="src/lib/deploy/LibRaindexDeploy.sol"
+
+versions=$(
+  curl -fsS "https://api.soldeer.xyz/api/v1/revision?project_name=raindex" 2>/dev/null \
+    | grep -oE '"version":"[0-9][0-9.]*"' | cut -d'"' -f4 | sort -u
+)
+
+if [ -z "$versions" ]; then
+  printf 'SKIP: could not fetch published soldeer versions'
+  exit 0
+fi
+
+# The six deployed contracts' constant prefixes.
+prefixes="RAINDEX_DEPLOYED \
+SUB_PARSER_DEPLOYED \
+ROUTE_PROCESSOR_DEPLOYED \
+GENERIC_POOL_ARB_ORDER_TAKER_DEPLOYED \
+ROUTE_PROCESSOR_ARB_ORDER_TAKER_DEPLOYED \
+GENERIC_POOL_FLASH_BORROWER_DEPLOYED"
+
+missing=""
+for v in $versions; do
+  suffix=$(printf '%s' "$v" | tr . _)
+  for p in $prefixes; do
+    for kind in ADDRESS CODEHASH; do
+      name="${p}_${kind}_${suffix}"
+      grep -qE "constant ${name} =" "$lib" || missing="${missing} ${name}"
+    done
+  done
+done
+
+if [ -n "$missing" ]; then
+  printf 'MISSING:%s' "$missing"
+else
+  printf 'OK'
+fi

--- a/src/lib/deploy/LibRaindexDeploy.sol
+++ b/src/lib/deploy/LibRaindexDeploy.sol
@@ -39,6 +39,17 @@ library LibRaindexDeploy {
     /// standard zoltu deployer.
     bytes32 constant RAINDEX_DEPLOYED_CODEHASH = RAINDEX_HASH;
 
+    /// The deployed address of the `RaindexV6` contract at the published `0.1.0`
+    /// tag. Pinned as a literal (not derived from the current pointers) so it
+    /// keeps referencing the `0.1.0` deployment after `RAINDEX_DEPLOYED_ADDRESS`
+    /// above advances to a newer version.
+    address constant RAINDEX_DEPLOYED_ADDRESS_0_1_0 = 0xb05D73E6BCc26AEB5b67Ff68C6E9C6151073e3cE;
+
+    /// The runtime code hash of the `RaindexV6` contract at the published `0.1.0`
+    /// tag.
+    bytes32 constant RAINDEX_DEPLOYED_CODEHASH_0_1_0 =
+        0xf5d6441f79933283777975573d385f5fc48c71f50ec85ef900dc947995e2f33d;
+
     /// The address of the `RaindexV6SubParser` contract when deployed with
     /// the rain standard zoltu deployer.
     address constant SUB_PARSER_DEPLOYED_ADDRESS = SUB_PARSER_ADDR;

--- a/src/lib/deploy/LibRaindexDeploy.sol
+++ b/src/lib/deploy/LibRaindexDeploy.sol
@@ -58,6 +58,15 @@ library LibRaindexDeploy {
     /// the rain standard zoltu deployer.
     bytes32 constant SUB_PARSER_DEPLOYED_CODEHASH = SUB_PARSER_HASH;
 
+    /// The deployed address of the `RaindexV6SubParser` contract at the
+    /// published `0.1.0` tag.
+    address constant SUB_PARSER_DEPLOYED_ADDRESS_0_1_0 = 0xBdb9cC5FF04A2bA28a4B0369d5592c469B9dFF53;
+
+    /// The runtime code hash of the `RaindexV6SubParser` contract at the
+    /// published `0.1.0` tag.
+    bytes32 constant SUB_PARSER_DEPLOYED_CODEHASH_0_1_0 =
+        0x59e436b1a58c24ce88745ff6a49800ae74b98ac6c1f78032c509ec926de32140;
+
     /// The address of the `RouteProcessor4` contract when deployed with the
     /// rain standard zoltu deployer.
     address constant ROUTE_PROCESSOR_DEPLOYED_ADDRESS = ROUTE_PROCESSOR_ADDR;
@@ -65,6 +74,15 @@ library LibRaindexDeploy {
     /// The code hash of the `RouteProcessor4` contract when deployed with the
     /// rain standard zoltu deployer.
     bytes32 constant ROUTE_PROCESSOR_DEPLOYED_CODEHASH = ROUTE_PROCESSOR_HASH;
+
+    /// The deployed address of the `RouteProcessor4` contract at the published
+    /// `0.1.0` tag.
+    address constant ROUTE_PROCESSOR_DEPLOYED_ADDRESS_0_1_0 = 0x6E2d0e71d900474b262E545Bc4C98b71ab368d21;
+
+    /// The runtime code hash of the `RouteProcessor4` contract at the published
+    /// `0.1.0` tag.
+    bytes32 constant ROUTE_PROCESSOR_DEPLOYED_CODEHASH_0_1_0 =
+        0xeb3745a79c6ba48e8767b9c355b8e7b79f9d6edeca004e4bb91be4de515a7eeb;
 
     /// The address of the `GenericPoolRaindexV6ArbOrderTaker` contract when
     /// deployed with the rain standard zoltu deployer.
@@ -74,6 +92,15 @@ library LibRaindexDeploy {
     /// deployed with the rain standard zoltu deployer.
     bytes32 constant GENERIC_POOL_ARB_ORDER_TAKER_DEPLOYED_CODEHASH = GENERIC_POOL_ARB_OT_HASH;
 
+    /// The deployed address of the `GenericPoolRaindexV6ArbOrderTaker` contract
+    /// at the published `0.1.0` tag.
+    address constant GENERIC_POOL_ARB_ORDER_TAKER_DEPLOYED_ADDRESS_0_1_0 = 0xA7299e32D8B89E064211FCDdE21A69cd0d54D0eb;
+
+    /// The runtime code hash of the `GenericPoolRaindexV6ArbOrderTaker` contract
+    /// at the published `0.1.0` tag.
+    bytes32 constant GENERIC_POOL_ARB_ORDER_TAKER_DEPLOYED_CODEHASH_0_1_0 =
+        0xba5ce714baf93e1405a4e93d4ace1717b8ff04ee4fcfbfcff6ada6210928397c;
+
     /// The address of the `RouteProcessorRaindexV6ArbOrderTaker` contract
     /// when deployed with the rain standard zoltu deployer.
     address constant ROUTE_PROCESSOR_ARB_ORDER_TAKER_DEPLOYED_ADDRESS = RP_ARB_OT_ADDR;
@@ -82,6 +109,16 @@ library LibRaindexDeploy {
     /// when deployed with the rain standard zoltu deployer.
     bytes32 constant ROUTE_PROCESSOR_ARB_ORDER_TAKER_DEPLOYED_CODEHASH = RP_ARB_OT_HASH;
 
+    /// The deployed address of the `RouteProcessorRaindexV6ArbOrderTaker`
+    /// contract at the published `0.1.0` tag.
+    address constant ROUTE_PROCESSOR_ARB_ORDER_TAKER_DEPLOYED_ADDRESS_0_1_0 =
+        0x3dbef2Fb2ADFE64048Aa7E177F1645Ce7Bf5216d;
+
+    /// The runtime code hash of the `RouteProcessorRaindexV6ArbOrderTaker`
+    /// contract at the published `0.1.0` tag.
+    bytes32 constant ROUTE_PROCESSOR_ARB_ORDER_TAKER_DEPLOYED_CODEHASH_0_1_0 =
+        0x728605dabf8d0f4235999e961f288b6e05765c8c210a302e81f1b4fea2754bc8;
+
     /// The address of the `GenericPoolRaindexV6FlashBorrower` contract when
     /// deployed with the rain standard zoltu deployer.
     address constant GENERIC_POOL_FLASH_BORROWER_DEPLOYED_ADDRESS = GENERIC_POOL_FB_ADDR;
@@ -89,6 +126,15 @@ library LibRaindexDeploy {
     /// The code hash of the `GenericPoolRaindexV6FlashBorrower` contract when
     /// deployed with the rain standard zoltu deployer.
     bytes32 constant GENERIC_POOL_FLASH_BORROWER_DEPLOYED_CODEHASH = GENERIC_POOL_FB_HASH;
+
+    /// The deployed address of the `GenericPoolRaindexV6FlashBorrower` contract
+    /// at the published `0.1.0` tag.
+    address constant GENERIC_POOL_FLASH_BORROWER_DEPLOYED_ADDRESS_0_1_0 = 0x8bdEd5aC59070533ec538a950e38B1a6F6cFA36c;
+
+    /// The runtime code hash of the `GenericPoolRaindexV6FlashBorrower` contract
+    /// at the published `0.1.0` tag.
+    bytes32 constant GENERIC_POOL_FLASH_BORROWER_DEPLOYED_CODEHASH_0_1_0 =
+        0xa1bf69e21c50d0f6c30fb102d78c768de58f733ca86ee745560aff7069c155c2;
 
     uint256 constant RAINDEX_START_BLOCK_ARBITRUM = 469385437;
     uint256 constant RAINDEX_START_BLOCK_BASE = 46821107;

--- a/test/lib/deploy/LibRaindexDeployTaggedConstants.t.sol
+++ b/test/lib/deploy/LibRaindexDeployTaggedConstants.t.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Test} from "forge-std-1.16.1/src/Test.sol";
+
+/// @title LibRaindexDeployTaggedConstantsTest
+/// @notice Every version published to the soldeer registry for `raindex` must
+/// have a full suite of pinned deploy constants in `LibRaindexDeploy`: a
+/// `*_DEPLOYED_ADDRESS_<version>` and `*_DEPLOYED_CODEHASH_<version>` for each of
+/// the six deployed contracts. `script/check-published-deploy-constants.sh`
+/// queries the live registry (via FFI) and lists any missing constants, so
+/// publishing a new tag without pinning its constants fails this test. Skips if
+/// the registry is unreachable rather than failing on network flakiness.
+contract LibRaindexDeployTaggedConstantsTest is Test {
+    function testAllPublishedSoldeerTagsHaveAFullConstantSuite() external {
+        string[] memory cmd = new string[](2);
+        cmd[0] = "bash";
+        cmd[1] = "script/check-published-deploy-constants.sh";
+        bytes memory out = vm.ffi(cmd);
+
+        // The registry could not be reached; there is nothing to verify.
+        if (_startsWith(out, bytes("SKIP"))) {
+            vm.skip(true);
+            return;
+        }
+
+        // On failure the actual value lists the missing `*_<version>` constants.
+        assertEq(string(out), "OK", "a published soldeer tag is missing pinned deploy constants");
+    }
+
+    function _startsWith(bytes memory s, bytes memory prefix) private pure returns (bool) {
+        if (s.length < prefix.length) {
+            return false;
+        }
+        for (uint256 i = 0; i < prefix.length; i++) {
+            if (s[i] != prefix[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+}


### PR DESCRIPTION
Adds `_<version>`-suffixed deployed-address and runtime-codehash literals to `LibRaindexDeploy` for all six deployed contracts, recording the published `0.1.0` tag's deployment:

| contract | address (0.1.0) | codehash |
|---|---|---|
| RaindexV6 | `0xb05D73E6…3e3cE` | `0xf5d6441f…` |
| RaindexV6SubParser | `0xBdb9cC5F…dFF53` | `0x59e436b1…` |
| RouteProcessor4 | `0x6E2d0e71…68d21` | `0xeb3745a7…` |
| GenericPoolRaindexV6ArbOrderTaker | `0xA7299e32…4D0eb` | `0xba5ce714…` |
| RouteProcessorRaindexV6ArbOrderTaker | `0x3dbef2Fb…5216d` | `0x728605da…` |
| GenericPoolRaindexV6FlashBorrower | `0x8bdEd5aC…fA36c` | `0xa1bf69e2…` |

The canonical `*_DEPLOYED_ADDRESS` constants are derived from `src/generated/*.pointers.sol`, so they advance to new deterministic addresses every time the bytecode changes. These pinned literals keep a permanent reference to the `0.1.0` deployment.

## Enforcement

Adds `LibRaindexDeployTaggedConstants.t.sol` + `script/check-published-deploy-constants.sh`: an FFI test that queries the **live soldeer registry** for raindex's published versions and asserts `LibRaindexDeploy` pins a full constant suite (address + codehash for all six contracts) for each one. Publishing a new tag without pinning its constants now fails this test. It **skips** (rather than fails) if the registry is unreachable, so it never breaks on network flakiness.

Verified: passes with `0.1.0` fully pinned, and reports the exact `MISSING` constant when one is removed. All 12 pointer values pinned exactly; no pointer/codehash drift; `LibRaindexDeploy.t.sol` stays 31/31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)