### PR TITLE
Complete #1847: hover text on all remaining icon-only buttons

### DIFF
--- a/packages/ui-components/src/__tests__/ButtonDarkMode.test.ts
+++ b/packages/ui-components/src/__tests__/ButtonDarkMode.test.ts
@@ -26,6 +26,14 @@ describe("ButtonDarkMode.svelte", () => {
     expect(screen.getByTestId("mock-component")).toBeInTheDocument();
   });
 
+  it("shows hover title and aria-label on the dark mode toggle button", () => {
+    render(ButtonDarkMode, { props: { colorTheme: mockColorThemeStore } });
+
+    const button = screen.getByTestId("dark-mode-toggle");
+    expect(button).toHaveAttribute("title", "Toggle dark mode");
+    expect(button).toHaveAttribute("aria-label", "Toggle dark mode");
+  });
+
   it('sets colorTheme to "light" when toggled in light mode', async () => {
     render(ButtonDarkMode, { props: { colorTheme: mockColorThemeStore } });
     const button = screen.getByRole("button");

--- a/packages/ui-components/src/__tests__/FixedBottomTransaction.test.ts
+++ b/packages/ui-components/src/__tests__/FixedBottomTransaction.test.ts
@@ -382,6 +382,7 @@ describe("FixedBottomTransaction", () => {
       name: "Dismiss transaction",
     });
     expect(closeButton).toHaveAttribute("aria-label", "Dismiss transaction");
+    expect(closeButton).toHaveAttribute("title", "Dismiss transaction");
   });
 
   it("should open links in new tab with proper attributes", () => {

--- a/packages/ui-components/src/__tests__/OrderDetail.test.ts
+++ b/packages/ui-components/src/__tests__/OrderDetail.test.ts
@@ -396,6 +396,10 @@ describe("OrderDetail", () => {
     const withdrawButton = screen.getAllByTestId("withdraw-button")[0];
     expect(withdrawButton).toHaveAttribute("title", "Withdraw from vault");
     expect(withdrawButton).toHaveAttribute("aria-label", "Withdraw from vault");
+
+    const refreshButton = screen.getByTestId("top-refresh");
+    expect(refreshButton).toHaveAttribute("title", "Refresh order");
+    expect(refreshButton).toHaveAttribute("aria-label", "Refresh order");
   });
 
   it("does not show Take Order button for inactive orders", async () => {

--- a/packages/ui-components/src/__tests__/OrderTradesListTable.test.ts
+++ b/packages/ui-components/src/__tests__/OrderTradesListTable.test.ts
@@ -220,6 +220,10 @@ test("renders a debug button for each trade", async () => {
   await waitFor(async () => {
     const buttons = screen.getAllByTestId("debug-trade-button");
     expect(buttons).toHaveLength(mockTradeOrdersList.length);
+    buttons.forEach((button) => {
+      expect(button).toHaveAttribute("title", "Debug trade");
+      expect(button).toHaveAttribute("aria-label", "Debug trade");
+    });
   });
 });
 

--- a/packages/ui-components/src/__tests__/OrdersListTable.test.ts
+++ b/packages/ui-components/src/__tests__/OrdersListTable.test.ts
@@ -586,6 +586,32 @@ describe("OrdersListTable", () => {
     );
   });
 
+  it("shows hover title and aria-label on the order actions menu button", async () => {
+    mockMatchesAccount.mockReturnValue(true);
+    const mockQuery = vi.mocked(await import("@tanstack/svelte-query"));
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    mockQuery.createInfiniteQuery = vi.fn((__options, _queryClient) => ({
+      subscribe: (fn: (value: any) => void) => {
+        fn({
+          data: { pages: [{ orders: [mockOrder], totalCount: 1 }] },
+          status: "success",
+          isFetching: false,
+          isFetched: true,
+        });
+        return { unsubscribe: () => {} };
+      },
+    })) as Mock;
+
+    render(OrdersListTable, {
+      ...defaultProps,
+      handleOrderRemoveModal: vi.fn(),
+    } as unknown as OrdersListTableProps);
+
+    const menuButton = screen.getByTestId(`order-menu-${mockOrder.id}`);
+    expect(menuButton).toHaveAttribute("title", "Order actions");
+    expect(menuButton).toHaveAttribute("aria-label", "Order actions");
+  });
+
   it("passes raindexAddresses filter to getOrders when raindexes are selected", async () => {
     const raindexAddress = "0x1111111111111111111111111111111111111111";
 

--- a/packages/ui-components/src/__tests__/TanstackAppTable.test.ts
+++ b/packages/ui-components/src/__tests__/TanstackAppTable.test.ts
@@ -214,6 +214,18 @@ test("shows refresh icon", async () => {
   );
 });
 
+test("shows hover title and aria-label on the refresh icon", async () => {
+  const pages = createPages();
+  const mockQuery = createMockQuery(pages);
+  renderTable(mockQuery);
+
+  await waitFor(() => {
+    const refreshButton = screen.getByTestId("refreshButton");
+    expect(refreshButton).toHaveAttribute("title", "Refresh");
+    expect(refreshButton).toHaveAttribute("aria-label", "Refresh");
+  });
+});
+
 test("invalidates queries when refresh button is clicked", async () => {
   const mockRefetch = vi.fn();
   const mockQuery = createMockQuery(createPages(), {

--- a/packages/ui-components/src/__tests__/TanstackOrderQuote.test.ts
+++ b/packages/ui-components/src/__tests__/TanstackOrderQuote.test.ts
@@ -83,6 +83,83 @@ describe("TanstackOrderQuote component", () => {
     });
   });
 
+  it("shows hover title and aria-label on the quote control icon buttons", async () => {
+    (mockOrder.getQuotes as Mock).mockResolvedValueOnce({
+      value: [
+        {
+          success: true,
+          block_number: "0x123",
+          pair: { pairName: "ETH/USDT", inputIndex: 0, outputIndex: 1 },
+          data: {
+            formattedMaxOutput: "1.550122181502135692",
+            formattedRatio: "6.563567234157974775",
+          },
+          error: undefined,
+        },
+      ],
+    });
+
+    const queryClient = new QueryClient();
+
+    render(TanstackOrderQuote, {
+      props: {
+        order: mockOrder,
+        handleQuoteDebugModal: vi.fn(),
+      },
+      context: new Map([["$$_queryClient", queryClient]]),
+    });
+
+    const refreshButton = await screen.findByTestId("refresh-button");
+    expect(refreshButton).toHaveAttribute("title", "Refresh quotes");
+    expect(refreshButton).toHaveAttribute("aria-label", "Refresh quotes");
+
+    const pauseButton = screen.getByTestId("pause-refresh-button");
+    expect(pauseButton).toHaveAttribute("title", "Pause auto-refresh");
+    expect(pauseButton).toHaveAttribute("aria-label", "Pause auto-refresh");
+
+    const resumeButton = screen.getByTestId("resume-refresh-button");
+    expect(resumeButton).toHaveAttribute("title", "Resume auto-refresh");
+    expect(resumeButton).toHaveAttribute("aria-label", "Resume auto-refresh");
+
+    const debugButton = await screen.findByTestId("debug-quote-button");
+    expect(debugButton).toHaveAttribute("title", "Debug quote");
+    expect(debugButton).toHaveAttribute("aria-label", "Debug quote");
+  });
+
+  it("shows hover title and aria-label on the quote error icon buttons", async () => {
+    (mockOrder.getQuotes as Mock).mockResolvedValueOnce({
+      value: [
+        {
+          success: false,
+          block_number: "0x123",
+          pair: { pairName: "ETH/USDT", inputIndex: 0, outputIndex: 1 },
+          data: undefined,
+          error: "Failed to calculate quote",
+        },
+      ],
+    });
+
+    const queryClient = new QueryClient();
+
+    render(TanstackOrderQuote, {
+      props: {
+        order: mockOrder,
+        handleQuoteDebugModal: vi.fn(),
+      },
+      context: new Map([["$$_queryClient", queryClient]]),
+    });
+
+    const copyButton = await screen.findByRole("button", {
+      name: "Copy quote error",
+    });
+    expect(copyButton).toHaveAttribute("title", "Copy quote error");
+    expect(copyButton).toHaveAttribute("aria-label", "Copy quote error");
+
+    const debugErrorButton = screen.getByTestId("debug-quote-error-button");
+    expect(debugErrorButton).toHaveAttribute("title", "Debug quote");
+    expect(debugErrorButton).toHaveAttribute("aria-label", "Debug quote");
+  });
+
   it("refreshes the quote when the refresh icon is clicked", async () => {
     (mockOrder.getQuotes as Mock).mockResolvedValueOnce({
       value: [

--- a/packages/ui-components/src/__tests__/VaultDetail.test.ts
+++ b/packages/ui-components/src/__tests__/VaultDetail.test.ts
@@ -203,6 +203,10 @@ describe("VaultDetail", () => {
         "aria-label",
         "Withdraw from vault",
       );
+
+      const refreshButton = screen.getByTestId("top-refresh");
+      expect(refreshButton).toHaveAttribute("title", "Refresh vault");
+      expect(refreshButton).toHaveAttribute("aria-label", "Refresh vault");
     });
   });
 

--- a/packages/ui-components/src/lib/components/ButtonDarkMode.svelte
+++ b/packages/ui-components/src/lib/components/ButtonDarkMode.svelte
@@ -10,6 +10,12 @@
 	}
 </script>
 
-<button type="button" on:click={toggle}>
+<button
+	type="button"
+	title="Toggle dark mode"
+	aria-label="Toggle dark mode"
+	data-testid="dark-mode-toggle"
+	on:click={toggle}
+>
 	<DarkMode />
 </button>

--- a/packages/ui-components/src/lib/components/TanstackAppTable.svelte
+++ b/packages/ui-components/src/lib/components/TanstackAppTable.svelte
@@ -203,6 +203,8 @@
   <Refresh
     class="ml-2 h-8 w-5 cursor-pointer text-gray-400 dark:text-gray-400"
     data-testid="refreshButton"
+    title="Refresh"
+    ariaLabel="Refresh"
     spin={$query.isLoading || $query.isFetching}
     on:click={async () => {
       if (queryKey) {

--- a/packages/ui-components/src/lib/components/detail/OrderDetail.svelte
+++ b/packages/ui-components/src/lib/components/detail/OrderDetail.svelte
@@ -158,6 +158,8 @@
 
 				<Refresh
 					testId="top-refresh"
+					title="Refresh order"
+					ariaLabel="Refresh order"
 					on:click={handleRefresh}
 					spin={$orderDetailQuery.isLoading || $orderDetailQuery.isFetching}
 				/>

--- a/packages/ui-components/src/lib/components/detail/TanstackOrderQuote.svelte
+++ b/packages/ui-components/src/lib/components/detail/TanstackOrderQuote.svelte
@@ -100,16 +100,24 @@
 			<Refresh
 				data-testid="refresh-button"
 				class="h-8 w-5 cursor-pointer text-gray-400 dark:text-gray-400"
+				title="Refresh quotes"
+				ariaLabel="Refresh quotes"
 				on:click={refreshQuotes}
 				spin={$orderQuoteQuery.isLoading || $orderQuoteQuery.isFetching}
 			/>
 			<PauseSolid
+				data-testid="pause-refresh-button"
+				title="Pause auto-refresh"
+				ariaLabel="Pause auto-refresh"
 				class={`ml-2 h-8 w-3 cursor-pointer text-gray-400 dark:text-gray-400 ${!enabled ? 'hidden' : ''}`}
 				on:click={() => {
 					enabled = false;
 				}}
 			/>
 			<PlaySolid
+				data-testid="resume-refresh-button"
+				title="Resume auto-refresh"
+				ariaLabel="Resume auto-refresh"
 				on:click={() => {
 					enabled = true;
 					blockNumber = undefined;
@@ -163,6 +171,9 @@
 							<TableBodyCell>
 								{#if handleQuoteDebugModal}
 									<button
+										data-testid="debug-quote-button"
+										title="Debug quote"
+										aria-label="Debug quote"
 										on:click={() =>
 											handleQuoteDebugModal(
 												orderModalArg,
@@ -191,6 +202,7 @@
 									<button
 										type="button"
 										class="mt-0.5 rounded border border-transparent p-1 text-gray-400 transition hover:bg-gray-100 hover:text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-gray-100"
+										title="Copy quote error"
 										aria-label="Copy quote error"
 										on:click={() => copyQuoteError(item.error)}
 									>
@@ -207,6 +219,9 @@
 							<TableBodyCell>
 								{#if handleQuoteDebugModal}
 									<button
+										data-testid="debug-quote-error-button"
+										title="Debug quote"
+										aria-label="Debug quote"
 										on:click={() =>
 											handleQuoteDebugModal(
 												order,

--- a/packages/ui-components/src/lib/components/detail/VaultDetail.svelte
+++ b/packages/ui-components/src/lib/components/detail/VaultDetail.svelte
@@ -109,6 +109,8 @@
 
 			<Refresh
 				testId="top-refresh"
+				title="Refresh vault"
+				ariaLabel="Refresh vault"
 				on:click={handleRefresh}
 				spin={$vaultDetailQuery.isLoading || $vaultDetailQuery.isFetching}
 			/>

--- a/packages/ui-components/src/lib/components/icon/Refresh.svelte
+++ b/packages/ui-components/src/lib/components/icon/Refresh.svelte
@@ -15,6 +15,7 @@
 	export let size = ctx.size || 'md';
 	export let role = ctx.role || 'img';
 	export let ariaLabel = 'refresh';
+	export let title = 'Refresh';
 	export let spin = false;
 	export let testId = 'refresh-button';
 </script>
@@ -23,7 +24,7 @@
 	data-testid={testId}
 	xmlns="http://www.w3.org/2000/svg"
 	fill="none"
-	{...$$restProps}
+	{...{ title, ...$$restProps }}
 	class={twMerge(
 		'shrink-0 cursor-pointer outline-none',
 		sizes[size],

--- a/packages/ui-components/src/lib/components/tables/OrderTradesListTable.svelte
+++ b/packages/ui-components/src/lib/components/tables/OrderTradesListTable.svelte
@@ -160,6 +160,8 @@
         <button
           data-testid="debug-trade-button"
           class="text-gray-500 hover:text-gray-700"
+          title="Debug trade"
+          aria-label="Debug trade"
           on:click={() => {
             if (rpcs) handleDebugTradeModal(item.transaction.id, rpcs);
           }}

--- a/packages/ui-components/src/lib/components/tables/OrdersListTable.svelte
+++ b/packages/ui-components/src/lib/components/tables/OrdersListTable.svelte
@@ -271,6 +271,8 @@
 								data-testid={`order-menu-${item.id}`}
 								id={`order-menu-${item.id}`}
 								class="border-none px-2"
+								title="Order actions"
+								aria-label="Order actions"
 								on:click={(e) => {
 									e.stopPropagation();
 								}}

--- a/packages/ui-components/src/lib/components/transactions/FixedBottomTransaction.svelte
+++ b/packages/ui-components/src/lib/components/transactions/FixedBottomTransaction.svelte
@@ -62,6 +62,7 @@
 			<button
 				on:click={dismissTransaction}
 				class="flex-shrink-0 p-1 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+				title="Dismiss transaction"
 				aria-label="Dismiss transaction"
 			>
 				<CloseOutline class="h-4 w-4" />

--- a/packages/webapp/src/__tests__/Sidebar.test.ts
+++ b/packages/webapp/src/__tests__/Sidebar.test.ts
@@ -84,6 +84,24 @@ describe('Sidebar', () => {
 		const barsButton = screen.getByTestId('sidebar-bars');
 		expect(barsButton).toBeInTheDocument();
 	});
+	it('shows hover title and aria-label on the open and close menu buttons', async () => {
+		mockWindowSize(500);
+		const mockColorTheme = writable('light');
+		const mockPage = {
+			url: { pathname: '/' }
+		};
+		render(Sidebar, { colorTheme: mockColorTheme, page: mockPage });
+
+		const barsButton = screen.getByTestId('sidebar-bars');
+		expect(barsButton).toHaveAttribute('title', 'Open menu');
+		expect(barsButton).toHaveAttribute('aria-label', 'Open menu');
+
+		await fireEvent.click(barsButton);
+
+		const closeButton = await screen.findByTestId('close-button');
+		expect(closeButton).toHaveAttribute('title', 'Close menu');
+		expect(closeButton).toHaveAttribute('aria-label', 'Close menu');
+	});
 	it('shows sidebar on wide screen', () => {
 		mockWindowSize(1025);
 		const mockColorTheme = writable('light');

--- a/packages/webapp/src/__tests__/TakeOrderModal.test.ts
+++ b/packages/webapp/src/__tests__/TakeOrderModal.test.ts
@@ -134,6 +134,21 @@ describe('TakeOrderModal', () => {
 		});
 	});
 
+	it('shows hover title and aria-label on the refresh quote icon', async () => {
+		vi.mocked(mockOrder.getQuotes).mockResolvedValue({
+			value: mockQuotes as never,
+			error: undefined
+		});
+
+		render(TakeOrderModal, defaultProps);
+
+		await waitFor(() => {
+			const refreshButton = screen.getByTestId('refresh-button');
+			expect(refreshButton).toHaveAttribute('title', 'Refresh quote');
+			expect(refreshButton).toHaveAttribute('aria-label', 'Refresh quote');
+		});
+	});
+
 	it('shows pair selector when multiple quotes are available', async () => {
 		const multiQuotes = [
 			...mockQuotes,

--- a/packages/webapp/src/lib/components/Sidebar.svelte
+++ b/packages/webapp/src/lib/components/Sidebar.svelte
@@ -55,6 +55,8 @@
 			color="alternative"
 			class="absolute left-2 top-2 flex size-8 items-center p-5 lg:hidden"
 			data-testid="sidebar-bars"
+			title="Open menu"
+			aria-label="Open menu"
 		>
 			<BarsSolid class="" />
 		</Button>
@@ -69,6 +71,8 @@
 			<CloseButton
 				data-testid="close-button"
 				class="absolute right-3 top-2 z-20 flex size-8 items-center border dark:border-gray-700 lg:hidden"
+				title="Close menu"
+				name="Close menu"
 				on:click={() => (sideBarHidden = true)}
 			/>
 		{/if}

--- a/packages/webapp/src/lib/components/TakeOrderModal.svelte
+++ b/packages/webapp/src/lib/components/TakeOrderModal.svelte
@@ -299,6 +299,8 @@
 						<h4 class="text-sm font-medium text-gray-700 dark:text-gray-300">Current Quote</h4>
 						<Refresh
 							class="h-5 w-5 cursor-pointer text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+							title="Refresh quote"
+							ariaLabel="Refresh quote"
 							on:click={refreshQuotes}
 							spin={isFetchingQuotes}
 						/>


### PR DESCRIPTION
## Complete #1847: hover text on all remaining icon-only buttons

#2743 was a partial pass that added hover text to the vault deposit/withdraw/menu
buttons (the *one example* the issue gives). This PR finishes #1847 by auditing the
**entire** webapp + ui-components for icon-only buttons (clickable elements rendering
only an icon, no visible text label) and adding hover text to every one still missing it.

### Mechanism (matches #2743)

Each icon-only button gets a visible hover `title` attribute (the actual hover
tooltip) plus an `aria-label` for screen readers, with text describing its action.
For the bare flowbite-icon components (`Refresh`, `PauseSolid`, `PlaySolid`) the
screen-reader text is passed via the component's `ariaLabel` prop (a plain
`aria-label` attribute is overridden by the component's own default), and `title`
is forwarded onto the SVG. The shared `Refresh` icon gained an optional `title` prop
so every refresh control can carry a contextual hover label.

### Already covered by #2743

| Component | Button | title / aria-label |
|---|---|---|
| `detail/OrderDetail.svelte` | deposit-button | Deposit into vault |
| `detail/OrderDetail.svelte` | withdraw-button | Withdraw from vault |
| `detail/VaultDetail.svelte` | deposit-button | Deposit to vault |
| `detail/VaultDetail.svelte` | withdraw-button | Withdraw from vault |
| `tables/VaultsListTable.svelte` | vault-menu | Vault actions |

### Added in this PR

| Component | Button (icon) | Hover title / aria-label |
|---|---|---|
| `ButtonDarkMode.svelte` | dark-mode toggle (`DarkMode`) | Toggle dark mode |
| `tables/OrdersListTable.svelte` | order actions menu (`DotsVerticalOutline`) | Order actions |
| `tables/OrderTradesListTable.svelte` | debug-trade-button (`BugOutline`) | Debug trade |
| `detail/TanstackOrderQuote.svelte` | refresh (`Refresh`) | Refresh quotes |
| `detail/TanstackOrderQuote.svelte` | pause auto-refresh (`PauseSolid`) | Pause auto-refresh |
| `detail/TanstackOrderQuote.svelte` | resume auto-refresh (`PlaySolid`) | Resume auto-refresh |
| `detail/TanstackOrderQuote.svelte` | debug quote, success row (`BugOutline`) | Debug quote |
| `detail/TanstackOrderQuote.svelte` | debug quote, error row (`BugOutline`) | Debug quote |
| `detail/TanstackOrderQuote.svelte` | copy quote error (`ClipboardOutline`) | Copy quote error |
| `transactions/FixedBottomTransaction.svelte` | dismiss (`CloseOutline`) | Dismiss transaction |
| `detail/OrderDetail.svelte` | top-refresh (`Refresh`) | Refresh order |
| `detail/VaultDetail.svelte` | top-refresh (`Refresh`) | Refresh vault |
| `TanstackAppTable.svelte` | refreshButton (`Refresh`) | Refresh |
| `webapp Sidebar.svelte` | open menu (`BarsSolid`) | Open menu |
| `webapp Sidebar.svelte` | close menu (`CloseButton`) | Close menu |
| `webapp TakeOrderModal.svelte` | refresh quote (`Refresh`) | Refresh quote |

Buttons that already had visible text next to their icon (e.g. `Hash.svelte`,
`LocalDbStatusCard.svelte`, "Clear search", "Take Order", "Remove", "Dismiss") are
not icon-only and are out of scope.

### Tests

Component tests assert the exact `title`/`aria-label` text on every touched button
(mutation-validated: removing or emptying a title fails the test). Existing
deposit/withdraw tests were extended to also assert the adjacent refresh control.

### Verification

- ui-components: `vitest` 644/644 pass, `svelte-check` 0 errors, `prettier`+`eslint` clean.
- webapp: `vitest` pass, `eslint` clean, `svelte-check` 0 errors with
  `PUBLIC_WALLETCONNECT_PROJECT_ID` set. The only check failure without it is the
  pre-existing `PUBLIC_WALLETCONNECT_PROJECT_ID` env error in
  `lib/services/handleWalletInitialization.ts` (present identically on `main`,
  unrelated to this change).

Closes #1847

🤖 Generated with [Claude Code](https://claude.com/claude-code)
