### PR TITLE
script: build-start-blocks.sh to refresh deploy-block bookkeeping (#2687)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,16 @@ address + codehash. Do the whole cascade without asking:
    - A deploy run shows `completed/failure` but the **on-chain deploy
      succeeded** if the log contains `ONCHAIN EXECUTION COMPLETE & SUCCESSFUL` —
      only the etherscan `--verify` step failed (cosmetic).
-3. **Re-check** — `testProdDeploy*` ("X not deployed") fork-tests stay red until
+3. **Refresh start-block bookkeeping (only if RaindexV6 moved)** — a redeploy of
+   the orderbook changes `RAINDEX_DEPLOYED_ADDRESS`, so the subgraph indexing
+   bookkeeping (`RAINDEX_START_BLOCK_*` constants, `subgraph/networks.json`,
+   `subgraph/subgraph.yaml`) goes stale and reds `testIsStartBlock*` /
+   `testNetworksJson*` / `testSubgraphYamlAddress`. Run
+   `script/build-start-blocks.sh` (binary-searches each chain's new deploy block
+   over an archive RPC and rewrites all three). Needs per-chain archive RPCs via
+   the foundry `rpc_endpoints` env vars (it falls back to public endpoints). Arb
+   redeploys that don't move RaindexV6 (e.g. a LibRaindexArb change) skip this.
+4. **Re-check** — `testProdDeploy*` ("X not deployed") fork-tests stay red until
    the new addresses have code on-chain. After deploying, re-trigger PR CI with
    an empty commit.
 

--- a/script/build-start-blocks.sh
+++ b/script/build-start-blocks.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+# SPDX-License-Identifier: LicenseRef-DCL-1.0
+# SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+
+# Refresh the RaindexV6 deploy-block bookkeeping after a redeploy.
+#
+# Finds the exact block at which the currently-pinned RaindexV6 was deployed on
+# each mainnet by binary-searching `eth_getCode` over an archive RPC, then
+# rewrites the new per-chain blocks + the current pinned address into:
+#   - the RAINDEX_START_BLOCK_* constants in src/lib/deploy/LibRaindexDeploy.sol
+#   - subgraph/networks.json (address + startBlock per network)
+#   - subgraph/subgraph.yaml (data source address)
+#
+# RaindexV6 is CREATE2-deployed, so its address only ever holds the one bytecode
+# it was created with: the first block with code at that address IS the deploy
+# block. Per-chain RPCs come from the foundry rpc_endpoints env vars, falling
+# back to public archive endpoints. Set BUILD_START_BLOCKS_INPUT to a file of
+# `STARTBLOCK <network> <block>` lines to skip the (RPC-bound) search, e.g. for
+# tests.
+set -euo pipefail
+
+LIB="src/lib/deploy/LibRaindexDeploy.sol"
+NET="subgraph/networks.json"
+YAML="subgraph/subgraph.yaml"
+PTR="src/generated/RaindexV6.pointers.sol"
+
+ARB_RPC="${ARBITRUM_RPC_URL:-https://arbitrum.drpc.org}"
+BASE_RPC="${BASE_RPC_URL:-https://mainnet.base.org}"
+FLARE_RPC="${FLARE_RPC_URL:-https://flare-api.flare.network/ext/C/rpc}"
+POLY_RPC="${POLYGON_RPC_URL:-https://polygon.drpc.org}"
+
+ADDR=$(grep -aoE 'DEPLOYED_ADDRESS = address\(0x[0-9a-fA-F]{40}' "$PTR" | grep -aoE '0x[0-9a-fA-F]{40}')
+[ -n "$ADDR" ] || { echo "could not read RAINDEX_DEPLOYED_ADDRESS from $PTR" >&2; exit 1; }
+
+# rpc_call <rpc> <method> <params-json> -> raw JSON (empty on transport error).
+rpc_call() {
+    curl -fsSL -m 25 -X POST "$1" -H 'Content-Type: application/json' \
+        -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"$2\",\"params\":$3}" 2>/dev/null || true
+}
+
+# code_at <rpc> <addr> <block-dec> -> yes | no | err. Distinguishes an RPC error
+# (retryable) from a genuinely empty account, so the search never mistakes an
+# archive-window/timeout boundary for the deploy block.
+code_at() {
+    local hex res
+    hex=$(printf '0x%x' "$3")
+    res=$(rpc_call "$1" eth_getCode "[\"$2\",\"$hex\"]")
+    case "$res" in
+    *'"result":"0x"'*) echo no ;;
+    *'"result":"0x'*) echo yes ;;
+    *) echo err ;;
+    esac
+}
+
+head_of() {
+    local res
+    res=$(rpc_call "$1" eth_blockNumber "[]")
+    printf '%d' "$(printf '%s' "$res" | grep -aoE '"result":"0x[0-9a-f]+"' | grep -aoE '0x[0-9a-f]+')"
+}
+
+# find_deploy_block <rpc> <addr> -> first block with code (the CREATE2 deploy).
+find_deploy_block() {
+    local rpc=$1 addr=$2 head delta floor lo hi mid errs=0
+    head=$(head_of "$rpc")
+    [ "${head:-0}" -gt 0 ] || { echo "could not read head block from $rpc" >&2; return 1; }
+    [ "$(code_at "$rpc" "$addr" "$head")" = "yes" ] || { echo "no code for $addr at head on $rpc" >&2; return 1; }
+
+    # Walk a lower bound back in growing steps until the address has no code,
+    # so the search holds however long ago the deploy happened.
+    delta=250000
+    floor=$(( head > delta ? head - delta : 1 ))
+    while [ "$floor" -gt 1 ] && [ "$(code_at "$rpc" "$addr" "$floor")" = "yes" ]; do
+        delta=$(( delta * 4 ))
+        floor=$(( head > delta ? head - delta : 1 ))
+    done
+
+    lo=$floor; hi=$head
+    while [ "$lo" -lt "$hi" ]; do
+        mid=$(( (lo + hi) / 2 ))
+        case "$(code_at "$rpc" "$addr" "$mid")" in
+        yes) hi=$mid ;;
+        no) lo=$(( mid + 1 )) ;;
+        err)
+            errs=$(( errs + 1 ))
+            [ "$errs" -gt 12 ] && { echo "too many RPC errors searching $rpc" >&2; return 1; }
+            sleep 2
+            ;;
+        esac
+    done
+
+    # Verify the boundary on a second, independent read to catch load-balanced
+    # archives that answer the same historical block inconsistently.
+    [ "$(code_at "$rpc" "$addr" "$lo")" = "yes" ] || { echo "boundary check failed: no code at $lo on $rpc" >&2; return 1; }
+    [ "$lo" -le 1 ] || [ "$(code_at "$rpc" "$addr" "$(( lo - 1 ))")" = "no" ] \
+        || { echo "boundary check failed: code already at $(( lo - 1 )) on $rpc" >&2; return 1; }
+    echo "$lo"
+}
+
+if [ -n "${BUILD_START_BLOCKS_INPUT:-}" ]; then
+    OUT=$(cat "$BUILD_START_BLOCKS_INPUT")
+else
+    echo "finding RaindexV6 ($ADDR) deploy block on each chain..." >&2
+    OUT="STARTBLOCK arbitrum $(find_deploy_block "$ARB_RPC" "$ADDR")
+STARTBLOCK base $(find_deploy_block "$BASE_RPC" "$ADDR")
+STARTBLOCK flare $(find_deploy_block "$FLARE_RPC" "$ADDR")
+STARTBLOCK polygon $(find_deploy_block "$POLY_RPC" "$ADDR")"
+fi
+
+get() { printf '%s\n' "$OUT" | grep -aoE "STARTBLOCK $1 [0-9]+" | grep -aoE '[0-9]+$' | head -1; }
+ARB=$(get arbitrum); BASE=$(get base); FLARE=$(get flare); POLY=$(get polygon)
+for pair in "arbitrum:$ARB" "base:$BASE" "flare:$FLARE" "polygon:$POLY"; do
+    [ -n "${pair#*:}" ] || { echo "missing start block for ${pair%%:*}; finder output:" >&2; printf '%s\n' "$OUT" >&2; exit 1; }
+done
+
+sed -i -E "s/(RAINDEX_START_BLOCK_ARBITRUM = )[0-9]+/\1${ARB}/" "$LIB"
+sed -i -E "s/(RAINDEX_START_BLOCK_BASE = )[0-9]+/\1${BASE}/" "$LIB"
+sed -i -E "s/(RAINDEX_START_BLOCK_FLARE = )[0-9]+/\1${FLARE}/" "$LIB"
+sed -i -E "s/(RAINDEX_START_BLOCK_POLYGON = )[0-9]+/\1${POLY}/" "$LIB"
+
+sed -i -E "s/(address: \")0x[0-9a-fA-F]+(\")/\1${ADDR}\2/" "$YAML"
+
+jq --arg addr "$ADDR" --argjson arb "$ARB" --argjson base "$BASE" --argjson flare "$FLARE" --argjson poly "$POLY" '
+    ."arbitrum-one".Raindex = {address: $addr, startBlock: $arb}
+    | .matic.Raindex = {address: $addr, startBlock: $poly}
+    | .base.Raindex = {address: $addr, startBlock: $base}
+    | .flare.Raindex = {address: $addr, startBlock: $flare}
+' "$NET" >"${NET}.tmp" && mv "${NET}.tmp" "$NET"
+
+echo "start blocks: arbitrum=${ARB} base=${BASE} flare=${FLARE} polygon=${POLY}  address=${ADDR}"


### PR DESCRIPTION
Closes #2687.

A RaindexV6 redeploy moves `RAINDEX_DEPLOYED_ADDRESS`, which silently invalidates the subgraph-indexing bookkeeping — the `RAINDEX_START_BLOCK_*` constants, `subgraph/networks.json`, and `subgraph/subgraph.yaml` — redding `testIsStartBlock*`, `testNetworksJson*`, and `testSubgraphYamlAddress` until someone manually hunts down the new per-chain deploy blocks (this was most of the work on the last orderbook redeploy).

`script/build-start-blocks.sh` scripts it:
- **Finds** the deploy block on each mainnet by binary-searching `eth_getCode` for the first block with code at the (CREATE2-deterministic) raindex address.
- **Writes** the new blocks + current pinned address into all three files.

Correctness lessons from the manual run, baked in:
- **error-vs-empty**: distinguishes an RPC error from a genuinely empty account, so the search never converges on an archive-window/timeout boundary instead of the deploy block.
- **boundary verification**: re-checks `code at N` and `no code at N-1` on an independent read, to catch load-balanced archives that answer the same historical block inconsistently.
- **adaptive lower bound**: walks back in growing steps until the address has no code, so it works however long ago the deploy happened.

**Validated end-to-end against the live `0.1.5` raindex (`0xE020…`)**: it independently re-derives `arbitrum 471755491 / base 47118075 / flare 62584927 / polygon 88213689` and produces a **zero diff** against the committed bookkeeping. A `BUILD_START_BLOCKS_INPUT` override exercises the sed/jq writer without RPC (idempotent on known values; writes on changed ones).

Tooling/docs only (`script/` + `CLAUDE.md` are `.soldeerignore`'d) — no bytecode change, no redeploy. The deploy runbook now points at it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contract deployment runbook to include start-block refresh step for RaindexV6 redeployments, addressing potential subgraph indexing issues.

* **New Features**
  * Added automated script to determine RaindexV6 CREATE2 deploy block per chain using archive RPC endpoints and update relevant configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->