### PR TITLE
Fix missing chainId deser error when loading tokens list (#2525)

### DIFF
--- a/crates/common/src/local_db/query/fetch_all_tokens/mod.rs
+++ b/crates/common/src/local_db/query/fetch_all_tokens/mod.rs
@@ -81,4 +81,29 @@ mod tests {
         assert!(stmt.sql.contains("raindex_address IN"));
         assert_eq!(stmt.params.len(), 1);
     }
+
+    #[test]
+    fn selects_columns_aliased_to_camel_case() {
+        let stmt =
+            build_fetch_all_tokens_stmt(&FetchAllTokensArgs::default()).expect("should build");
+        assert!(stmt.sql.contains("AS chainId"));
+        assert!(stmt.sql.contains("AS raindexAddress"));
+        assert!(stmt.sql.contains("AS tokenAddress"));
+    }
+
+    #[test]
+    fn deserializes_camel_case_db_row() {
+        let json = r#"{
+            "chainId": 42161,
+            "raindexAddress": "0x0000000000000000000000000000000000000001",
+            "tokenAddress": "0x0000000000000000000000000000000000000002",
+            "name": "Token",
+            "symbol": "TKN",
+            "decimals": 18
+        }"#;
+        let token: LocalDbToken = serde_json::from_str(json).expect("should deserialize");
+        assert_eq!(token.chain_id, 42161);
+        assert_eq!(token.name, "Token");
+        assert_eq!(token.decimals, 18);
+    }
 }

--- a/crates/common/src/local_db/query/fetch_all_tokens/mod.rs
+++ b/crates/common/src/local_db/query/fetch_all_tokens/mod.rs
@@ -103,7 +103,38 @@ mod tests {
         }"#;
         let token: LocalDbToken = serde_json::from_str(json).expect("should deserialize");
         assert_eq!(token.chain_id, 42161);
+        assert_eq!(
+            token.raindex_address,
+            "0x0000000000000000000000000000000000000001"
+                .parse::<Address>()
+                .unwrap()
+        );
+        assert_eq!(
+            token.token_address,
+            "0x0000000000000000000000000000000000000002"
+                .parse::<Address>()
+                .unwrap()
+        );
         assert_eq!(token.name, "Token");
+        assert_eq!(token.symbol, "TKN");
         assert_eq!(token.decimals, 18);
+    }
+
+    #[test]
+    fn rejects_snake_case_db_row() {
+        let json = r#"{
+            "chain_id": 42161,
+            "raindex_address": "0x0000000000000000000000000000000000000001",
+            "token_address": "0x0000000000000000000000000000000000000002",
+            "name": "Token",
+            "symbol": "TKN",
+            "decimals": 18
+        }"#;
+        let err = serde_json::from_str::<LocalDbToken>(json)
+            .expect_err("snake_case keys must not deserialize");
+        assert!(
+            err.to_string().contains("missing field `chainId`"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/crates/common/src/local_db/query/fetch_all_tokens/query.sql
+++ b/crates/common/src/local_db/query/fetch_all_tokens/query.sql
@@ -1,4 +1,10 @@
-SELECT DISTINCT chain_id, raindex_address, token_address, name, symbol, decimals
+SELECT DISTINCT
+  chain_id AS chainId,
+  raindex_address AS raindexAddress,
+  token_address AS tokenAddress,
+  name,
+  symbol,
+  decimals
 FROM erc20_tokens
 WHERE 1=1
   /*CHAIN_IDS_CLAUSE*/


### PR DESCRIPTION
## Summary

Fixes #2525 — "Deserialization error: missing field `chainId` when loading tokens list".

The local-database tokens-list query (`fetch_all_tokens`) selected its columns with their raw snake_case names:

```sql
SELECT DISTINCT chain_id, raindex_address, token_address, name, symbol, decimals
```

The rows are returned by the JS SQLite driver keyed by the SQL column names verbatim, then deserialized into `LocalDbToken`, which uses `#[serde(rename_all = "camelCase")]` and therefore expects `chainId`, `raindexAddress`, `tokenAddress`. The key mismatch produced `missing field chainId`, so the tokens list failed to load even though orders/orderbook still rendered.

Every other local-db query already aliases its output columns to camelCase (`o.chain_id AS chainId`, `o.raindex_address AS raindexAddress`, ...). This query was the only one that did not. The fix applies the same aliasing.

## Changes

- `crates/common/src/local_db/query/fetch_all_tokens/query.sql`: alias `chain_id`, `raindex_address`, `token_address` to camelCase in the SELECT (WHERE/ORDER BY keep the real column names).
- `crates/common/src/local_db/query/fetch_all_tokens/mod.rs`: regression test `selects_columns_aliased_to_camel_case` (fails before the fix with `assertion failed: stmt.sql.contains("AS chainId")`) plus a `deserializes_camel_case_db_row` deser test over a `chainId` fixture.

## Verification

- Regression test fails on the unaliased SQL and passes with the fix.
- `cargo test -p raindex_common --lib local_db::query::fetch_all_tokens` — 5 passed, 0 failed.
- `cargo fmt --all`, clippy clean.

No Solidity, pointer, constant, or public-API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for SQL column aliasing and JSON deserialization, ensuring correct data parsing when fetching tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->