### PR TITLE
ci(vercel): path-filter preview/prod deploy to webapp-relevant changes

### DIFF
--- a/.github/workflows/vercel-preview.yaml
+++ b/.github/workflows/vercel-preview.yaml
@@ -19,6 +19,20 @@ on:
   push:
     branches-ignore:
       - main
+    # Only build/deploy a preview when something webapp-relevant changed. The
+    # webapp build pulls the wasm bindings (crates/**, incl. committed abis),
+    # the JS workspaces (packages/**), deps, the nix toolchain, and the build
+    # script — sol-only / CI / docs / audit pushes can't change it, so skip the
+    # ~30-min build for them. (Not a required check, so skipping is safe.)
+    paths:
+      - 'packages/**'
+      - 'crates/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'flake.nix'
+      - 'flake.lock'
+      - 'script/vercel-build.sh'
+      - '.github/workflows/vercel-preview.yaml'
 concurrency:
   group: ${{ format('{0}-vercel-preview', github.ref) }}
   cancel-in-progress: true

--- a/.github/workflows/vercel-prod.yaml
+++ b/.github/workflows/vercel-prod.yaml
@@ -6,6 +6,18 @@ on:
   push:
     branches:
       - main
+    # Only redeploy prod when something webapp-relevant changed (see
+    # vercel-preview.yaml for the rationale) — a sol-only main merge shouldn't
+    # rebuild + redeploy the webapp.
+    paths:
+      - 'packages/**'
+      - 'crates/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'flake.nix'
+      - 'flake.lock'
+      - 'script/vercel-build.sh'
+      - '.github/workflows/vercel-prod.yaml'
 jobs:
   Deploy-Preview:
     permissions:


### PR DESCRIPTION
The slow ~30-min check on raindex PRs is **Deploy-Preview-Push** (wasm + 3 JS workspace builds + vercel deploy). Two facts make it cheap to fix:

1. It is **not a required merge check** (required = `test`, `subgraph-test`, `test-js-bindings`, `wasm-artifacts`, `wasm-browser-test`, `wasm-test`).
2. `vercel-preview`/`vercel-prod` had **no `paths:` filter** — they ran on *every* branch/main push.

So sol-only / CI / `.soldeerignore` / audit / subgraph PRs were each paying ~30 min of pointless webapp build. This adds a `paths:` allowlist (`packages/**`, `crates/**` incl. committed abis, deps, nix toolchain, the build script, the workflow file) so the preview/prod build only runs when something webapp-relevant actually changes. Since it's not required, skipping it on non-matching PRs is safe.

Pairs with #2681 (shared wasm cache). Net: most PRs skip the 30-min build entirely; webapp PRs still get a (now cache-shared) preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD pipeline efficiency by adding targeted path filters to deployment workflows. Preview and production deployments now trigger only when relevant source code or configuration files are modified, reducing unnecessary deployment cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->