### PR TITLE
ci: handle first-time npm publish of @rainlanguage/raindex

### DIFF
--- a/.github/workflows/npm-package-release.yml
+++ b/.github/workflows/npm-package-release.yml
@@ -181,7 +181,17 @@ jobs:
       - name: Set Version
         if: ${{ env.OLD_HASH != env.NEW_HASH }}
         run: |
-          npm version prerelease --preid alpha --no-git-tag-version  -w @rainlanguage/raindex
+          # npm version prerelease reifies the workspace, which resolves
+          # @rainlanguage/raindex against the registry. The first time the
+          # package is published it doesn't exist there yet, so that resolution
+          # 404s and the bump fails (E404). When npm view reports no published
+          # version, publish the version already committed in package.json as
+          # the initial release instead of bumping it.
+          if npm view @rainlanguage/raindex@latest version &>/dev/null; then
+            npm version prerelease --preid alpha --no-git-tag-version  -w @rainlanguage/raindex
+          else
+            echo "@rainlanguage/raindex not yet on npm; publishing committed version as initial release"
+          fi
           RAINDEX_NEW_VERSION=$(jq -r '.version' ./packages/raindex/package.json)
           echo "RAINDEX_NEW_VERSION=$RAINDEX_NEW_VERSION" >> $GITHUB_ENV
           jq --arg v "$RAINDEX_NEW_VERSION" '.dependencies."@rainlanguage/raindex" = $v' ./packages/ui-components/package.json > tmp.json && mv tmp.json ./packages/ui-components/package.json


### PR DESCRIPTION
## What

Gate the raindex prerelease bump in the `NPM Packages Release` workflow's "Set Version" step on whether the package is already published. When `npm view @rainlanguage/raindex@latest` reports no published version, publish the version already committed in `package.json` (`0.0.1-alpha.238`) as the initial release instead of running `npm version prerelease`.

## Why

`@rainlanguage/raindex` was renamed from `@rainlanguage/orderbook` and has never been published to npm. The "Set Version" step runs `npm version prerelease -w @rainlanguage/raindex`, which reifies the workspace and resolves `@rainlanguage/raindex` against the registry. That resolution 404s because the package doesn't exist yet:

```
npm error code E404
npm error 404  The requested resource '@rainlanguage/raindex@0.0.1-alpha.238' could not be found
```

`npm version` exits 1 on that E404, failing the step on every `main` push since the soldeer-migration merge (June 11). Once the initial publish lands, subsequent runs see the published version and bump via `npm version prerelease` as before.

## Verification

Reproduced the failure in `nix develop .#wasm-shell`: the unpatched `npm version prerelease -w @rainlanguage/raindex` exits `1` with the E404 above.

Confirmed registry state matches the issue: `npm view @rainlanguage/raindex@latest` -> E404; `npm view @rainlanguage/orderbook@latest` -> `0.0.1-alpha.239`; `npm view @rainlanguage/ui-components@latest` -> `0.0.1-alpha.238`.

With the fix, ran the exact "Set Version" + `npm pack` step logic under `set -euxo pipefail`. It completes green for the first-publish case:

```
RAINDEX_NEW_VERSION=0.0.1-alpha.238
UC_NEW_VERSION=0.0.1-alpha.238
RAINDEX_NPM_PACKAGE=rainlanguage-raindex-0.0.1-alpha.238.tgz
UC_NPM_PACKAGE=rainlanguage-ui-components-0.0.1-alpha.238.tgz
```

Verified both branches of the conditional select correctly: an already-published package (`@rainlanguage/ui-components`) takes the `npm version prerelease` path (no regression); the unpublished `@rainlanguage/raindex` takes the initial-release path.

Fixes #2602

🤖 Generated with [Claude Code](https://claude.com/claude-code)
