### PR TITLE
fix(test): repair quote tests broken by the #2701 OrderNoSources guard

### DIFF
--- a/test/concrete/parser/RaindexV6SubParser.routingTokenDecimalsAndMasks.t.sol
+++ b/test/concrete/parser/RaindexV6SubParser.routingTokenDecimalsAndMasks.t.sol
@@ -5,8 +5,8 @@ pragma solidity =0.8.25;
 import {Test} from "forge-std-1.16.1/src/Test.sol";
 import {OperandV2} from "rain-interpreter-interface-0.1.0/src/interface/ISubParserV4.sol";
 import {OPCODE_CONTEXT} from "rain-interpreter-interface-0.1.0/src/interface/IInterpreterV4.sol";
-import {ContextGridOverflow} from "rainlang-0.1.2/src/error/ErrSubParse.sol";
-import {LibSubParse} from "rainlang-0.1.2/src/lib/parse/LibSubParse.sol";
+import {ContextGridOverflow} from "rainlang-0.1.5/src/error/ErrSubParse.sol";
+import {LibSubParse} from "rainlang-0.1.5/src/lib/parse/LibSubParse.sol";
 import {LibRaindexSubParser} from "../../../src/lib/LibRaindexSubParser.sol";
 
 /// @title RaindexV6SubParserRoutingTokenDecimalsAndMasksTest

--- a/test/concrete/raindex/RaindexV6.calculateOrderIOHarness.t.sol
+++ b/test/concrete/raindex/RaindexV6.calculateOrderIOHarness.t.sol
@@ -42,6 +42,7 @@ import {ITOFUTokenDecimals, TOFUOutcome} from "rain-tofu-erc20-decimals-0.1.1/sr
 import {LibTOFUTokenDecimals} from "rain-tofu-erc20-decimals-0.1.1/src/lib/LibTOFUTokenDecimals.sol";
 import {LibRainDeploy} from "rain-deploy-0.1.2/src/lib/LibRainDeploy.sol";
 import {LibOrder} from "src/lib/LibOrder.sol";
+import {LibTestAddOrder} from "test/util/lib/LibTestAddOrder.sol";
 import {REVERTING_MOCK_BYTECODE} from "test/util/lib/LibTestConstants.sol";
 import {IERC20Metadata} from "@openzeppelin-contracts-5.6.1/token/ERC20/extensions/IERC20Metadata.sol";
 
@@ -145,7 +146,10 @@ contract RaindexV6CalculateOrderIOHarnessTest is Test {
     }
 
     /// Build a single-input single-output order pointing at the fixed-stack
-    /// interpreter.
+    /// interpreter. The evaluable carries the canonical two-source bytecode
+    /// (calculate + handle IO) so `addOrder4`'s source-count guard accepts it;
+    /// `calculateOrderIO`/`quote2` drive the fixed-stack interpreter regardless
+    /// of the bytecode, so the sources only matter to the add path.
     function _order() internal view returns (OrderV4 memory order) {
         IOV2[] memory inputs = new IOV2[](1);
         inputs[0] = IOV2(inputToken, INPUT_VAULT_ID);
@@ -153,7 +157,11 @@ contract RaindexV6CalculateOrderIOHarnessTest is Test {
         outputs[0] = IOV2(outputToken, OUTPUT_VAULT_ID);
         order = OrderV4({
             owner: owner,
-            evaluable: EvaluableV4({interpreter: IInterpreterV4(address(interpreter)), store: store, bytecode: hex""}),
+            evaluable: EvaluableV4({
+                interpreter: IInterpreterV4(address(interpreter)),
+                store: store,
+                bytecode: LibTestAddOrder.VALID_ORDER_BYTECODE
+            }),
             validInputs: inputs,
             validOutputs: outputs,
             nonce: bytes32(uint256(0xDEAD))
@@ -581,7 +589,11 @@ contract RaindexV6CalculateOrderIOHarnessTest is Test {
         outputs[0] = IOV2(outputToken, OUTPUT_VAULT_ID);
         OrderV4 memory order = OrderV4({
             owner: owner,
-            evaluable: EvaluableV4({interpreter: IInterpreterV4(address(interpreter)), store: store, bytecode: hex""}),
+            evaluable: EvaluableV4({
+                interpreter: IInterpreterV4(address(interpreter)),
+                store: store,
+                bytecode: LibTestAddOrder.VALID_ORDER_BYTECODE
+            }),
             validInputs: inputs,
             validOutputs: outputs,
             nonce: bytes32(uint256(0xBEEF))

--- a/test/concrete/raindex/RaindexV6.orderMgmt.fresh.t.sol
+++ b/test/concrete/raindex/RaindexV6.orderMgmt.fresh.t.sol
@@ -31,8 +31,11 @@ contract RaindexV6OrderMgmtFreshTest is RaindexV6FreshTest, IMetaV1_2 {
     using Strings for address;
     using Strings for uint256;
 
-    /// Any bytecode is accepted by `addOrder4`; the stack/IO checks are runtime.
-    bytes constant CALC_BYTECODE = hex"02000000040000000000000000";
+    /// The canonical two-source (calculate + handle IO) serialized bytecode that
+    /// `addOrder4`'s source-count guard accepts, so each test exercises the
+    /// specific input/output/meta guard it targets rather than the source-count
+    /// guard. The runtime stack/IO checks are not reached by `addOrder4`.
+    bytes constant CALC_BYTECODE = LibTestAddOrder.VALID_ORDER_BYTECODE;
 
     // -----------------------------------------------------------------------
     // addOrder4: input/output guards (A1, A2)


### PR DESCRIPTION
## What

PR #2701 (issue #2652) added an `OrderNoSources()` source-count guard to
`addOrder4`: it reverts when an order's evaluable bytecode deserializes to
fewer than two sources (calculate + handle IO). #2701 updated most tests for
the new guard but missed several that construct **source-less** orders, so
those tests now revert during their setup — before reaching the behavior they
assert.

This PR repairs them. **Test-only**, no source/artifact/pointer changes.

### The three quote tests (the assigned breakage)

In `test/concrete/raindex/RaindexV6.calculateOrderIOHarness.t.sol`, three
`quote2` tests add a live order via `addOrder4` with empty (`hex""`) bytecode,
which now reverts `OrderNoSources()` before the quote assertion:

- `testQuoteLiveOrderReturnsCappedMaxAndRatio`
- `testQuoteLiveSelfTradeReverts`
- `testQuoteRemovedOrderReturnsFalseZeroZero`

Fix: give the harness order the canonical two-source
`LibTestAddOrder.VALID_ORDER_BYTECODE` (the same `[constants][bytecode]` blob
the passing add/quote suites use). The harness drives a fixed-stack
interpreter that ignores the bytecode, so `calculateOrderIO`/`quote2` behave
identically and each test still asserts exactly what it did before
(vault-capped max + ratio; self-trade revert; removed-order `(false, 0, 0)`).

### Two more tests broken by the same #2701 guard

While running the full suite to verify, the same guard was found breaking five
`addOrder4` tests in `test/concrete/raindex/RaindexV6.orderMgmt.fresh.t.sol`,
which set a 13-byte `CALC_BYTECODE` blob that deserializes to **zero** sources.
They hit `OrderNoSources()` instead of the input/output/meta guard each one
targets (`testFreshAddOrderNoInputsReverts`, `testFreshAddOrderOneInputPasses`,
`testFreshAddOrderNoOutputsReverts`,
`testFreshAddOrderNoInputsTakesPrecedenceOverNoOutputs`,
`testFreshAddOrderMetaEmitsExact`). Fix: point `CALC_BYTECODE` at
`VALID_ORDER_BYTECODE` and correct its now-stale "any bytecode is accepted"
comment.

### Compile blocker that masked all of the above

`test/concrete/parser/RaindexV6SubParser.routingTokenDecimalsAndMasks.t.sol`
imported `rainlang-0.1.2/...` while the repo pins `rainlang-0.1.5`. The path
didn't resolve, so `forge test` failed to **compile** the whole suite — which
is why `rainix-sol/test` is currently red on `main` with a `Source ... not
found` compiler error rather than test failures. The `OrderNoSources` failures
above were latent behind it. Fix: bump the two imports to `rainlang-0.1.5`
(both symbols exist there and `src/lib/LibRaindexSubParser.sol` already imports
`LibSubParse` from `rainlang-0.1.5`).

## Verification

`nix develop github:rainlanguage/rainix#sol-shell -c forge test`:
**675 passed, 12 failed, 1 skipped** (was 670/17 with the compile blocker
hand-patched). The 8 quote/orderMgmt tests above all pass. `forge fmt --check`
is clean.

The 12 remaining failures are pre-existing and **environment-only**, unrelated
to this change:
- `testProdDeploy{Arbitrum,Base,BaseSepolia,Flare,Polygon}`,
  `testStartBlock{Base,Flare,Polygon}`,
  `testIsStartBlock{Base,Flare,Polygon}` — `vm.createSelectFork: environment
  variable '<CHAIN>_RPC_URL' not found` (need per-chain RPC endpoints).
- `testSubgraphYamlAddress` — `vm.ffi` can't find `yq` on the local PATH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test dependencies and improved bytecode initialization in order management tests for enhanced validation coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->