### PR TITLE
docs: document onTakeOrders2 permissionless-sweep intent (audit I01)

### DIFF
--- a/src/abstract/RaindexV6ArbOrderTaker.sol
+++ b/src/abstract/RaindexV6ArbOrderTaker.sol
@@ -64,8 +64,19 @@ abstract contract RaindexV6ArbOrderTaker is
     }
 
     /// @inheritdoc IRaindexV6OrderTaker
-    /// @dev Empty no-op. The contract holds no value between operations and the
-    /// caller chooses which raindex to interact with, so there is nothing to
-    /// protect via `msg.sender` validation here.
+    /// @dev Empty no-op, and intentionally permissionless: the contract holds no
+    /// value between operations and the caller chooses which raindex to interact
+    /// with, so there is nothing to protect via `msg.sender` validation.
+    ///
+    /// The permissionless entry is also the recovery path for value that reaches
+    /// the contract by accident. Unsolicited transfers cannot be prevented: ERC20
+    /// transfers have no recipient hook to revert in, and the arb legitimately
+    /// receives ERC20 and ETH mid-operation. Because anyone may call the
+    /// take-orders entrypoints, a stray balance is swept out by the next call
+    /// rather than stranded; gating this hook to an active orderbook callback
+    /// would instead brick such balances permanently. Concrete implementations
+    /// that move value here (e.g. the generic-pool variant's unlimited
+    /// approve-and-call with whole-ETH-balance forward) are safe only under this
+    /// no-value-between-operations invariant.
     function onTakeOrders2(address, address, Float, Float, bytes calldata) public virtual override {}
 }

--- a/src/lib/LibGenericPoolExchange.sol
+++ b/src/lib/LibGenericPoolExchange.sol
@@ -37,7 +37,10 @@ library LibGenericPoolExchange {
 
         // Approve-call-revoke: the caller controls spender and pool, which is
         // safe because the contract holds no tokens or ETH between arb
-        // operations — there is nothing for a malicious caller to extract.
+        // operations — there is nothing for a malicious caller to extract. Value
+        // sent here by accident is recoverable through this permissionless path
+        // rather than stranded; see `onTakeOrders2` on the base contract for why
+        // unsolicited transfers cannot be rejected and gating would brick them.
         IERC20(token).forceApprove(spender, type(uint256).max);
         //slither-disable-next-line unused-return
         pool.functionCallWithValue(encodedFunctionCall, address(this).balance);


### PR DESCRIPTION
Closes #2624.

I01 flags that `onTakeOrders2` is permissionless and the generic-pool variant exposes an arbitrary approve-and-call + whole-ETH-forward over any balance on the contract. The audit's recommendations don't hold up:
- **Can't reject ERC20 receives** — `transfer`/`transferFrom` have no recipient hook to revert in.
- **Can't reject ETH** — the arb legitimately receives ETH mid-operation (the exchange forwards `address(this).balance`).
- **Gating bricks funds** — the permissionless entry *is* the recovery path; gate it and accidentally-sent value is stranded forever instead of swept out by the next call.

So I01 is accept-by-design (the `#2610` zero-address guards are the appropriate hardening). This documents that intent + the accidental-value scenario in the NatSpec of the base `onTakeOrders2` and the `LibGenericPoolExchange` exchange comment, where future readers will see it.

Comments only — `bytecode_hash = "none"`, so the deterministic bytecode/addresses are unchanged (regenerating pointers produced no diff). No re-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded internal documentation clarifying contract behavior, including permissionless operation patterns and recovery mechanisms for unintended token transfers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->