### PR TITLE
ci: share the rust cache key across the docs Vercel workflows

### DIFF
--- a/.github/workflows/vercel-docs-preview.yaml
+++ b/.github/workflows/vercel-docs-preview.yaml
@@ -40,7 +40,9 @@ jobs:
           gc-max-store-size-linux: 8G
       - uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: rust-${{ github.workflow }}
+          # Shared across the docs preview/prod workflows so a preview run (off
+          # main) restores the cache the prod run saves on main.
+          prefix-key: rust-vercel-docs
       - name: Cache npm
         uses: actions/cache@v4
         with:

--- a/.github/workflows/vercel-docs-preview.yaml
+++ b/.github/workflows/vercel-docs-preview.yaml
@@ -40,9 +40,11 @@ jobs:
           gc-max-store-size-linux: 8G
       - uses: Swatinem/rust-cache@v2
         with:
-          # Shared across the docs preview/prod workflows so a preview run (off
-          # main) restores the cache the prod run saves on main.
+          # Restore this branch's own cache if it has one, else fall back to the
+          # cache the prod run saves on main (shared prefix-key). save-if keeps
+          # this branch's cache warm across re-runs.
           prefix-key: rust-vercel-docs
+          save-if: true
       - name: Cache npm
         uses: actions/cache@v4
         with:

--- a/.github/workflows/vercel-docs-prod.yaml
+++ b/.github/workflows/vercel-docs-prod.yaml
@@ -37,7 +37,9 @@ jobs:
           gc-max-store-size-linux: 8G
       - uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: rust-${{ github.workflow }}
+          # Shared across the docs preview/prod workflows so a preview run (off
+          # main) restores the cache the prod run saves on main.
+          prefix-key: rust-vercel-docs
       - name: Cache npm
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
The docs **preview** and **prod** Vercel workflows key `Swatinem/rust-cache` with `rust-${{ github.workflow }}`. The two workflows have different names, so:
- `vercel-docs-prod` (runs on `main`, where rust-cache saves) saves under `rust-<prod-workflow-name>-…`
- `vercel-docs-preview` (runs off `main`, restore-only) looks under `rust-<preview-workflow-name>-…`

The keys never match, so the preview always reports the rust cache as **not found** and rebuilds from scratch. Use a shared literal `prefix-key: rust-vercel-docs` so the preview restores the cache prod saves on main.

(The nix-store cache is keyed by OS + nix hashes, not the workflow name, so it's unaffected. The webapp Vercel workflows and the rainix reusable workflow copy this same `${{ github.workflow }}` pattern — I'll fix those in their open PRs #2655 / rainix#220.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)