### PR TITLE
Fix red main: rustfmt build_approval_calldata signature

### DIFF
--- a/crates/common/src/raindex_client/vaults.rs
+++ b/crates/common/src/raindex_client/vaults.rs
@@ -443,10 +443,7 @@ impl RaindexVault {
     /// Used by [`RaindexVault::get_calldatas`] so the on-chain allowance is only read once.
     /// It reads the allowance via [`Self::read_allowance`] (deposit-free), so it takes no
     /// [`DepositArgs`].
-    async fn build_approval_calldata(
-        &self,
-        amount: &Float,
-    ) -> Result<Option<Bytes>, RaindexError> {
+    async fn build_approval_calldata(&self, amount: &Float) -> Result<Option<Bytes>, RaindexError> {
         let allowance = self.read_allowance().await?;
         let allowance_float = Float::from_fixed_decimal(allowance, self.token.decimals)?;
 


### PR DESCRIPTION
## Problem

`main` is red on the `rs-static` job, which runs `cargo fmt --all -- --check`:

```
Diff in crates/common/src/raindex_client/vaults.rs:443:
-    async fn build_approval_calldata(
-        &self,
-        amount: &Float,
-    ) -> Result<Option<Bytes>, RaindexError> {
+    async fn build_approval_calldata(&self, amount: &Float) -> Result<Option<Bytes>, RaindexError> {
```

The `build_approval_calldata` signature is split across four lines but fits on
one, so rustfmt wants it collapsed. This reds `rs-static` on main and every open
PR.

## Fix

Apply exactly the formatting `cargo fmt` produces: collapse the signature to one
line. No behavior change.

## Local proof

In `nix develop .#wasm-shell`: `cargo fmt --all -- --check` -> exit 0 (was exit 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)