### PR TITLE
Show Syncing in top-level localdb status badge

### DIFF
--- a/packages/ui-components/src/__tests__/LocalDbStatusCard.test.ts
+++ b/packages/ui-components/src/__tests__/LocalDbStatusCard.test.ts
@@ -29,10 +29,24 @@ describe("LocalDbStatusCard", () => {
     expect(screen.getByTestId("local-db-status")).toBeInTheDocument();
   });
 
-  it("shows active status when no networks have failures", () => {
+  it("shows syncing status when a network is syncing and none are failing", () => {
     const networkStatuses = new Map<number, NetworkSyncStatus>([
       [1, { chainId: 1, status: "active", schedulerState: "leader" }],
       [137, { chainId: 137, status: "syncing", schedulerState: "leader" }],
+    ]);
+
+    render(LocalDbStatusCard, {
+      props: { networkStatuses },
+    });
+
+    expect(screen.getByText("LocalDB")).toBeInTheDocument();
+    expect(screen.getByText("Syncing")).toBeInTheDocument();
+  });
+
+  it("shows active status when all networks are active", () => {
+    const networkStatuses = new Map<number, NetworkSyncStatus>([
+      [1, { chainId: 1, status: "active", schedulerState: "leader" }],
+      [137, { chainId: 137, status: "active", schedulerState: "leader" }],
     ]);
 
     render(LocalDbStatusCard, {
@@ -77,7 +91,7 @@ describe("LocalDbStatusCard", () => {
     expect(screen.getByTestId("local-db-status-header")).toBeInTheDocument();
   });
 
-  it("shows active status when all networks are syncing but none failing", () => {
+  it("shows syncing status when all networks are syncing but none failing", () => {
     const networkStatuses = new Map<number, NetworkSyncStatus>([
       [137, { chainId: 137, status: "syncing", schedulerState: "leader" }],
       [42161, { chainId: 42161, status: "syncing", schedulerState: "leader" }],
@@ -87,7 +101,79 @@ describe("LocalDbStatusCard", () => {
       props: { networkStatuses },
     });
 
-    expect(screen.getByText("Active")).toBeInTheDocument();
+    expect(screen.getByText("Syncing")).toBeInTheDocument();
+  });
+
+  it("shows syncing status when only a raindex is syncing", () => {
+    const networkStatuses = new Map<number, NetworkSyncStatus>([
+      [137, { chainId: 137, status: "active", schedulerState: "leader" }],
+    ]);
+    const raindexStatuses = new Map<string, RaindexSyncStatus>([
+      [
+        "137:0x1234567890123456789012345678901234567890",
+        {
+          raindexId: {
+            chainId: 137,
+            raindexAddress: "0x1234567890123456789012345678901234567890",
+          },
+          status: "syncing",
+          schedulerState: "leader",
+        },
+      ],
+    ]);
+
+    render(LocalDbStatusCard, {
+      props: { networkStatuses, raindexStatuses },
+    });
+
+    expect(screen.getByText("Syncing")).toBeInTheDocument();
+  });
+
+  it("shows failure when a network fails even while another is syncing", () => {
+    const networkStatuses = new Map<number, NetworkSyncStatus>([
+      [137, { chainId: 137, status: "syncing", schedulerState: "leader" }],
+      [
+        42161,
+        {
+          chainId: 42161,
+          status: "failure",
+          schedulerState: "leader",
+          error: "RPC error",
+        },
+      ],
+    ]);
+
+    render(LocalDbStatusCard, {
+      props: { networkStatuses },
+    });
+
+    expect(screen.getByText("Failure")).toBeInTheDocument();
+  });
+
+  it("shows failure when a raindex fails even while a network is syncing", () => {
+    const networkStatuses = new Map<number, NetworkSyncStatus>([
+      [137, { chainId: 137, status: "syncing", schedulerState: "leader" }],
+    ]);
+    const raindexStatuses = new Map<string, RaindexSyncStatus>([
+      [
+        "137:0x1234567890123456789012345678901234567890",
+        {
+          raindexId: {
+            chainId: 137,
+            raindexAddress: "0x1234567890123456789012345678901234567890",
+          },
+          status: "failure",
+          schedulerState: "leader",
+          error: "Decode error",
+        },
+      ],
+    ]);
+
+    render(LocalDbStatusCard, {
+      props: { networkStatuses, raindexStatuses },
+    });
+
+    expect(screen.getByText("Failure")).toBeInTheDocument();
   });
 
   it("shows active status when empty maps are provided", () => {

--- a/packages/ui-components/src/lib/components/LocalDbStatusCard.svelte
+++ b/packages/ui-components/src/lib/components/LocalDbStatusCard.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-	import type { LocalDbStatus, NetworkSyncStatus, RaindexSyncStatus } from '@rainlanguage/raindex';
+	import type { NetworkSyncStatus, RaindexSyncStatus } from '@rainlanguage/raindex';
 	import LocalDbStatusBadge from './LocalDbStatusBadge.svelte';
 	import LocalDbStatusModal from './LocalDbStatusModal.svelte';
+	import { aggregateLocalDbStatus } from '../utils/localDbStatus';
 	import { ChevronRightOutline } from 'flowbite-svelte-icons';
 
 	export let networkStatuses: Map<number, NetworkSyncStatus> = new Map();
@@ -11,8 +12,10 @@
 
 	$: networkList = Array.from(networkStatuses.values());
 	$: hasNetworks = networkList.length > 0;
-	$: hasFailure = networkList.some((s) => s.status === 'failure');
-	$: displayStatus = (hasFailure ? 'failure' : 'active') as LocalDbStatus;
+	$: displayStatus = aggregateLocalDbStatus([
+		...networkList,
+		...Array.from(raindexStatuses.values())
+	]).status;
 
 	function openModal() {
 		modalOpen = true;

--- a/packages/ui-components/src/lib/index.ts
+++ b/packages/ui-components/src/lib/index.ts
@@ -73,6 +73,8 @@ export { default as FixedBottomTransaction } from "./components/transactions/Fix
 export { default as LocalDbStatusCard } from "./components/LocalDbStatusCard.svelte";
 export { default as LocalDbStatusBadge } from "./components/LocalDbStatusBadge.svelte";
 export { default as LocalDbStatusModal } from "./components/LocalDbStatusModal.svelte";
+export { aggregateLocalDbStatus } from "./utils/localDbStatus";
+export type { AggregableSyncStatus } from "./utils/localDbStatus";
 
 //Types
 export type { AppStoresInterface } from "./types/appStores.ts";

--- a/packages/ui-components/src/lib/utils/localDbStatus.ts
+++ b/packages/ui-components/src/lib/utils/localDbStatus.ts
@@ -1,0 +1,39 @@
+import type { LocalDbStatus } from "@rainlanguage/raindex";
+
+/**
+ * The minimal shape required to aggregate a top-level localdb status: anything
+ * carrying a per-chain/per-raindex {@link LocalDbStatus} and an optional error
+ * message (e.g. `NetworkSyncStatus` or `RaindexSyncStatus`).
+ */
+export interface AggregableSyncStatus {
+  status: LocalDbStatus;
+  error?: string;
+}
+
+/**
+ * Collapses many per-chain / per-raindex sync statuses into the single
+ * top-level localdb status shown in the sidebar badge.
+ *
+ * Priority is `failure` > `syncing` > `active`:
+ * - If any status is `failure`, the result is `failure` (carrying that
+ *   status's error).
+ * - Else if any status is `syncing`, the result is `syncing`.
+ * - Else the result is `active`.
+ *
+ * An empty input (nothing configured) is treated as `active`.
+ */
+export function aggregateLocalDbStatus(statuses: AggregableSyncStatus[]): {
+  status: LocalDbStatus;
+  error: string | undefined;
+} {
+  const failure = statuses.find((s) => s.status === "failure");
+  if (failure) {
+    return { status: "failure", error: failure.error };
+  }
+
+  if (statuses.some((s) => s.status === "syncing")) {
+    return { status: "syncing", error: undefined };
+  }
+
+  return { status: "active", error: undefined };
+}

--- a/packages/webapp/src/lib/stores/localDbStatus.ts
+++ b/packages/webapp/src/lib/stores/localDbStatus.ts
@@ -1,4 +1,5 @@
-import type { NetworkSyncStatus, LocalDbStatus, RaindexSyncStatus } from '@rainlanguage/raindex';
+import type { NetworkSyncStatus, RaindexSyncStatus } from '@rainlanguage/raindex';
+import { aggregateLocalDbStatus } from '@rainlanguage/ui-components';
 import { writable, derived } from 'svelte/store';
 
 export const networkStatuses = writable<Map<number, NetworkSyncStatus>>(new Map());
@@ -40,28 +41,11 @@ export function updateStatus(status: NetworkSyncStatus | RaindexSyncStatus) {
 
 export const aggregateStatus = derived(
 	[networkStatuses, raindexStatuses],
-	([$networkMap, $raindexMap]) => {
-		const allStatuses: { status: LocalDbStatus; error?: string }[] = [
+	([$networkMap, $raindexMap]) =>
+		aggregateLocalDbStatus([
 			...Array.from($networkMap.values()),
 			...Array.from($raindexMap.values())
-		];
-
-		if (allStatuses.length === 0) {
-			return { status: 'active' as LocalDbStatus, error: undefined };
-		}
-
-		const failure = allStatuses.find((s) => s.status === 'failure');
-		if (failure) {
-			return { status: 'failure' as LocalDbStatus, error: failure.error };
-		}
-
-		const syncing = allStatuses.find((s) => s.status === 'syncing');
-		if (syncing) {
-			return { status: 'syncing' as LocalDbStatus, error: undefined };
-		}
-
-		return { status: 'active' as LocalDbStatus, error: undefined };
-	}
+		])
 );
 
 export const localDbStatus = aggregateStatus;


### PR DESCRIPTION
## Problem

The top-level `LOCALDB` badge in the webapp sidebar only ever shows `ACTIVE` or `FAILURE`. While a chain is partway through its pipeline (manifest fetched, dumps downloading, engine running, etc.) the per-chain modal correctly reads `SYNCING`, but the sidebar badge does not — so the user can't tell a healthy-and-idle database from one that is busy bootstrapping and not yet authoritative.

## Root cause

The sidebar renders `LocalDbStatusCard` directly (`Sidebar.svelte`), and the card computed its badge as:

```ts
$: hasFailure = networkList.some((s) => s.status === 'failure');
$: displayStatus = (hasFailure ? 'failure' : 'active') as LocalDbStatus;
```

This only inspects `networkStatuses`, never emits `'syncing'`, and ignores `raindexStatuses` entirely. The `LocalDbStatusBadge` already renders a `syncing` state, and the webapp `aggregateStatus` store already implemented the correct `failure > syncing > active` priority across both lists — but the sidebar badge used the card's own (buggy) logic, not the store.

## Fix

- Add a shared `aggregateLocalDbStatus(statuses)` helper in `ui-components` that collapses a combined list of per-chain / per-raindex statuses into a single top-level status using the priority **`failure` > `syncing` > `active`** (empty input ⇒ `active`). This mirrors the canonical Rust rule in `crates/common/.../local_db/status.rs`.
- The card now derives `displayStatus` from this helper over `networkStatuses` **and** `raindexStatuses`.
- The webapp `aggregateStatus` store (which had the same rule hand-rolled) now calls the same helper, so the card and the store can't drift.

Per the issue's acceptance criteria: a mid-sync chain ⇒ badge reads `Syncing`; all chains ready ⇒ `Active`; any failure ⇒ `Failure` regardless of others' progress.

## How the tests discriminate (mutation-validated)

Updated `LocalDbStatusCard.test.ts`. The previous case "shows active status when all networks are syncing" asserted `Active` (enshrining the bug) — it now asserts `Syncing`, per the issue. Added cases for a syncing-only network, a syncing-only raindex, and `failure`-beats-`syncing` precedence (network failure and raindex failure, each with a sibling syncing).

Mutation testing against the helper:
- Mutating the syncing branch to return `active` instead of `syncing` ⇒ exactly the 3 syncing assertions fail (network-syncing, all-syncing, raindex-syncing).
- Reordering so syncing is checked before failure ⇒ exactly the 2 `failure`-beats-`syncing` precedence assertions fail.
Restoring the source returns the suite to green, so the tests provably pin both the syncing emission and the `failure > syncing` priority.

## Verification

- Full `@rainlanguage/ui-components` suite: 640 tests pass.
- Full `@rainlanguage/webapp` suite: 180 tests pass (store's existing 26 `localDbStatus` tests still pass after the refactor to the shared helper).
- `ui-components` prettier + eslint + `svelte-check`: clean (0 errors / 0 warnings). `webapp` eslint: clean.
- The only `webapp` `svelte-check` reds are the pre-existing `PUBLIC_WALLETCONNECT_PROJECT_ID` env-var errors in `handleWalletInitialization.ts` (unset `.env`), unrelated to this change.

Frontend/TS only — no Solidity, no Rust source, no generated artifacts or bytecode changes; no redeploy needed.

Closes #2565

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for status card to validate additional sync and failure state combinations.

* **Refactor**
  * Centralized local database status aggregation logic with improved state priority handling (failure overrides syncing, syncing overrides active).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->