### PR TITLE
Document RouteProcessor arb does not forward ETH to processRoute (#2699)

### DIFF
--- a/src/concrete/arb/RouteProcessorRaindexV6ArbOrderTaker.sol
+++ b/src/concrete/arb/RouteProcessorRaindexV6ArbOrderTaker.sol
@@ -42,6 +42,15 @@ contract RouteProcessorRaindexV6ArbOrderTaker is RaindexV6ArbOrderTaker {
         if (!lossless) {
             outputTokenAmount++;
         }
+        // `processRoute` is `payable`, but this arb calls it with no value:
+        // native-ETH input legs are unsupported here, the swap is funded purely
+        // by the ERC20 `inputToken` approval above. This deliberately diverges
+        // from `LibGenericPoolExchange.exchange`, which forwards
+        // `address(this).balance` to the caller-chosen pool. Any ETH held by
+        // this contract is not routed into the swap; it is swept to `msg.sender`
+        // by `finalizeArb`'s native-gas sweep, matching the recovery behaviour
+        // documented at `receive()`/`fallback()` below and on the base
+        // `RaindexV6ArbOrderTaker`.
         //slither-disable-next-line unused-return
         IRouteProcessor(routeProcessor)
             .processRoute(inputToken, inputTokenAmount, outputToken, outputTokenAmount, address(this), route);

--- a/test/concrete/arb/RouteProcessorRaindexV6ArbOrderTaker.noEthForward.t.sol
+++ b/test/concrete/arb/RouteProcessorRaindexV6ArbOrderTaker.noEthForward.t.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Test} from "forge-std-1.16.1/src/Test.sol";
+
+import {RouteProcessorRaindexV6ArbOrderTaker} from "../../../src/concrete/arb/RouteProcessorRaindexV6ArbOrderTaker.sol";
+import {Float} from "raindex-interface-0.1.1/src/interface/IRaindexV6.sol";
+import {IRouteProcessor} from "src/interface/IRouteProcessor.sol";
+import {LibRainDeploy} from "rain-deploy-0.1.2/src/lib/LibRainDeploy.sol";
+import {LibTOFUTokenDecimals} from "rain-tofu-erc20-decimals-0.1.1/src/lib/LibTOFUTokenDecimals.sol";
+import {LibRaindexDeploy} from "../../../src/lib/deploy/LibRaindexDeploy.sol";
+import {MockToken} from "test/util/concrete/MockToken.sol";
+
+/// @dev Route processor mock that records the `msg.value` it was called with in
+/// storage slot 0, so a test can assert how much native ETH the arb forwarded.
+contract ValueRecordingRouteProcessor is IRouteProcessor {
+    function processRoute(address, uint256, address, uint256, address, bytes memory)
+        external
+        payable
+        returns (uint256)
+    {
+        // Slot 0 holds the last `msg.value` seen, readable via `vm.load` from
+        // the etched address.
+        assembly ("memory-safe") {
+            sstore(0, callvalue())
+        }
+        return 0;
+    }
+}
+
+/// @title RouteProcessorRaindexV6ArbOrderTakerNoEthForwardTest
+/// @notice Locks the documented divergence from `LibGenericPoolExchange` (#2699):
+/// the route-processor arb funds `processRoute` purely via the ERC20 approval and
+/// forwards NO native ETH into the swap, even while holding an ETH balance. The
+/// generic-pool arbs forward `address(this).balance`; this arb does not, leaving
+/// any held ETH for `finalizeArb`'s native-gas sweep instead.
+contract RouteProcessorRaindexV6ArbOrderTakerNoEthForwardTest is Test {
+    function testProcessRouteCalledWithNoEthValue(uint256 ethBalance) external {
+        ethBalance = bound(ethBalance, 1, 1e24);
+
+        LibRainDeploy.etchZoltuFactory(vm);
+        LibRainDeploy.deployZoltu(LibTOFUTokenDecimals.TOFU_DECIMALS_EXPECTED_CREATION_CODE);
+
+        MockToken tokenA = new MockToken("A", "A", 18);
+        MockToken tokenB = new MockToken("B", "B", 18);
+
+        ValueRecordingRouteProcessor recorder = new ValueRecordingRouteProcessor();
+        vm.etch(LibRaindexDeploy.ROUTE_PROCESSOR_DEPLOYED_ADDRESS, address(recorder).code);
+        address routeProcessor = LibRaindexDeploy.ROUTE_PROCESSOR_DEPLOYED_ADDRESS;
+        // Seed slot 0 with a sentinel so a zero read is genuinely from the call.
+        vm.store(routeProcessor, bytes32(0), bytes32(type(uint256).max));
+
+        RouteProcessorRaindexV6ArbOrderTaker arb = new RouteProcessorRaindexV6ArbOrderTaker();
+
+        // Give the arb a non-zero native ETH balance. If the arb forwarded its
+        // balance like the generic-pool path, the recorder would see it.
+        vm.deal(address(arb), ethBalance);
+
+        bytes memory route = abi.encode(hex"");
+        arb.onTakeOrders2(address(tokenA), address(tokenB), Float.wrap(0), Float.wrap(0), route);
+
+        // The arb called `processRoute` with zero value: native-ETH input legs
+        // are unsupported and the held ETH is NOT routed into the swap.
+        assertEq(uint256(vm.load(routeProcessor, bytes32(0))), 0, "processRoute msg.value must be 0");
+
+        // The held ETH is untouched by the swap; it stays on the arb to be swept
+        // by `finalizeArb` (not exercised by this direct `onTakeOrders2` call).
+        assertEq(address(arb).balance, ethBalance, "arb retains its ETH balance");
+        assertEq(routeProcessor.balance, 0, "route processor received no ETH");
+    }
+}


### PR DESCRIPTION
## What

Resolves the triage question in #2699 along the documentation path the issue itself proposes.

The three arbs diverge on whether they forward the contract's native ETH balance into the swap:

- The **generic-pool arbs** forward the full balance: `LibGenericPoolExchange.exchange` does `pool.functionCallWithValue(encodedFunctionCall, address(this).balance)`.
- The **route-processor arb** calls `processRoute` (which is `payable`) with **no value**.

This PR documents that the route-processor arb's behaviour is **intentional**: native-ETH input legs are unsupported here, the swap is funded purely by the ERC20 `inputToken` approval, and any ETH held by the contract is swept to `msg.sender` by `finalizeArb`'s native-gas sweep (#2668) rather than routed into the swap. This is consistent with the recovery behaviour already documented at the contract's `receive()`/`fallback()` and on the base `RaindexV6ArbOrderTaker`.

## Why this path (not the forward-ETH fix)

The issue is phrased as a "question for triage" with two options:
1. **Document** that ERC20-only routing is intentional (this PR) — comment-only, no bytecode change, no redeploy.
2. **Forward** `address(this).balance` as `processRoute{value: ...}(...)` — this changes deployed bytecode and is a separate PR requiring a redeploy.

This PR takes option 1. If the maintainer instead wants the value-forwarding fix, that is a distinct bytecode-changing PR.

## Bytecode / deploy

**No bytecode change.** The contract change is comment-only — the executable statements are byte-identical to `main`. Landable without a redeploy.

## How the test discriminates

`RouteProcessorRaindexV6ArbOrderTaker.noEthForward.t.sol` etches a recording route-processor mock that stores the `msg.value` it was called with, funds the arb with a fuzzed non-zero ETH balance, calls `onTakeOrders2`, and asserts:

- `processRoute` saw `msg.value == 0` (the documented divergence — ETH is not forwarded);
- the arb still holds its full ETH balance (the swap did not consume it; only `finalizeArb` would sweep it);
- the route processor received no ETH.

Mutation-validated: changing the call to `processRoute{value: address(this).balance}(...)` (the alternative forward-ETH fix) makes the test FAIL (`processRoute msg.value must be 0: 848 != 0`), proving it locks the documented behaviour and discriminates the two resolutions. Restoring the source makes it pass. All 10 route-processor arb tests pass.

Closes #2699

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that native ETH is not forwarded to swap routes; all swaps are funded via ERC20 token approvals.
  * Documented that any ETH held by the contract is swept back to the sender.

* **Tests**
  * Added test to verify native ETH is not forwarded to swaps, even when the contract holds ETH.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->