### PR TITLE
ci(soldeer): exclude .env.example from the published Soldeer package

### DIFF
--- a/.soldeerignore
+++ b/.soldeerignore
@@ -8,6 +8,8 @@
 .cargo
 .coderabbit.yaml
 .devcontainer.json
+.env
+.env.example
 .envrc
 .gas-snapshot
 .git


### PR DESCRIPTION
The soldeer autopublish (rainix#221) `push` aborts in CI on soldeer's interactive **sensitive-files** warning (`error during IO operation: not connected` — no stdin) because the package includes `.env.example` (soldeer flags `.env*`). This is why raindex's registry is stuck at `0.1.0` while `sol-v0.1.1` is tagged.

Fix: exclude `.env`/`.env.example` via `.soldeerignore` so the package is clean and the push runs non-interactively — **not** `--skip-warnings` (that warning exists to stop publishing secrets).

Verified locally: `forge soldeer push --dry-run` zip now has **no** env/secret files (38 entries, was 40). Pairs with the bump-logic fix rainix#223; once both land, the next raindex push to main publishes `0.1.2` cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)