### PR TITLE
docs: document pull/pushTokens rounding policy + residual dust (audit L01)

### DIFF
--- a/src/concrete/raindex/RaindexV6.sol
+++ b/src/concrete/raindex/RaindexV6.sol
@@ -1114,6 +1114,15 @@ contract RaindexV6 is IRaindexV6, IMetaV1_2, ReentrancyGuard, Multicall, Raindex
 
     /// @dev Pulls `amount` of `token` from `account` via `safeTransferFrom`.
     /// Returns the fixed-decimal amount transferred and the token decimals.
+    ///
+    /// A lossy float->fixed-decimal conversion is rounded UP here so the contract
+    /// never pulls in less than the vault accounting credits. `pushTokens` rounds
+    /// DOWN for the same protocol-favoring reason. Together this keeps the
+    /// orderbook solvent — its real token balance is always >= the sum of the
+    /// vault balances — but each lossy conversion leaves a sub-token-unit residue
+    /// in the contract that is not attributed to any vault and has no recovery
+    /// path. Such dust is under one base unit per conversion and can never cause
+    /// insolvency.
     function pullTokens(address account, address token, Float amount) internal returns (uint256, uint8) {
         (TOFUOutcome tofuOutcome, uint8 decimals) = LibTOFUTokenDecimals.decimalsForToken(token);
         if (tofuOutcome != TOFUOutcome.Consistent && tofuOutcome != TOFUOutcome.Initial) {
@@ -1138,6 +1147,11 @@ contract RaindexV6 is IRaindexV6, IMetaV1_2, ReentrancyGuard, Multicall, Raindex
 
     /// @dev Pushes `amountFloat` of `token` to `account` via `safeTransfer`.
     /// Returns the fixed-decimal amount transferred and the token decimals.
+    ///
+    /// A lossy float->fixed-decimal conversion is truncated (rounded DOWN) here
+    /// so the contract never sends more than the vault accounting debits. See
+    /// `pullTokens` for the full rounding policy and its solvency / residual-dust
+    /// tradeoff.
     function pushTokens(address account, address token, Float amountFloat) internal returns (uint256, uint8) {
         (TOFUOutcome tofuOutcome, uint8 decimals) = LibTOFUTokenDecimals.decimalsForToken(token);
         if (tofuOutcome != TOFUOutcome.Consistent && tofuOutcome != TOFUOutcome.Initial) {


### PR DESCRIPTION
Closes #2623.

L01 notes that the conservative rounding in `pullTokens`/`pushTokens` traps orphaned dust, and recommends documenting the policy + considering a sweep. This documents the policy in the NatSpec of both functions:
- `pullTokens` rounds lossy float→fixed-decimal conversions **up** (contract never receives less than the accounting credits),
- `pushTokens` rounds **down** (never sends more than it debits),
- so the orderbook is always solvent (real balance ≥ Σ vault balances), at the cost of a sub-token-unit residue per lossy conversion that belongs to no vault and has no recovery path (bounded by < 1 base unit/conversion, never an insolvency risk).

The "consider a sweep" half is filed as a detailed follow-up: #2673 (the hard part is there's no per-token total obligation to compute the sweepable excess from — it needs a new accumulator).

Comment only — `bytecode_hash = "none"`, regenerating pointers produced no diff, so no behavior/bytecode change. No re-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)