### PR TITLE
Add SQLite PRAGMA application_id + user_version schema-version guard

### DIFF
--- a/crates/common/src/local_db/executor.rs
+++ b/crates/common/src/local_db/executor.rs
@@ -1,8 +1,10 @@
 use super::functions;
+use super::query::create_tables::RAINDEX_APPLICATION_ID;
 use super::query::{
     FromDbJson, LocalDbQueryError, LocalDbQueryExecutor, SqlStatement, SqlStatementBatch, SqlValue,
 };
 use async_trait::async_trait;
+use raindex_app_settings::local_db_manifest::DB_SCHEMA_VERSION;
 use rusqlite::{types::ValueRef, Connection};
 use serde_json::{json, Map, Value};
 use std::convert::TryFrom;
@@ -61,7 +63,51 @@ fn open_connection(db_path: &Path) -> Result<Connection, LocalDbQueryError> {
     functions::register_all(&conn).map_err(|e| {
         LocalDbQueryError::database(format!("Failed to register sqlite functions: {e}"))
     })?;
+    verify_schema_guard(&conn)?;
     Ok(conn)
+}
+
+/// Structural schema-version guard read from the SQLite file header on every
+/// connection open. `application_id` labels the file as a raindex local-db and
+/// `user_version` carries the schema version; both are stamped by
+/// `create_tables` (see `query.sql`) and survive table corruption.
+///
+/// A brand-new file reports `application_id == 0` before any tables are
+/// created, so it is allowed through unverified to let bootstrap create and
+/// stamp the schema. Once stamped, a foreign file (wrong `application_id`) or a
+/// stale-version file (wrong `user_version`) is rejected up front rather than
+/// surfacing later as an opaque `no such column` error.
+fn verify_schema_guard(conn: &Connection) -> Result<(), LocalDbQueryError> {
+    let app_id: i32 = conn
+        .query_row("PRAGMA application_id", [], |row| row.get(0))
+        .map_err(|e| LocalDbQueryError::database(format!("Failed to read application_id: {e}")))?;
+
+    // An unstamped, freshly-created database header reads zero. Defer to
+    // bootstrap, which creates the tables and stamps the header.
+    if app_id == 0 {
+        return Ok(());
+    }
+
+    if app_id != RAINDEX_APPLICATION_ID {
+        return Err(LocalDbQueryError::NotARaindexDb {
+            expected: RAINDEX_APPLICATION_ID,
+            found: app_id,
+        });
+    }
+
+    let user_version: i32 = conn
+        .query_row("PRAGMA user_version", [], |row| row.get(0))
+        .map_err(|e| LocalDbQueryError::database(format!("Failed to read user_version: {e}")))?;
+
+    let expected = DB_SCHEMA_VERSION as i32;
+    if user_version != expected {
+        return Err(LocalDbQueryError::SchemaVersionMismatch {
+            expected,
+            found: user_version,
+        });
+    }
+
+    Ok(())
 }
 
 fn join_err(err: tokio::task::JoinError) -> LocalDbQueryError {
@@ -188,7 +234,171 @@ impl LocalDbQueryExecutor for RusqliteExecutor {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::local_db::query::create_tables::create_tables_stmt;
     use tempfile::TempDir;
+
+    #[test]
+    fn empty_db_passes_schema_guard() {
+        // A brand-new connection has application_id == 0 and must be allowed
+        // through so bootstrap can create and stamp the schema.
+        let conn = Connection::open_in_memory().unwrap();
+        verify_schema_guard(&conn).expect("unstamped db should pass the guard");
+    }
+
+    #[test]
+    fn stamped_db_passes_schema_guard() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(create_tables_stmt().sql())
+            .expect("create tables stamps the header");
+        verify_schema_guard(&conn).expect("correctly stamped db should pass the guard");
+    }
+
+    #[test]
+    fn wrong_application_id_is_detected() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(create_tables_stmt().sql())
+            .expect("create tables stamps the header");
+        // Re-stamp the header with a foreign application_id (a SQLite file that
+        // is not a raindex local-db) while leaving user_version valid.
+        let foreign = RAINDEX_APPLICATION_ID + 1;
+        conn.pragma_update(None, "application_id", foreign)
+            .expect("override application_id");
+
+        match verify_schema_guard(&conn) {
+            Err(LocalDbQueryError::NotARaindexDb { expected, found }) => {
+                assert_eq!(expected, RAINDEX_APPLICATION_ID);
+                assert_eq!(found, foreign);
+            }
+            other => panic!("expected NotARaindexDb, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn wrong_user_version_is_detected() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(create_tables_stmt().sql())
+            .expect("create tables stamps the header");
+        // Keep the raindex application_id but advance user_version to a stale /
+        // future schema number.
+        let bumped = DB_SCHEMA_VERSION as i32 + 1;
+        conn.pragma_update(None, "user_version", bumped)
+            .expect("override user_version");
+
+        match verify_schema_guard(&conn) {
+            Err(LocalDbQueryError::SchemaVersionMismatch { expected, found }) => {
+                assert_eq!(expected, DB_SCHEMA_VERSION as i32);
+                assert_eq!(found, bumped);
+            }
+            other => panic!("expected SchemaVersionMismatch, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn open_rejects_foreign_application_id_db() {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("foreign.db");
+
+        // Build a stamped raindex db, then corrupt only the application_id label
+        // in the file header so a fresh open must reject it.
+        {
+            let conn = Connection::open(&db_path).unwrap();
+            conn.execute_batch(create_tables_stmt().sql()).unwrap();
+            conn.pragma_update(None, "application_id", RAINDEX_APPLICATION_ID + 7)
+                .unwrap();
+        }
+
+        let exec = RusqliteExecutor::new(&db_path);
+        let err = exec
+            .query_text(&SqlStatement::new("SELECT 1;"))
+            .await
+            .expect_err("open of a foreign db must fail");
+        assert!(
+            matches!(err, LocalDbQueryError::NotARaindexDb { .. }),
+            "expected NotARaindexDb, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn open_rejects_stale_user_version_db() {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("stale.db");
+
+        {
+            let conn = Connection::open(&db_path).unwrap();
+            conn.execute_batch(create_tables_stmt().sql()).unwrap();
+            conn.pragma_update(None, "user_version", DB_SCHEMA_VERSION as i32 + 1)
+                .unwrap();
+        }
+
+        let exec = RusqliteExecutor::new(&db_path);
+        let err = exec
+            .query_text(&SqlStatement::new("SELECT 1;"))
+            .await
+            .expect_err("open of a stale-version db must fail");
+        assert!(
+            matches!(err, LocalDbQueryError::SchemaVersionMismatch { .. }),
+            "expected SchemaVersionMismatch, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn create_tables_stamps_header_and_open_succeeds() {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("stamped.db");
+
+        let exec = RusqliteExecutor::new(&db_path);
+        // First open hits an empty file (application_id == 0) and stamps it.
+        exec.query_text(&create_tables_stmt()).await.unwrap();
+
+        // A subsequent open must read back the stamped header and succeed.
+        #[derive(serde::Deserialize)]
+        struct VersionRow {
+            user_version: i64,
+        }
+        let rows: Vec<VersionRow> = exec
+            .query_json(&SqlStatement::new("PRAGMA user_version;"))
+            .await
+            .unwrap();
+        assert_eq!(rows[0].user_version, DB_SCHEMA_VERSION as i64);
+
+        let conn = Connection::open(&db_path).unwrap();
+        let app_id: i32 = conn
+            .query_row("PRAGMA application_id", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(app_id, RAINDEX_APPLICATION_ID);
+    }
+
+    #[tokio::test]
+    async fn data_only_dump_apply_preserves_header() {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("dump.db");
+
+        let exec = RusqliteExecutor::new(&db_path);
+        exec.query_text(&create_tables_stmt()).await.unwrap();
+
+        // Apply a data-only insert batch (the shape produced by export_data_only).
+        let mut batch = SqlStatementBatch::new();
+        batch.add(SqlStatement::new(
+            "INSERT INTO db_metadata (id, db_schema_version) VALUES (1, 5);",
+        ));
+        let batch = batch.ensure_transaction();
+        exec.execute_batch(&batch).await.unwrap();
+
+        // The header guard must still pass after applying data rows.
+        exec.query_text(&SqlStatement::new("SELECT 1;"))
+            .await
+            .expect("open after dump apply should still pass the guard");
+
+        let conn = Connection::open(&db_path).unwrap();
+        let app_id: i32 = conn
+            .query_row("PRAGMA application_id", [], |row| row.get(0))
+            .unwrap();
+        let user_version: i32 = conn
+            .query_row("PRAGMA user_version", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(app_id, RAINDEX_APPLICATION_ID);
+        assert_eq!(user_version, DB_SCHEMA_VERSION as i32);
+    }
 
     #[tokio::test]
     async fn execute_batch_runs_all_statements() {

--- a/crates/common/src/local_db/executor.rs
+++ b/crates/common/src/local_db/executor.rs
@@ -274,6 +274,27 @@ mod tests {
     }
 
     #[test]
+    fn negative_application_id_is_detected() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(create_tables_stmt().sql())
+            .expect("create tables stamps the header");
+        // A foreign file whose application_id has the top bit set reads back as
+        // a negative i32. It is neither zero (unstamped) nor the raindex magic,
+        // so it must be rejected as NotARaindexDb rather than waved through.
+        let foreign = i32::MIN;
+        conn.pragma_update(None, "application_id", foreign)
+            .expect("override application_id");
+
+        match verify_schema_guard(&conn) {
+            Err(LocalDbQueryError::NotARaindexDb { expected, found }) => {
+                assert_eq!(expected, RAINDEX_APPLICATION_ID);
+                assert_eq!(found, foreign);
+            }
+            other => panic!("expected NotARaindexDb, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn wrong_user_version_is_detected() {
         let conn = Connection::open_in_memory().unwrap();
         conn.execute_batch(create_tables_stmt().sql())
@@ -288,6 +309,27 @@ mod tests {
             Err(LocalDbQueryError::SchemaVersionMismatch { expected, found }) => {
                 assert_eq!(expected, DB_SCHEMA_VERSION as i32);
                 assert_eq!(found, bumped);
+            }
+            other => panic!("expected SchemaVersionMismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn stale_user_version_is_detected() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(create_tables_stmt().sql())
+            .expect("create tables stamps the header");
+        // Keep the raindex application_id but roll user_version back to an older
+        // schema number. A stale (lower) version must be rejected just like a
+        // future (higher) one.
+        let stale = DB_SCHEMA_VERSION as i32 - 1;
+        conn.pragma_update(None, "user_version", stale)
+            .expect("override user_version");
+
+        match verify_schema_guard(&conn) {
+            Err(LocalDbQueryError::SchemaVersionMismatch { expected, found }) => {
+                assert_eq!(expected, DB_SCHEMA_VERSION as i32);
+                assert_eq!(found, stale);
             }
             other => panic!("expected SchemaVersionMismatch, got {other:?}"),
         }

--- a/crates/common/src/local_db/query/create_tables/mod.rs
+++ b/crates/common/src/local_db/query/create_tables/mod.rs
@@ -2,6 +2,15 @@ use crate::local_db::query::SqlStatement;
 
 pub const CREATE_TABLES_SQL: &str = include_str!("query.sql");
 
+/// Stable `PRAGMA application_id` stamped into the SQLite file header of every
+/// raindex local-db. The value is the big-endian ASCII of "RIDX"
+/// (0x52 'R', 0x49 'I', 0x44 'D', 0x58 'X'), giving a fixed, human-recognisable
+/// magic that identifies the file as a raindex local-db rather than some other
+/// SQLite file. It is a 32-bit header label and never changes across schema
+/// versions. SQLite exposes `application_id`/`user_version` as signed 32-bit
+/// integers, so the constant is typed `i32`.
+pub const RAINDEX_APPLICATION_ID: i32 = 0x5249_4458;
+
 pub const REQUIRED_TABLES: &[&str] = &[
     "db_metadata",
     "target_watermarks",
@@ -155,7 +164,36 @@ fn normalize_ident(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use raindex_app_settings::local_db_manifest::DB_SCHEMA_VERSION;
     use std::collections::{HashMap, HashSet};
+
+    #[test]
+    fn pragmas_match_schema_version() {
+        // The application_id PRAGMA literal must equal the documented magic.
+        let expected_app_id = format!("PRAGMA application_id = 0x{:08X};", RAINDEX_APPLICATION_ID);
+        assert!(
+            CREATE_TABLES_SQL.contains(&expected_app_id),
+            "create_tables SQL must stamp application_id with the raindex magic ({expected_app_id})"
+        );
+
+        // The user_version PRAGMA literal must stay in lockstep with the
+        // Rust-side DB_SCHEMA_VERSION constant. A schema bump that forgets to
+        // update the SQL header trips this assertion.
+        let expected_user_version = format!("PRAGMA user_version = {DB_SCHEMA_VERSION};");
+        assert!(
+            CREATE_TABLES_SQL.contains(&expected_user_version),
+            "create_tables SQL must stamp user_version = {DB_SCHEMA_VERSION} to match DB_SCHEMA_VERSION"
+        );
+    }
+
+    #[test]
+    fn raindex_application_id_is_ridx_ascii() {
+        assert_eq!(
+            RAINDEX_APPLICATION_ID.to_be_bytes(),
+            *b"RIDX",
+            "application id must be the big-endian ASCII of \"RIDX\""
+        );
+    }
 
     #[test]
     fn required_tables_match_sql_create_statements() {

--- a/crates/common/src/local_db/query/create_tables/mod.rs
+++ b/crates/common/src/local_db/query/create_tables/mod.rs
@@ -3,13 +3,16 @@ use crate::local_db::query::SqlStatement;
 pub const CREATE_TABLES_SQL: &str = include_str!("query.sql");
 
 /// Stable `PRAGMA application_id` stamped into the SQLite file header of every
-/// raindex local-db. The value is the big-endian ASCII of "RIDX"
-/// (0x52 'R', 0x49 'I', 0x44 'D', 0x58 'X'), giving a fixed, human-recognisable
-/// magic that identifies the file as a raindex local-db rather than some other
-/// SQLite file. It is a 32-bit header label and never changes across schema
-/// versions. SQLite exposes `application_id`/`user_version` as signed 32-bit
-/// integers, so the constant is typed `i32`.
-pub const RAINDEX_APPLICATION_ID: i32 = 0x5249_4458;
+/// raindex local-db. The value is a fixed, uniform 32-bit identifier: the
+/// high-bit-cleared first 4 bytes of
+/// `sha256("raindex.local_db.application_id.v1")`. It is used only by
+/// `verify_schema_guard` to recognise a file as a raindex local-db rather than
+/// some other SQLite file. A uniform value is chosen instead of a
+/// printable-ASCII magic so it is unlikely to collide with another
+/// application's `application_id`. SQLite exposes
+/// `application_id`/`user_version` as signed 32-bit integers, so the constant is
+/// typed `i32`.
+pub const RAINDEX_APPLICATION_ID: i32 = 0x73DC_DCFD;
 
 pub const REQUIRED_TABLES: &[&str] = &[
     "db_metadata",
@@ -187,11 +190,18 @@ mod tests {
     }
 
     #[test]
-    fn raindex_application_id_is_ridx_ascii() {
+    fn raindex_application_id_matches_sha256_derivation() {
+        // The application_id is the high-bit-cleared first 4 bytes of
+        // sha256("raindex.local_db.application_id.v1"). Recompute it here so a
+        // typo in the constant is caught.
+        use sha2::{Digest, Sha256};
+        let digest = Sha256::digest(b"raindex.local_db.application_id.v1");
+        let first4 = u32::from_be_bytes(digest[..4].try_into().unwrap());
+        let expected = (first4 & 0x7FFF_FFFF) as i32;
         assert_eq!(
-            RAINDEX_APPLICATION_ID.to_be_bytes(),
-            *b"RIDX",
-            "application id must be the big-endian ASCII of \"RIDX\""
+            RAINDEX_APPLICATION_ID, expected,
+            "application id must be the high-bit-cleared first 4 bytes of \
+             sha256(\"raindex.local_db.application_id.v1\")"
         );
     }
 

--- a/crates/common/src/local_db/query/create_tables/query.sql
+++ b/crates/common/src/local_db/query/create_tables/query.sql
@@ -1,5 +1,14 @@
 BEGIN TRANSACTION;
 
+-- Structural schema-version guard stamped into the SQLite file header.
+-- `application_id` labels the file as a raindex local-db (0x52494458 == "RIDX");
+-- `user_version` carries the schema version. Both live in the header, so they
+-- survive table corruption and are readable without touching `db_metadata`.
+-- Keep `user_version` in lockstep with `DB_SCHEMA_VERSION`; the
+-- `pragmas_match_schema_version` test enforces this.
+PRAGMA application_id = 0x52494458;
+PRAGMA user_version = 5;
+
 -- Global DB metadata (singleton)
 CREATE TABLE IF NOT EXISTS db_metadata (
     id INTEGER PRIMARY KEY CHECK (id = 1),

--- a/crates/common/src/local_db/query/create_tables/query.sql
+++ b/crates/common/src/local_db/query/create_tables/query.sql
@@ -1,12 +1,13 @@
 BEGIN TRANSACTION;
 
 -- Structural schema-version guard stamped into the SQLite file header.
--- `application_id` labels the file as a raindex local-db (0x52494458 == "RIDX");
--- `user_version` carries the schema version. Both live in the header, so they
--- survive table corruption and are readable without touching `db_metadata`.
--- Keep `user_version` in lockstep with `DB_SCHEMA_VERSION`; the
--- `pragmas_match_schema_version` test enforces this.
-PRAGMA application_id = 0x52494458;
+-- `application_id` labels the file as a raindex local-db (0x73DCDCFD, a uniform
+-- identifier matching `RAINDEX_APPLICATION_ID`); `user_version` carries the
+-- schema version. Both live in the header, so they survive table corruption and
+-- are readable without touching `db_metadata`. Keep `user_version` in lockstep
+-- with `DB_SCHEMA_VERSION`; the `pragmas_match_schema_version` test enforces
+-- this.
+PRAGMA application_id = 0x73DCDCFD;
 PRAGMA user_version = 5;
 
 -- Global DB metadata (singleton)

--- a/crates/common/src/local_db/query/mod.rs
+++ b/crates/common/src/local_db/query/mod.rs
@@ -61,6 +61,12 @@ pub enum LocalDbQueryError {
 
     #[error("Operation not implemented: {operation}")]
     NotImplemented { operation: String },
+
+    #[error("not a raindex local-db: application_id {found:#010x} != expected {expected:#010x}")]
+    NotARaindexDb { expected: i32, found: i32 },
+
+    #[error("local-db schema version mismatch: user_version {found} != expected {expected}")]
+    SchemaVersionMismatch { expected: i32, found: i32 },
 }
 
 impl LocalDbQueryError {


### PR DESCRIPTION
## What

Adds a structural schema-version guard to the local DB layer using the two
SQLite header PRAGMAs purpose-built for this, as proposed in #2577.

- `PRAGMA application_id` — a fixed 32-bit magic (`0x52494458`, ASCII `"RIDX"`)
  that labels the file as a raindex local-db, exposed as the documented
  `RAINDEX_APPLICATION_ID` constant in the local-DB query layer.
- `PRAGMA user_version` — the schema version, kept in lockstep with
  `DB_SCHEMA_VERSION`.

Both are stamped atomically inside the existing `create_tables` batch
(`query.sql`), so any DB raindex creates carries the header label. Every
native connection open (`RusqliteExecutor::open_connection`) now verifies them
via a `verify_schema_guard` hook:

- a brand-new, unstamped file (`application_id == 0`) is allowed through so
  bootstrap can create and stamp the schema;
- a foreign file (wrong `application_id`) is rejected with `NotARaindexDb`;
- a stale/future file (wrong `user_version`) is rejected with
  `SchemaVersionMismatch`.

This turns a late, opaque `no such column: raindex_address` failure into an
up-front, descriptive error, and catches a file that changed underneath a
long-lived process on its next open rather than only once at bootstrap.

## Scope notes (from the issue)

- The `db_metadata` row check in `BootstrapPipeline::ensure_schema` is left in
  place as belt-and-braces — the row is what user-facing migration logic
  queries; the PRAGMA is what code that doesn't know about migrations sees.
- The data-only dump/export path emits only `INSERT`s (and skips
  `db_metadata`), so applying a dump never clobbers `application_id` /
  `user_version`. Confirmed and locked in with a test.
- Rust-only; no Solidity, no on-disk format change, no migration steps (the
  existing auto-reset on mismatch stays).

## Tests

New, all green (`cargo test -p raindex_common --lib local_db::`):

- `pragmas_match_schema_version`, `raindex_application_id_is_ridx_ascii`
- `empty_db_passes_schema_guard`, `stamped_db_passes_schema_guard`
- `wrong_application_id_is_detected`, `wrong_user_version_is_detected`
- `open_rejects_foreign_application_id_db`, `open_rejects_stale_user_version_db`
- `create_tables_stamps_header_and_open_succeeds`
- `data_only_dump_apply_preserves_header`

`cargo fmt --all` and `rainix-rs-static` pass.

Closes #2577

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Database schema validation is now enforced on every connection
  * System automatically rejects databases with incompatible schema versions or corrupted format information
  * New diagnostic error messages provide clearer information about database compatibility issues
  * Database format and version information is now persisted to detect schema mismatches

<!-- end of auto-generated comment: release notes by coderabbit.ai -->