### PR TITLE
test: deploy TOFU in the RouteProcessor onTakeOrders2 fuzz setup

### DIFF
--- a/test/concrete/arb/RouteProcessorRaindexV6ArbOrderTaker.onTakeOrders2Fuzz.t.sol
+++ b/test/concrete/arb/RouteProcessorRaindexV6ArbOrderTaker.onTakeOrders2Fuzz.t.sol
@@ -10,6 +10,8 @@ import {LibDecimalFloat} from "rain-math-float-0.1.1/src/lib/LibDecimalFloat.sol
 import {LibRaindexDeploy} from "../../../src/lib/deploy/LibRaindexDeploy.sol";
 import {MockToken} from "test/util/concrete/MockToken.sol";
 import {MockRouteProcessor} from "test/util/concrete/MockRouteProcessor.sol";
+import {LibRainDeploy} from "rain-deploy-0.1.2/src/lib/LibRainDeploy.sol";
+import {LibTOFUTokenDecimals} from "rain-tofu-erc20-decimals-0.1.1/src/lib/LibTOFUTokenDecimals.sol";
 
 /// @title RouteProcessorRaindexV6ArbOrderTakerOnTakeOrders2FuzzTest
 /// @notice Audit A07-3 (#2534): `onTakeOrders2` had only concrete coverage
@@ -39,6 +41,13 @@ contract RouteProcessorRaindexV6ArbOrderTakerOnTakeOrders2FuzzTest is Test {
         int256 inputExponent;
         int256 outputCoefficient;
         int256 outputExponent;
+    }
+
+    /// `onTakeOrders2` resolves token decimals via the deployed TOFU contract,
+    /// so it must exist before the callback runs.
+    function setUp() public {
+        LibRainDeploy.etchZoltuFactory(vm);
+        LibRainDeploy.deployZoltu(LibTOFUTokenDecimals.TOFU_DECIMALS_EXPECTED_CREATION_CODE);
     }
 
     /// Mirror the contract's conversions in a separate frame: the input side is


### PR DESCRIPTION
Fixes a regression on `main`. L03 (#2662) routed `RouteProcessorRaindexV6ArbOrderTaker.onTakeOrders2` through `LibTOFUTokenDecimals.safeDecimalsForToken`, which reverts `TOFUTokenDecimalsNotDeployed` when the TOFU contract isn't deployed. Seven of the eight RouteProcessor test files already deploy it; the `onTakeOrders2` fuzz test didn't — so `testOnTakeOrders2ForwardsConvertedAmounts` has been red on `main` since #2662 merged (it got merged --admin over what I misread as only the stale pre-deploy fork-test red — my miss).

Adds a `setUp` that etches the zoltu factory and deploys the TOFU contract (matching the sibling tests). Verified: the fuzz test passes (200 runs), concrete arb 30/30, abstract arb 28/28.

This also unblocks #2675 (and any other branch off main), which was red purely because of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test setup and initialization procedures for route processor validation to ensure proper handling of token decimal infrastructure during automated fuzz testing, improving overall test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->