### PR TITLE
docs: document the onTakeOrders2 callback partial state (audit I02)

### DIFF
--- a/src/concrete/raindex/RaindexV6.sol
+++ b/src/concrete/raindex/RaindexV6.sol
@@ -599,6 +599,15 @@ contract RaindexV6 is IRaindexV6, IMetaV1_2, ReentrancyGuard, Multicall, Raindex
 
         pushTokens(msg.sender, io.outputToken, totalTakerInput);
 
+        // Integrator note on the state observed inside `onTakeOrders2`: the
+        // orders are fully recorded and handled and the taker has received
+        // `io.outputToken`, but their `io.inputToken` payment has not been pulled
+        // yet and the vault-0 input settlements below have not run. For the
+        // duration of the callback the contract's actual token balance is below
+        // its internal vault accounting: `vaultBalance2` already reflects the
+        // post-trade balances, and `maxFlashLoan` returns a correspondingly
+        // reduced amount until settlement completes. Re-entering raindex from the
+        // callback is blocked by `nonReentrant`.
         if (config.data.length > 0) {
             IRaindexV6OrderTaker(msg.sender)
                 .onTakeOrders2(io.outputToken, io.inputToken, totalTakerInput, totalTakerOutput, config.data);


### PR DESCRIPTION
Closes #2625.

I02 asks that the contract state during the `onTakeOrders2` callback be documented for integrators. `takeOrders4` settles **push → callback → pull**: the taker receives `io.outputToken`, is called back, and only then pays `io.inputToken` (and the vault-0 input settlements run after that). So for the duration of the callback the contract's actual token balance is **below its internal vault accounting**.

This adds an integrator note at the callback site documenting exactly that:
- `vaultBalance2` already reflects the post-trade balances,
- `maxFlashLoan` returns a correspondingly reduced amount until settlement completes,
- re-entering raindex from the callback is blocked by `nonReentrant`.

The push-callback-pull ordering is intentional (the existing comment explains why: the taker can source their input via external trades inside the callback), so this is documentation only — no behavior change. `bytecode_hash = "none"`, so the deterministic bytecode/addresses are unchanged (regenerating pointers produced no diff). No re-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)