### PR TITLE
test: pin handle-IO sees the same order's calculate set (H01)

### DIFF
--- a/test/concrete/raindex/RaindexV6.takeOrder.batchStateAdversarial.t.sol
+++ b/test/concrete/raindex/RaindexV6.takeOrder.batchStateAdversarial.t.sol
@@ -324,4 +324,23 @@ contract RaindexV6TakeOrderBatchStateAdversarialTest is RaindexV6ExternalRealTes
         }
         assertEq(count, 1, "exactly one ContextV2 emitted per filled order");
     }
+
+    /// handleIO commits an order's calculate-phase `kvs` to the store BEFORE
+    /// running that order's handle-IO eval, so handle-IO sees its own calculate
+    /// `:set` within the same evaluation (the contract intent: "handle IO to see
+    /// a consistent view on sets from calculate IO"). An order whose calculate
+    /// sets key 0 to 5 and whose handle-IO requires get(0) == 5 fills only if
+    /// that ordering holds; deferring the commit to after the handle-IO eval
+    /// would make handle-IO read an unset 0 and revert.
+    function testHandleIOSeesSameOrderCalculateSet() external {
+        mockTransfers();
+        address o = owner("frank");
+        fund(o);
+        OrderV4[] memory list = new OrderV4[](1);
+        list[0] = addOrder(o, ":set(0 5),_ _:1 1;:ensure(equal-to(get(0) 5) \"hio sees calc\");");
+        assertTrue(
+            take(list).eq(LibDecimalFloat.packLossless(1, 0)),
+            "order fills only if handle-IO sees its own calculate set"
+        );
+    }
 }


### PR DESCRIPTION
## What

Add `testHandleIOSeesSameOrderCalculateSet` — pins the H01 invariant that an order's handle-IO sees its own calculate `:set` within the same evaluation.

## Why — a coverage gap found by mutation

`handleIO` commits the calculate-phase `kvs` to the store **before** running the handle-IO eval (contract comment: *"handle IO to see a consistent view on sets from calculate IO"*). That ordering was unpinned:
- *Dropping* the commit entirely → caught by ~18 tests.
- But **relocating** it to *after* the handle-IO eval (later orders still see the set; only the same order's handle-IO reads an unset `0`) → **survived the whole concrete suite**.

The new test fills an order whose calculate does `:set(0 5)` and whose handle-IO does `:ensure(equal-to(get(0) 5))` — it fills only if the ordering holds. Mutation-verified: under the relocate mutation it reverts (`hio sees calc`).

Part of a retroactive adversarial-mutation campaign over the H01 fix (#2617 / #2644). The rest of the H01 behaviours — calculate/handle-IO kvs commits, the maxRatio/zeroAmount untaken no-op skips, cross-owner isolation, same-owner threading, the repeated-order cap — are already densely covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test to verify correct execution ordering: order calculation phase data is committed to storage before the same order's input/output operations execute.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->