### PR TITLE
Fix red main: split arb test into one-contract-per-file

### DIFF
--- a/test/concrete/arb/RouteProcessorRaindexV6ArbOrderTaker.noEthForward.t.sol
+++ b/test/concrete/arb/RouteProcessorRaindexV6ArbOrderTaker.noEthForward.t.sol
@@ -6,28 +6,11 @@ import {Test} from "forge-std-1.16.1/src/Test.sol";
 
 import {RouteProcessorRaindexV6ArbOrderTaker} from "../../../src/concrete/arb/RouteProcessorRaindexV6ArbOrderTaker.sol";
 import {Float} from "raindex-interface-0.1.1/src/interface/IRaindexV6.sol";
-import {IRouteProcessor} from "src/interface/IRouteProcessor.sol";
 import {LibRainDeploy} from "rain-deploy-0.1.2/src/lib/LibRainDeploy.sol";
 import {LibTOFUTokenDecimals} from "rain-tofu-erc20-decimals-0.1.1/src/lib/LibTOFUTokenDecimals.sol";
 import {LibRaindexDeploy} from "../../../src/lib/deploy/LibRaindexDeploy.sol";
 import {MockToken} from "test/util/concrete/MockToken.sol";
-
-/// @dev Route processor mock that records the `msg.value` it was called with in
-/// storage slot 0, so a test can assert how much native ETH the arb forwarded.
-contract ValueRecordingRouteProcessor is IRouteProcessor {
-    function processRoute(address, uint256, address, uint256, address, bytes memory)
-        external
-        payable
-        returns (uint256)
-    {
-        // Slot 0 holds the last `msg.value` seen, readable via `vm.load` from
-        // the etched address.
-        assembly ("memory-safe") {
-            sstore(0, callvalue())
-        }
-        return 0;
-    }
-}
+import {ValueRecordingRouteProcessor} from "test/util/concrete/ValueRecordingRouteProcessor.sol";
 
 /// @title RouteProcessorRaindexV6ArbOrderTakerNoEthForwardTest
 /// @notice Locks the documented divergence from `LibGenericPoolExchange` (#2699):

--- a/test/util/concrete/ValueRecordingRouteProcessor.sol
+++ b/test/util/concrete/ValueRecordingRouteProcessor.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {IRouteProcessor} from "src/interface/IRouteProcessor.sol";
+
+/// @dev Route processor mock that records the `msg.value` it was called with in
+/// storage slot 0, so a test can assert how much native ETH the arb forwarded.
+contract ValueRecordingRouteProcessor is IRouteProcessor {
+    function processRoute(address, uint256, address, uint256, address, bytes memory)
+        external
+        payable
+        returns (uint256)
+    {
+        // Slot 0 holds the last `msg.value` seen, readable via `vm.load` from
+        // the etched address.
+        assembly ("memory-safe") {
+            sstore(0, callvalue())
+        }
+        return 0;
+    }
+}


### PR DESCRIPTION
## Problem

`main` is red on the shared `rainix-sol / static` job. The
`rainix-sol-single-contract` check fails:

```
ERROR: test/concrete/arb/RouteProcessorRaindexV6ArbOrderTaker.noEthForward.t.sol declares 2 contracts; Rain convention is one contract per file.
```

The file declared two top-level contracts: the `ValueRecordingRouteProcessor`
mock and the `RouteProcessorRaindexV6ArbOrderTakerNoEthForwardTest` test. This
reds `rainix-sol / static` on main and every open PR rather than being a per-PR
cause.

## Fix

Move the `ValueRecordingRouteProcessor` mock (verbatim body) to
`test/util/concrete/ValueRecordingRouteProcessor.sol` — matching the existing
`test/util/concrete/` mock convention (e.g. `MockRouteProcessor.sol`) — and
import it. The test file now declares exactly one contract. The now-unused
`IRouteProcessor` import (only the moved mock used it) is removed from the test
file.

## Local proof

In `nix develop github:rainlanguage/rainix#sol-shell`:

- `rainix-sol-single-contract` -> exit 0 (was exit 1)
- `forge fmt --check` on both files -> clean
- `forge test --match-path test/concrete/arb/RouteProcessorRaindexV6ArbOrderTaker.noEthForward.t.sol`
  -> `1 passed; 0 failed` (`testProcessRouteCalledWithNoEthValue`, 5096 runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test utilities by consolidating mock route processor implementations to reduce duplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->