### PR TITLE
ci: deploy-subgraph runs on the slim subgraph shell

### DIFF
--- a/.github/workflows/deploy-subgraph.yaml
+++ b/.github/workflows/deploy-subgraph.yaml
@@ -31,11 +31,9 @@ jobs:
           primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-
           gc-max-store-size-linux: 1G
-      # subgraph-deploy runs a forge build, which needs the soldeer dependencies
-      # installed. Without this every import fails to resolve and the build aborts.
-      - run: nix develop -c forge soldeer install
-      - run: nix develop -c forge build
-      - run: nix develop -c subgraph-deploy
+      # subgraph-deploy builds from the committed subgraph/abis + subgraph/generated,
+      # so it needs no forge build and runs on the slim subgraph shell.
+      - run: nix develop github:rainlanguage/rainix#subgraph-shell -c subgraph-deploy
       # forwards status to telegram chat if this ci fails or gets canceled, only runs for default branch
       - name: Forward CI Status
         if: always()


### PR DESCRIPTION
Closes #2601.

Follow-up to rainlanguage/rainix#222 (merged), which made `subgraph-deploy` build from the committed `subgraph/abis` + `subgraph/generated` instead of running a forge build.

So this deploy workflow no longer needs the full devshell or a forge build:
- drops `forge soldeer install` + `forge build`,
- runs `subgraph-deploy` on `github:rainlanguage/rainix#subgraph-shell` (mirroring `test-subgraph`).

This clears the **last full-devshell (`nix develop -c …`) holdout** in `.github/workflows/` — the residual flagged when reviewing #2601. The deploy is `workflow_dispatch`, so it isn't exercised by PR CI; it'll run on the next manual dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow to utilize pre-committed artifacts, streamlining the subgraph deployment process and reducing build steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->