### PR TITLE
ci(vercel): share one rust/wasm cache across preview + prod

### DIFF
--- a/.github/workflows/vercel-preview.yaml
+++ b/.github/workflows/vercel-preview.yaml
@@ -59,7 +59,9 @@ jobs:
           gc-max-store-size-linux: 1G
       - uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: rust-${{ github.workflow }}
+          # Stable shared-key (same in vercel-prod.yaml) so preview + prod share
+          # one warm wasm/cargo cache instead of a separate per-workflow one.
+          shared-key: vercel-webapp
       - name: Cache npm
         uses: actions/cache@v4
         with:

--- a/.github/workflows/vercel-prod.yaml
+++ b/.github/workflows/vercel-prod.yaml
@@ -42,7 +42,9 @@ jobs:
           gc-max-store-size-linux: 1G
       - uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: rust-${{ github.workflow }}
+          # Stable shared-key (same in vercel-preview.yaml) so preview + prod
+          # share one warm wasm/cargo cache instead of a separate per-workflow one.
+          shared-key: vercel-webapp
       - name: Cache npm
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
`vercel-preview.yaml` and `vercel-prod.yaml` both keyed `Swatinem/rust-cache` on `prefix-key: rust-${{ github.workflow }}` — and `github.workflow` differs between them ("…Preview…" vs "…Production…"), so each kept a **separate** rust-cache and ran its own **cold** wasm/cargo compile (the dominant cost of the ~30-min webapp build).

They build the identical wasm, so replace the per-workflow prefix with a stable **`shared-key: vercel-webapp`** (same in both). After either workflow warms the cache, the other restores it instead of recompiling — roughly halving the cold wasm builds.

Doesn't change correctness; first run after a Cargo.lock change is still cold (unavoidable), but cross-workflow reuse is the win. (Separate from #2655, which added the caches in the first place.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)