### PR TITLE
Make vault links on Order pages read as clickable

### DIFF
--- a/packages/ui-components/src/__tests__/ButtonVaultLink.test.ts
+++ b/packages/ui-components/src/__tests__/ButtonVaultLink.test.ts
@@ -45,4 +45,18 @@ describe("ButtonVaultLink", () => {
       `token-info-${mockVault.vaultId}`,
     );
   });
+
+  it("should give the link a hover affordance so it reads as clickable", () => {
+    render(ButtonVaultLink, {
+      props: {
+        tokenVault: mockVault,
+        chainId: 1,
+        raindexAddress: "0x00",
+      },
+    });
+
+    const linkElement = screen.getByRole("link");
+    expect(linkElement).toHaveClass("text-blue-500");
+    expect(linkElement).toHaveClass("hover:underline");
+  });
 });

--- a/packages/ui-components/src/lib/components/ButtonVaultLink.svelte
+++ b/packages/ui-components/src/lib/components/ButtonVaultLink.svelte
@@ -19,6 +19,7 @@
 		<a
 			href={`/vaults/${chainId}-${raindexAddress}-${tokenVault.id}`}
 			id={`token-info-${tokenVault.vaultId}`}
+			class="text-blue-500 hover:underline"
 		>
 			{tokenVault.token.name} ({tokenVault.token.symbol})
 		</a>


### PR DESCRIPTION
## What

Vault token links on Order pages had no hover affordance. `ButtonVaultLink.svelte` rendered the token name as a bare `<a>` with no link color or hover style — `cursor-pointer` sat only on the outer container, so nothing about the link itself signalled that it was clickable, and hovering produced no visual change. This is the exact complaint in #1257 ("Currently there's no hover change").

## Fix

Add the repo's standard clickable-link styling — `class="text-blue-500 hover:underline"` — to the anchor in `ButtonVaultLink.svelte`. This is the same convention already used for links elsewhere in `ui-components` (e.g. `ToastDetail.svelte`, `ErrorPage.svelte`): a blue link color plus an underline-on-hover affordance. `ButtonVaultLink` is rendered by `detail/OrderDetail.svelte`, i.e. the Order pages the issue refers to.

## Tests

Added a discriminating test to the existing `ButtonVaultLink.test.ts` (kept in the source-organized test file). It grabs the link via `getByRole("link")` and asserts the anchor carries both `text-blue-500` (the link color) and `hover:underline` (the hover change).

How it discriminates — mutation-validated locally:
- Baseline (class present): the new test passes, all 3 tests green.
- Remove the `class` from the anchor: the new test FAILS (`expect(element).toHaveClass("text-blue-500")`), while the two pre-existing tests still pass — proving the new assertion specifically covers the added behavior rather than passing vacuously.

`npm run svelte-lint-format-check -w @rainlanguage/ui-components` (prettier + eslint + svelte-check) is clean: 0 errors, 0 warnings.

This is a pure CSS/Svelte change in `ui-components`; no deployed bytecode is involved, so it is landable without a deploy. Note: because it's pure CSS, mutation coverage on the visual behavior is inherently limited to asserting the class is present.

Closes #1257

🤖 Generated with [Claude Code](https://claude.com/claude-code)