### PR TITLE
Fix red main: gate allowance.rs tests to non-wasm (httpmock)

### DIFF
--- a/crates/common/src/allowance.rs
+++ b/crates/common/src/allowance.rs
@@ -18,7 +18,7 @@ pub async fn read_allowance(
     read_call(rpcs, token, allowanceCall { owner, spender }).await
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(target_family = "wasm")))]
 mod tests {
     use super::*;
     use alloy::hex::encode_prefixed;


### PR DESCRIPTION
## Problem

`main` is red on `wasm-test` and `wasm-browser-test` (both required checks). The
`raindex_common` lib tests fail to compile for `wasm32-unknown-unknown`:

```
error[E0432]: unresolved import `httpmock`
  --> crates/common/src/allowance.rs:26:9
26 |     use httpmock::MockServer;
```

`allowance.rs`'s `mod tests` was gated only `#[cfg(test)]`, but it uses
`httpmock` (a `[target.'cfg(not(target_family = "wasm"))'.dev-dependencies]`
dep) and `tokio::runtime::Runtime`, so it compiled under wasm where httpmock is
absent. The other 6 `error[E0282]: type annotations needed` were knock-on
effects of the failed crate compile, not independent problems. This reds both
wasm jobs on main and every open PR.

## Fix

Gate the module `#[cfg(all(test, not(target_family = "wasm")))]`, matching every
other httpmock-using test module in the crate (`erc20.rs`, `rpc_client.rs`,
`dotrain_order.rs`, vaults' `mod non_wasm`, ...). The tests still run on native
(`rs-test`).

## Local proof

In `nix develop .#wasm-shell`:

- `CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=wasm-bindgen-test-runner cargo test --no-run --target wasm32-unknown-unknown --lib -p raindex_common`
  -> `Finished`, exit 0 (was exit 101, `error[E0432]: unresolved import httpmock`)
- `cargo test --no-run -p raindex_common --lib` (native) -> `Finished`, exit 0
  (tests still compile on native).

🤖 Generated with [Claude Code](https://claude.com/claude-code)