### PR TITLE
fix: correct stale rainlang-0.1.2 import breaking the build on main

### DIFF
--- a/test/concrete/parser/RaindexV6SubParser.routingTokenDecimalsAndMasks.t.sol
+++ b/test/concrete/parser/RaindexV6SubParser.routingTokenDecimalsAndMasks.t.sol
@@ -5,8 +5,8 @@ pragma solidity =0.8.25;
 import {Test} from "forge-std-1.16.1/src/Test.sol";
 import {OperandV2} from "rain-interpreter-interface-0.1.0/src/interface/ISubParserV4.sol";
 import {OPCODE_CONTEXT} from "rain-interpreter-interface-0.1.0/src/interface/IInterpreterV4.sol";
-import {ContextGridOverflow} from "rainlang-0.1.2/src/error/ErrSubParse.sol";
-import {LibSubParse} from "rainlang-0.1.2/src/lib/parse/LibSubParse.sol";
+import {ContextGridOverflow} from "rainlang-0.1.5/src/error/ErrSubParse.sol";
+import {LibSubParse} from "rainlang-0.1.5/src/lib/parse/LibSubParse.sol";
 import {LibRaindexSubParser} from "../../../src/lib/LibRaindexSubParser.sol";
 
 /// @title RaindexV6SubParserRoutingTokenDecimalsAndMasksTest


### PR DESCRIPTION
## Why main is red

`main` HEAD is red on `copy-artifacts`, `rainix-sol / static`, and `rainix-sol / test`. PR #2705 (commit `9b9259370`, already merged to main) added `test/concrete/parser/RaindexV6SubParser.routingTokenDecimalsAndMasks.t.sol`, which imports from `rainlang-0.1.2/`:

```solidity
import {ContextGridOverflow} from "rainlang-0.1.2/src/error/ErrSubParse.sol";
import {LibSubParse} from "rainlang-0.1.2/src/lib/parse/LibSubParse.sol";
```

But `foundry.toml` pins `rainlang = "0.1.5"`. So `forge soldeer install` never fetches `0.1.2`, and the whole forge compile dies with:

```
Source "rainlang-0.1.2/src/error/ErrSubParse.sol" not found
```

A failed compile reddens `copy-artifacts` + `rainix-sol/{static,test}` on main HEAD and on every PR that inherits this commit.

## The fix

Bump only those two import lines in that one file to the pinned `0.1.5`:

```solidity
import {ContextGridOverflow} from "rainlang-0.1.5/src/error/ErrSubParse.sol";
import {LibSubParse} from "rainlang-0.1.5/src/lib/parse/LibSubParse.sol";
```

`0.1.5` is the correct version: the same `src/error/ErrSubParse.sol` and `src/lib/parse/LibSubParse.sol` paths exist in the installed `0.1.5` dep (`ContextGridOverflow` and `LibSubParse.subParserContext` are unchanged), and `src/lib/LibRaindexSubParser.sol` on main already imports `LibSubParse` from `rainlang-0.1.5/src/lib/parse/LibSubParse.sol` successfully.

This greens `copy-artifacts` + `rainix-sol/{static,test}` on main and unblocks all inheriting PRs.

## Scope

2-line, single-file, logic-free fix. No other file, no `foundry.toml`, no logic touched.

## Verification (under `nix develop github:rainlanguage/rainix#sol-shell`)

- Full `forge build` now compiles cleanly (was dying with the `not found` error).
- Full `copy-artifacts` sequence (`build-meta.sh` → `BuildPointers.sol` → `forge build` → `script/build.sh` → `forge fmt`) produces **no** artifact drift — `git status` shows only the one import file changed.
- `forge test --match-path 'test/concrete/parser/RaindexV6SubParser.routingTokenDecimalsAndMasks.t.sol'` → 4 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
