### PR TITLE
pin raindex 0.1.2 deployment constants

### DIFF
--- a/src/lib/deploy/LibRaindexDeploy.sol
+++ b/src/lib/deploy/LibRaindexDeploy.sol
@@ -50,6 +50,15 @@ library LibRaindexDeploy {
     bytes32 constant RAINDEX_DEPLOYED_CODEHASH_0_1_0 =
         0xf5d6441f79933283777975573d385f5fc48c71f50ec85ef900dc947995e2f33d;
 
+    /// The deployed address of the `RaindexV6` contract at the published `0.1.2`
+    /// tag.
+    address constant RAINDEX_DEPLOYED_ADDRESS_0_1_2 = 0x4F4527919DA654C1718Ca6Ef194F6547226685f6;
+
+    /// The runtime code hash of the `RaindexV6` contract at the published `0.1.2`
+    /// tag.
+    bytes32 constant RAINDEX_DEPLOYED_CODEHASH_0_1_2 =
+        0xab8c608cd668d2c2bcef0188d012a818b5c909f82257ccb8cdb042715e394ec7;
+
     /// The address of the `RaindexV6SubParser` contract when deployed with
     /// the rain standard zoltu deployer.
     address constant SUB_PARSER_DEPLOYED_ADDRESS = SUB_PARSER_ADDR;
@@ -67,6 +76,15 @@ library LibRaindexDeploy {
     bytes32 constant SUB_PARSER_DEPLOYED_CODEHASH_0_1_0 =
         0x59e436b1a58c24ce88745ff6a49800ae74b98ac6c1f78032c509ec926de32140;
 
+    /// The deployed address of the `RaindexV6SubParser` contract at the
+    /// published `0.1.2` tag.
+    address constant SUB_PARSER_DEPLOYED_ADDRESS_0_1_2 = 0x09Bc7AF266012F44fb41D8Bd682da931666605e1;
+
+    /// The runtime code hash of the `RaindexV6SubParser` contract at the
+    /// published `0.1.2` tag.
+    bytes32 constant SUB_PARSER_DEPLOYED_CODEHASH_0_1_2 =
+        0x704aadc1ed56f63ff918ab219e6681a5d2851d774e2ee136bbe7904ea3b2fdcd;
+
     /// The address of the `RouteProcessor4` contract when deployed with the
     /// rain standard zoltu deployer.
     address constant ROUTE_PROCESSOR_DEPLOYED_ADDRESS = ROUTE_PROCESSOR_ADDR;
@@ -82,6 +100,15 @@ library LibRaindexDeploy {
     /// The runtime code hash of the `RouteProcessor4` contract at the published
     /// `0.1.0` tag.
     bytes32 constant ROUTE_PROCESSOR_DEPLOYED_CODEHASH_0_1_0 =
+        0xeb3745a79c6ba48e8767b9c355b8e7b79f9d6edeca004e4bb91be4de515a7eeb;
+
+    /// The deployed address of the `RouteProcessor4` contract at the published
+    /// `0.1.2` tag. (Unchanged from `0.1.0`.)
+    address constant ROUTE_PROCESSOR_DEPLOYED_ADDRESS_0_1_2 = 0x6E2d0e71d900474b262E545Bc4C98b71ab368d21;
+
+    /// The runtime code hash of the `RouteProcessor4` contract at the published
+    /// `0.1.2` tag. (Unchanged from `0.1.0`.)
+    bytes32 constant ROUTE_PROCESSOR_DEPLOYED_CODEHASH_0_1_2 =
         0xeb3745a79c6ba48e8767b9c355b8e7b79f9d6edeca004e4bb91be4de515a7eeb;
 
     /// The address of the `GenericPoolRaindexV6ArbOrderTaker` contract when
@@ -101,6 +128,15 @@ library LibRaindexDeploy {
     bytes32 constant GENERIC_POOL_ARB_ORDER_TAKER_DEPLOYED_CODEHASH_0_1_0 =
         0xba5ce714baf93e1405a4e93d4ace1717b8ff04ee4fcfbfcff6ada6210928397c;
 
+    /// The deployed address of the `GenericPoolRaindexV6ArbOrderTaker` contract
+    /// at the published `0.1.2` tag.
+    address constant GENERIC_POOL_ARB_ORDER_TAKER_DEPLOYED_ADDRESS_0_1_2 = 0xdD8a5075476dbE40EDaB9b711133828Fdc74c972;
+
+    /// The runtime code hash of the `GenericPoolRaindexV6ArbOrderTaker` contract
+    /// at the published `0.1.2` tag.
+    bytes32 constant GENERIC_POOL_ARB_ORDER_TAKER_DEPLOYED_CODEHASH_0_1_2 =
+        0xb3bb9236040b5fd7354c56923dd6ddf790e8fa86638d8091abc5e1958227bf4f;
+
     /// The address of the `RouteProcessorRaindexV6ArbOrderTaker` contract
     /// when deployed with the rain standard zoltu deployer.
     address constant ROUTE_PROCESSOR_ARB_ORDER_TAKER_DEPLOYED_ADDRESS = RP_ARB_OT_ADDR;
@@ -119,6 +155,16 @@ library LibRaindexDeploy {
     bytes32 constant ROUTE_PROCESSOR_ARB_ORDER_TAKER_DEPLOYED_CODEHASH_0_1_0 =
         0x728605dabf8d0f4235999e961f288b6e05765c8c210a302e81f1b4fea2754bc8;
 
+    /// The deployed address of the `RouteProcessorRaindexV6ArbOrderTaker`
+    /// contract at the published `0.1.2` tag.
+    address constant ROUTE_PROCESSOR_ARB_ORDER_TAKER_DEPLOYED_ADDRESS_0_1_2 =
+        0xaaA2266C98DD65e51f90079f3Dd42464f8A8BaD5;
+
+    /// The runtime code hash of the `RouteProcessorRaindexV6ArbOrderTaker`
+    /// contract at the published `0.1.2` tag.
+    bytes32 constant ROUTE_PROCESSOR_ARB_ORDER_TAKER_DEPLOYED_CODEHASH_0_1_2 =
+        0x8181a5b98afff1113b831d4dc7f912e3e4a24bd440526b1350dbd7111df7284c;
+
     /// The address of the `GenericPoolRaindexV6FlashBorrower` contract when
     /// deployed with the rain standard zoltu deployer.
     address constant GENERIC_POOL_FLASH_BORROWER_DEPLOYED_ADDRESS = GENERIC_POOL_FB_ADDR;
@@ -135,6 +181,15 @@ library LibRaindexDeploy {
     /// at the published `0.1.0` tag.
     bytes32 constant GENERIC_POOL_FLASH_BORROWER_DEPLOYED_CODEHASH_0_1_0 =
         0xa1bf69e21c50d0f6c30fb102d78c768de58f733ca86ee745560aff7069c155c2;
+
+    /// The deployed address of the `GenericPoolRaindexV6FlashBorrower` contract
+    /// at the published `0.1.2` tag.
+    address constant GENERIC_POOL_FLASH_BORROWER_DEPLOYED_ADDRESS_0_1_2 = 0x3A60DEa68c69B9C2338F12235fd87320D17bCF6a;
+
+    /// The runtime code hash of the `GenericPoolRaindexV6FlashBorrower` contract
+    /// at the published `0.1.2` tag.
+    bytes32 constant GENERIC_POOL_FLASH_BORROWER_DEPLOYED_CODEHASH_0_1_2 =
+        0xe887c3af02ae0170b43a7c70a291032f31b7709ec1088e66119cd1253600c0f8;
 
     uint256 constant RAINDEX_START_BLOCK_ARBITRUM = 469964122;
     uint256 constant RAINDEX_START_BLOCK_BASE = 46893385;


### PR DESCRIPTION
The soldeer autopublish published `raindex 0.1.2` (real contract changes since 0.1.0 — M01 + arb5). `testAllPublishedSoldeerTagsHaveAFullConstantSuite` requires **every published soldeer tag** to have a full pinned deploy-constant suite in `LibRaindexDeploy`, so the missing `*_0_1_2` constants turned that test red on **main and every open PR**.

This pins the 12 `*_0_1_2` constants (address + codehash for all six deployed contracts), values taken from the current `src/generated/*.pointers.sol` (= the 0.1.2 bytecode). Sanity-checked: the two arb addresses match the contracts I deployed for the arb5 redeploy (`0xdD8a50…`, `0xaaA226…`).

- **5 of 6 changed** since 0.1.0 (RAINDEX, SUB_PARSER, both arb-takers, FLASH_BORROWER); only RouteProcessor4 is unchanged.
- All six are **already deployed on-chain** (`testProdDeploy*` is green), so no new deploy is needed — this is constants-only.
- `script/check-published-deploy-constants.sh` now returns `OK`.

Unblocks main + the other open PRs (#2682).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added version 0.1.2 deployment configuration support for Raindex ecosystem components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->