### PR TITLE
Replace stale goldsky subgraph URLs in test fixtures with placeholders

### DIFF
--- a/crates/cli/src/commands/chart.rs
+++ b/crates/cli/src/commands/chart.rs
@@ -81,9 +81,9 @@ networks:
     chain-id: 14
     currency: "FLR"
 subgraphs:
-  flare: "https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/raindex-flare/2024-12-13-9dc7/gn"
+  flare: "https://example.com/subgraphs/flare/gn"
 metaboards:
-  flare: "https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-flare-0x893BBFB7/0.1/gn"
+  flare: "https://example.com/metaboards/flare/gn"
 raindexes:
   flare:
     address: {raindex}

--- a/crates/js_api/src/registry.rs
+++ b/crates/js_api/src/registry.rs
@@ -818,11 +818,11 @@ networks:
     chain-id: 8453
     currency: ETH
 subgraphs:
-  flare: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/raindex-flare/0.8/gn
-  base: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/raindex-base/0.9/gn
+  flare: https://example.com/subgraphs/flare/gn
+  base: https://example.com/subgraphs/base/gn
 metaboards:
-  flare: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-flare-0x893BBFB7/0.1/gn
-  base: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-base-0x59401C93/0.1/gn
+  flare: https://example.com/metaboards/flare/gn
+  base: https://example.com/metaboards/base/gn
 rainlangs:
   flare:
     address: 0x1111111111111111111111111111111111111111

--- a/packages/raindex/test/js_api/dotrainRegistry.test.ts
+++ b/packages/raindex/test/js_api/dotrainRegistry.test.ts
@@ -37,11 +37,11 @@ networks:
     chain-id: 8453
     currency: ETH
 subgraphs:
-  flare: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/raindex-flare/0.8/gn
-  base: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/raindex-base/0.9/gn
+  flare: https://example.com/subgraphs/flare/gn
+  base: https://example.com/subgraphs/base/gn
 metaboards:
-  flare: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-flare-0x893BBFB7/0.1/gn
-  base: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-base-0x59401C93/0.1/gn
+  flare: https://example.com/metaboards/flare/gn
+  base: https://example.com/metaboards/base/gn
 rainlangs:
   flare:
     address: 0x1111111111111111111111111111111111111111

--- a/packages/ui-components/src/lib/__fixtures__/settings.yaml
+++ b/packages/ui-components/src/lib/__fixtures__/settings.yaml
@@ -37,25 +37,25 @@ networks:
     chain-id: 1
     currency: ETH
 subgraphs:
-  flare: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/ob4-flare/0.8/gn
-  base: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/ob4-base/0.9/gn
-  sepolia: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/ob4-sepolia/0.1/gn
-  polygon: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/ob4-polygon/0.1/gn
-  arbitrum: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/ob4-arbitrum/0.2/gn
-  matchain: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/ob4-polygon/0.1/gn
-  bsc: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/ob4-bsc/2024-10-14-63f4/gn
-  linea: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/ob4-linea/2024-10-14-12fc/gn
-  ethereum: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/metadata-mainnet/2024-10-25-2857/gn
+  flare: https://example.com/subgraphs/flare/gn
+  base: https://example.com/subgraphs/base/gn
+  sepolia: https://example.com/subgraphs/sepolia/gn
+  polygon: https://example.com/subgraphs/polygon/gn
+  arbitrum: https://example.com/subgraphs/arbitrum/gn
+  matchain: https://example.com/subgraphs/matchain/gn
+  bsc: https://example.com/subgraphs/bsc/gn
+  linea: https://example.com/subgraphs/linea/gn
+  ethereum: https://example.com/subgraphs/ethereum/gn
 metaboards:
-  flare: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-flare-0x893BBFB7/0.1/gn
-  base: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-base-0x59401C93/0.1/gn
-  sepolia: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-sepolia-0x77991674/0.1/gn
-  polygon: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-polygon/0.1/gn
-  arbitrum: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-arbitrum/0.1/gn
-  matchain: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-polygon/0.1/gn
-  bsc: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-bsc/0.1/gn
-  linea: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-linea-0xed7d6156/1.0.0/gn
-  ethereum: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/metadata-mainnet/2024-10-25-2857/gn
+  flare: https://example.com/metaboards/flare/gn
+  base: https://example.com/metaboards/base/gn
+  sepolia: https://example.com/metaboards/sepolia/gn
+  polygon: https://example.com/metaboards/polygon/gn
+  arbitrum: https://example.com/metaboards/arbitrum/gn
+  matchain: https://example.com/metaboards/matchain/gn
+  bsc: https://example.com/metaboards/bsc/gn
+  linea: https://example.com/metaboards/linea/gn
+  ethereum: https://example.com/metaboards/ethereum/gn
 raindexes:
   flare:
     address: 0xCEe8Cd002F151A536394E564b84076c41bBBcD4d


### PR DESCRIPTION
## What

Replace the hardcoded, real-looking-but-stale goldsky subgraph/metaboard URLs in test fixtures with obvious `https://example.com/...` placeholders, in the four fixtures that carried them:

- `crates/cli/src/commands/chart.rs` — flare subgraph + metaboard fixture
- `crates/js_api/src/registry.rs` — mock settings content
- `packages/raindex/test/js_api/dotrainRegistry.test.ts` — mock settings content
- `packages/ui-components/src/lib/__fixtures__/settings.yaml` — fixture settings

The YAML structure (network / subgraph / metaboard keys, addresses) is unchanged; only the URL *values* are swapped.

## Why

The #2556 audit found 17 unused goldsky deployments billing without serving production traffic. The only in-repo references to those stale / deprecated-chain (flare, bsc, linea, mainnet) deployments live in test/fixture code, where real-looking URLs can be mistaken for live config and keep stale deployments looking "in use." None of these tests fetch the subgraph URLs — they drive a `LocalEvm` / mock HTTP server and parse the URLs as opaque strings — so swapping them to placeholders is behavior-preserving and decouples the fixtures from the goldsky deployments that can now be deleted.

This is pure test cleanup; it does not touch any runtime default or production registry. The broken `mb-polygon` reference is tracked separately in #2557.

## Verification

- `cargo test -p raindex_cli --lib commands::chart` — 4 passed
- `cargo test -p raindex_js_api --lib registry` — 19 passed
- `vitest run test/js_api/dotrainRegistry.test.ts` (through the real wasm bindings) — 17 passed
- `__fixtures__/settings.yaml` re-validated as well-formed YAML (no test imports it directly)

Fixes #2556

🤖 Generated with [Claude Code](https://claude.com/claude-code)
