### PR TITLE
Add hover title/explainer text over icon-only action buttons

### DIFF
--- a/packages/ui-components/src/__tests__/OrderDetail.test.ts
+++ b/packages/ui-components/src/__tests__/OrderDetail.test.ts
@@ -377,6 +377,27 @@ describe("OrderDetail", () => {
     );
   });
 
+  it("shows hover title and aria-label on the deposit and withdraw icon buttons", async () => {
+    mockMatchesAccount.mockReturnValue(true);
+
+    render(OrderDetail, {
+      props: defaultProps,
+      context: new Map([["$$_queryClient", queryClient]]),
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Order")).toBeInTheDocument();
+    });
+
+    const depositButton = screen.getAllByTestId("deposit-button")[0];
+    expect(depositButton).toHaveAttribute("title", "Deposit into vault");
+    expect(depositButton).toHaveAttribute("aria-label", "Deposit into vault");
+
+    const withdrawButton = screen.getAllByTestId("withdraw-button")[0];
+    expect(withdrawButton).toHaveAttribute("title", "Withdraw from vault");
+    expect(withdrawButton).toHaveAttribute("aria-label", "Withdraw from vault");
+  });
+
   it("does not show Take Order button for inactive orders", async () => {
     (mockRaindexClient.getOrderByHash as Mock).mockResolvedValue({
       value: {

--- a/packages/ui-components/src/__tests__/VaultDetail.test.ts
+++ b/packages/ui-components/src/__tests__/VaultDetail.test.ts
@@ -184,6 +184,28 @@ describe("VaultDetail", () => {
     });
   });
 
+  it("shows hover title and aria-label on the deposit and withdraw icon buttons", async () => {
+    mockMatchesAccount.mockReturnValue(true);
+
+    render(VaultDetail, {
+      props: defaultProps,
+      context: new Map([["$$_queryClient", queryClient]]),
+    });
+
+    await waitFor(() => {
+      const depositButton = screen.getByTestId("deposit-button");
+      expect(depositButton).toHaveAttribute("title", "Deposit to vault");
+      expect(depositButton).toHaveAttribute("aria-label", "Deposit to vault");
+
+      const withdrawButton = screen.getByTestId("withdraw-button");
+      expect(withdrawButton).toHaveAttribute("title", "Withdraw from vault");
+      expect(withdrawButton).toHaveAttribute(
+        "aria-label",
+        "Withdraw from vault",
+      );
+    });
+  });
+
   it("doesn't show deposit/withdraw buttons when account doesn't match", async () => {
     mockMatchesAccount.mockReturnValue(false);
 

--- a/packages/ui-components/src/__tests__/VaultsListTable.test.ts
+++ b/packages/ui-components/src/__tests__/VaultsListTable.test.ts
@@ -231,6 +231,33 @@ describe("VaultsListTable", () => {
     );
   });
 
+  it("shows hover title and aria-label on the vault actions menu button", async () => {
+    mockMatchesAccount.mockReturnValue(true);
+    const mockQuery = vi.mocked(await import("@tanstack/svelte-query"));
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    mockQuery.createInfiniteQuery = vi.fn((__options, _queryClient) => ({
+      subscribe: (fn: (value: any) => void) => {
+        fn({
+          data: { pages: [mockVaultsList] },
+          status: "success",
+          isFetching: false,
+          isFetched: true,
+        });
+        return { unsubscribe: () => {} };
+      },
+    })) as Mock;
+
+    render(VaultsListTable, {
+      ...defaultProps,
+      handleDepositModal: vi.fn(),
+      handleWithdrawModal: vi.fn(),
+    } as unknown as VaultsListTableProps);
+
+    const menuButton = screen.getByTestId("vault-menu");
+    expect(menuButton).toHaveAttribute("title", "Vault actions");
+    expect(menuButton).toHaveAttribute("aria-label", "Vault actions");
+  });
+
   it("hides action buttons when user is not the vault owner", () => {
     mockMatchesAccount.mockReturnValue(false);
     render(VaultsListTable, {

--- a/packages/ui-components/src/lib/components/detail/OrderDetail.svelte
+++ b/packages/ui-components/src/lib/components/detail/OrderDetail.svelte
@@ -269,6 +269,8 @@
 														color="light"
 														size="xs"
 														data-testid="deposit-button"
+														title="Deposit into vault"
+														aria-label="Deposit into vault"
 														on:click={() => onDeposit(raindexClient, vault)}
 													>
 														<ArrowDownToBracketOutline size="xs" />
@@ -277,6 +279,8 @@
 														color="light"
 														size="xs"
 														data-testid="withdraw-button"
+														title="Withdraw from vault"
+														aria-label="Withdraw from vault"
 														on:click={() => onWithdraw(raindexClient, vault)}
 													>
 														<ArrowUpFromBracketOutline size="xs" />

--- a/packages/ui-components/src/lib/components/detail/VaultDetail.svelte
+++ b/packages/ui-components/src/lib/components/detail/VaultDetail.svelte
@@ -89,6 +89,7 @@
 					color="light"
 					size="xs"
 					data-testid="deposit-button"
+					title="Deposit to vault"
 					aria-label="Deposit to vault"
 					on:click={() => onDeposit(raindexClient, data)}
 				>
@@ -98,6 +99,7 @@
 					color="light"
 					size="xs"
 					data-testid="withdraw-button"
+					title="Withdraw from vault"
 					aria-label="Withdraw from vault"
 					on:click={() => onWithdraw(raindexClient, data)}
 				>

--- a/packages/ui-components/src/lib/components/tables/VaultsListTable.svelte
+++ b/packages/ui-components/src/lib/components/tables/VaultsListTable.svelte
@@ -354,6 +354,8 @@
 						data-testid="vault-menu"
 						id={`vault-menu-${item.id}`}
 						class="mr-2 border-none px-2"
+						title="Vault actions"
+						aria-label="Vault actions"
 						on:click={(e) => {
 							e.stopPropagation();
 						}}


### PR DESCRIPTION
Closes #1847

## What

Icon-only buttons in the vault/order UI rendered a bare icon (deposit / withdraw arrows, the three-dot vault menu) with no accompanying text. Hovering gave no explanation of what the button does, and screen readers had nothing to announce. The issue asks for "hover text on them, as a title or explainer of what that icon button is supposed to do".

This adds a descriptive `title` (the hover tooltip the issue requests) and a matching `aria-label` (for screen readers) to the icon-only action buttons:

- **`OrderDetail.svelte`** — per-vault deposit/withdraw icon buttons. Previously had **neither** `title` nor `aria-label`. Now `title`/`aria-label` = "Deposit into vault" / "Withdraw from vault".
- **`VaultsListTable.svelte`** — the per-row three-dot "Vault actions" menu button (`vault-menu`). Previously had **neither**. Now "Vault actions".
- **`VaultDetail.svelte`** — deposit/withdraw icon buttons. These already had an `aria-label` but **no `title`**, so there was no visual hover tooltip. Added `title` alongside the existing `aria-label`.

No bytecode / Solidity / generated artifacts are touched — this is landable without a deploy.

## Tests and how they discriminate

Added one test per component asserting each icon button carries the expected `title` and `aria-label` via `toHaveAttribute`, using the existing render harness and `data-testid` selectors.

Mutation-validated: replacing each `title="..."` value with `"MUTANT"` makes exactly the three new tests fail (`3 failed | 47 passed`), each on its `title` assertion, and restoring makes all 50 pass again. This proves the tests pin the actual attribute value rather than merely the button's presence.

Ran the three affected suites under `nix develop .#wasm-shell` (after building `@rainlanguage/raindex`): `OrderDetail.test.ts`, `VaultDetail.test.ts`, `VaultsListTable.test.ts` — 50/50 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)