### PR TITLE
Fix red main: pin 0.1.8 and 0.1.9 deploy constants

### DIFF
--- a/src/lib/deploy/LibRaindexDeploy.sol
+++ b/src/lib/deploy/LibRaindexDeploy.sol
@@ -105,6 +105,24 @@ library LibRaindexDeploy {
     bytes32 constant RAINDEX_DEPLOYED_CODEHASH_0_1_7 =
         0x774ca4c194abf0720bca6c033580762029a80291feefd0a4b7855b16bcbbf7a9;
 
+    /// The deployed address of the `RaindexV6` contract at the published `0.1.8`
+    /// tag. (Unchanged from `0.1.7`.)
+    address constant RAINDEX_DEPLOYED_ADDRESS_0_1_8 = 0x86594ac4319230870C6E587f4ACa48FAb575619e;
+
+    /// The runtime code hash of the `RaindexV6` contract at the published `0.1.8`
+    /// tag.
+    bytes32 constant RAINDEX_DEPLOYED_CODEHASH_0_1_8 =
+        0x774ca4c194abf0720bca6c033580762029a80291feefd0a4b7855b16bcbbf7a9;
+
+    /// The deployed address of the `RaindexV6` contract at the published `0.1.9`
+    /// tag. (Unchanged from `0.1.7`.)
+    address constant RAINDEX_DEPLOYED_ADDRESS_0_1_9 = 0x86594ac4319230870C6E587f4ACa48FAb575619e;
+
+    /// The runtime code hash of the `RaindexV6` contract at the published `0.1.9`
+    /// tag.
+    bytes32 constant RAINDEX_DEPLOYED_CODEHASH_0_1_9 =
+        0x774ca4c194abf0720bca6c033580762029a80291feefd0a4b7855b16bcbbf7a9;
+
     /// The address of the `RaindexV6SubParser` contract when deployed with
     /// the rain standard zoltu deployer.
     address constant SUB_PARSER_DEPLOYED_ADDRESS = SUB_PARSER_ADDR;
@@ -176,6 +194,24 @@ library LibRaindexDeploy {
     bytes32 constant SUB_PARSER_DEPLOYED_CODEHASH_0_1_7 =
         0x704aadc1ed56f63ff918ab219e6681a5d2851d774e2ee136bbe7904ea3b2fdcd;
 
+    /// The deployed address of the `RaindexV6SubParser` contract at the
+    /// published `0.1.8` tag. (Unchanged from `0.1.2`.)
+    address constant SUB_PARSER_DEPLOYED_ADDRESS_0_1_8 = 0x09Bc7AF266012F44fb41D8Bd682da931666605e1;
+
+    /// The runtime code hash of the `RaindexV6SubParser` contract at the
+    /// published `0.1.8` tag.
+    bytes32 constant SUB_PARSER_DEPLOYED_CODEHASH_0_1_8 =
+        0x704aadc1ed56f63ff918ab219e6681a5d2851d774e2ee136bbe7904ea3b2fdcd;
+
+    /// The deployed address of the `RaindexV6SubParser` contract at the
+    /// published `0.1.9` tag. (Unchanged from `0.1.2`.)
+    address constant SUB_PARSER_DEPLOYED_ADDRESS_0_1_9 = 0x09Bc7AF266012F44fb41D8Bd682da931666605e1;
+
+    /// The runtime code hash of the `RaindexV6SubParser` contract at the
+    /// published `0.1.9` tag.
+    bytes32 constant SUB_PARSER_DEPLOYED_CODEHASH_0_1_9 =
+        0x704aadc1ed56f63ff918ab219e6681a5d2851d774e2ee136bbe7904ea3b2fdcd;
+
     /// The address of the `RouteProcessor4` contract when deployed with the
     /// rain standard zoltu deployer.
     address constant ROUTE_PROCESSOR_DEPLOYED_ADDRESS = ROUTE_PROCESSOR_ADDR;
@@ -245,6 +281,24 @@ library LibRaindexDeploy {
     /// The runtime code hash of the `RouteProcessor4` contract at the published `0.1.7`
     /// tag.
     bytes32 constant ROUTE_PROCESSOR_DEPLOYED_CODEHASH_0_1_7 =
+        0xeb3745a79c6ba48e8767b9c355b8e7b79f9d6edeca004e4bb91be4de515a7eeb;
+
+    /// The deployed address of the `RouteProcessor4` contract at the published
+    /// `0.1.8` tag. (Unchanged from `0.1.7`.)
+    address constant ROUTE_PROCESSOR_DEPLOYED_ADDRESS_0_1_8 = 0x6E2d0e71d900474b262E545Bc4C98b71ab368d21;
+
+    /// The runtime code hash of the `RouteProcessor4` contract at the published
+    /// `0.1.8` tag.
+    bytes32 constant ROUTE_PROCESSOR_DEPLOYED_CODEHASH_0_1_8 =
+        0xeb3745a79c6ba48e8767b9c355b8e7b79f9d6edeca004e4bb91be4de515a7eeb;
+
+    /// The deployed address of the `RouteProcessor4` contract at the published
+    /// `0.1.9` tag. (Unchanged from `0.1.7`.)
+    address constant ROUTE_PROCESSOR_DEPLOYED_ADDRESS_0_1_9 = 0x6E2d0e71d900474b262E545Bc4C98b71ab368d21;
+
+    /// The runtime code hash of the `RouteProcessor4` contract at the published
+    /// `0.1.9` tag.
+    bytes32 constant ROUTE_PROCESSOR_DEPLOYED_CODEHASH_0_1_9 =
         0xeb3745a79c6ba48e8767b9c355b8e7b79f9d6edeca004e4bb91be4de515a7eeb;
 
     /// The address of the `GenericPoolRaindexV6ArbOrderTaker` contract when
@@ -319,6 +373,24 @@ library LibRaindexDeploy {
     /// The runtime code hash of the `GenericPoolRaindexV6ArbOrderTaker` contract at the published `0.1.7`
     /// tag.
     bytes32 constant GENERIC_POOL_ARB_ORDER_TAKER_DEPLOYED_CODEHASH_0_1_7 =
+        0xc4492cb22d918a3f0d41f13e533744ef03a2e7f744ec0a43b79d97a04c537544;
+
+    /// The deployed address of the `GenericPoolRaindexV6ArbOrderTaker` contract
+    /// at the published `0.1.8` tag. (Unchanged from `0.1.7`.)
+    address constant GENERIC_POOL_ARB_ORDER_TAKER_DEPLOYED_ADDRESS_0_1_8 = 0xc0c17e58018C80A5420dF7756acd2B2dcf37e380;
+
+    /// The runtime code hash of the `GenericPoolRaindexV6ArbOrderTaker` contract
+    /// at the published `0.1.8` tag.
+    bytes32 constant GENERIC_POOL_ARB_ORDER_TAKER_DEPLOYED_CODEHASH_0_1_8 =
+        0xc4492cb22d918a3f0d41f13e533744ef03a2e7f744ec0a43b79d97a04c537544;
+
+    /// The deployed address of the `GenericPoolRaindexV6ArbOrderTaker` contract
+    /// at the published `0.1.9` tag. (Unchanged from `0.1.7`.)
+    address constant GENERIC_POOL_ARB_ORDER_TAKER_DEPLOYED_ADDRESS_0_1_9 = 0xc0c17e58018C80A5420dF7756acd2B2dcf37e380;
+
+    /// The runtime code hash of the `GenericPoolRaindexV6ArbOrderTaker` contract
+    /// at the published `0.1.9` tag.
+    bytes32 constant GENERIC_POOL_ARB_ORDER_TAKER_DEPLOYED_CODEHASH_0_1_9 =
         0xc4492cb22d918a3f0d41f13e533744ef03a2e7f744ec0a43b79d97a04c537544;
 
     /// The address of the `RouteProcessorRaindexV6ArbOrderTaker` contract
@@ -402,6 +474,26 @@ library LibRaindexDeploy {
     bytes32 constant ROUTE_PROCESSOR_ARB_ORDER_TAKER_DEPLOYED_CODEHASH_0_1_7 =
         0xc3fb3bb0355fee22e54cade57f5ff828478d59f34fdd8057bc0bc6a11b3d48fc;
 
+    /// The deployed address of the `RouteProcessorRaindexV6ArbOrderTaker`
+    /// contract at the published `0.1.8` tag. (Unchanged from `0.1.7`.)
+    address constant ROUTE_PROCESSOR_ARB_ORDER_TAKER_DEPLOYED_ADDRESS_0_1_8 =
+        0x5Ec2625ee7c73c85fAb2bc4cf527E1434F0dcC5d;
+
+    /// The runtime code hash of the `RouteProcessorRaindexV6ArbOrderTaker`
+    /// contract at the published `0.1.8` tag.
+    bytes32 constant ROUTE_PROCESSOR_ARB_ORDER_TAKER_DEPLOYED_CODEHASH_0_1_8 =
+        0xc3fb3bb0355fee22e54cade57f5ff828478d59f34fdd8057bc0bc6a11b3d48fc;
+
+    /// The deployed address of the `RouteProcessorRaindexV6ArbOrderTaker`
+    /// contract at the published `0.1.9` tag. (Unchanged from `0.1.7`.)
+    address constant ROUTE_PROCESSOR_ARB_ORDER_TAKER_DEPLOYED_ADDRESS_0_1_9 =
+        0x5Ec2625ee7c73c85fAb2bc4cf527E1434F0dcC5d;
+
+    /// The runtime code hash of the `RouteProcessorRaindexV6ArbOrderTaker`
+    /// contract at the published `0.1.9` tag.
+    bytes32 constant ROUTE_PROCESSOR_ARB_ORDER_TAKER_DEPLOYED_CODEHASH_0_1_9 =
+        0xc3fb3bb0355fee22e54cade57f5ff828478d59f34fdd8057bc0bc6a11b3d48fc;
+
     /// The address of the `GenericPoolRaindexV6FlashBorrower` contract when
     /// deployed with the rain standard zoltu deployer.
     address constant GENERIC_POOL_FLASH_BORROWER_DEPLOYED_ADDRESS = GENERIC_POOL_FB_ADDR;
@@ -474,6 +566,24 @@ library LibRaindexDeploy {
     /// The runtime code hash of the `GenericPoolRaindexV6FlashBorrower` contract at the published `0.1.7`
     /// tag.
     bytes32 constant GENERIC_POOL_FLASH_BORROWER_DEPLOYED_CODEHASH_0_1_7 =
+        0xed618063fd6ffc7558e4588ea6357356e781d660fa22caa292a2f9aeaa21996f;
+
+    /// The deployed address of the `GenericPoolRaindexV6FlashBorrower` contract
+    /// at the published `0.1.8` tag. (Unchanged from `0.1.7`.)
+    address constant GENERIC_POOL_FLASH_BORROWER_DEPLOYED_ADDRESS_0_1_8 = 0xAd8af7f90a06659E9bBFD457c6C642fB60B1F46b;
+
+    /// The runtime code hash of the `GenericPoolRaindexV6FlashBorrower` contract
+    /// at the published `0.1.8` tag.
+    bytes32 constant GENERIC_POOL_FLASH_BORROWER_DEPLOYED_CODEHASH_0_1_8 =
+        0xed618063fd6ffc7558e4588ea6357356e781d660fa22caa292a2f9aeaa21996f;
+
+    /// The deployed address of the `GenericPoolRaindexV6FlashBorrower` contract
+    /// at the published `0.1.9` tag. (Unchanged from `0.1.7`.)
+    address constant GENERIC_POOL_FLASH_BORROWER_DEPLOYED_ADDRESS_0_1_9 = 0xAd8af7f90a06659E9bBFD457c6C642fB60B1F46b;
+
+    /// The runtime code hash of the `GenericPoolRaindexV6FlashBorrower` contract
+    /// at the published `0.1.9` tag.
+    bytes32 constant GENERIC_POOL_FLASH_BORROWER_DEPLOYED_CODEHASH_0_1_9 =
         0xed618063fd6ffc7558e4588ea6357356e781d660fa22caa292a2f9aeaa21996f;
 
     uint256 constant RAINDEX_START_BLOCK_ARBITRUM = 473030678;


### PR DESCRIPTION
## Problem

`main` is red on the shared `rainix-sol / test` job (and every open PR shares
this). The 0.1.8 and 0.1.9 soldeer releases published `raindex` tags without
pinning their deploy constants, so `testAllPublishedSoldeerTagsHaveAFullConstantSuite`
fails:

```
[FAIL: a published soldeer tag is missing pinned deploy constants:
MISSING: RAINDEX_DEPLOYED_ADDRESS_0_1_8 ... GENERIC_POOL_FLASH_BORROWER_DEPLOYED_CODEHASH_0_1_9]
```

`script/check-published-deploy-constants.sh` queries the live registry and
reports the missing `*_0_1_8` and `*_0_1_9` constants for all six deployed
contracts (24 constants).

## Fix

No deployed contract changed between 0.1.7 and 0.1.9. Every current
`src/generated/*.pointers.sol` `DEPLOYED_ADDRESS` / `BYTECODE_HASH` is
byte-identical to the pinned `0.1.7` value for all six contracts, so the 0.1.8
and 0.1.9 releases were content-gate triggered by non-contract `src/` changes.
Pin both versions reusing each contract's `0.1.7` address/codehash (24 new
constants), following the existing `(Unchanged from ...)` convention. No new
deploy is needed (the prod-deploy fork tests are already green; the contracts
were deployed by their own PRs).

Per the runbook, pinning published-tag constants is not itself a content change
(the autopublish gate strips the pinned `*_<ver>` blocks before hashing), so
this does not trigger a further publish.

## Local proof

- `bash script/check-published-deploy-constants.sh` -> `OK` (was a long `MISSING:` list)
- In `nix develop github:rainlanguage/rainix#sol-shell`:
  `forge test --ffi --match-path test/lib/deploy/LibRaindexDeployTaggedConstants.t.sol`
  -> `1 passed; 0 failed` (`testAllPublishedSoldeerTagsHaveAFullConstantSuite`)
- `forge fmt --check src/lib/deploy/LibRaindexDeploy.sol` -> clean
- Each new `*_0_1_8` / `*_0_1_9` codehash verified byte-identical to its `*_0_1_7` sibling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)