### PR TITLE
RAI-1025 extend add order indexing wait

### DIFF
--- a/packages/ui-components/src/__tests__/TransactionManager.test.ts
+++ b/packages/ui-components/src/__tests__/TransactionManager.test.ts
@@ -1009,6 +1009,39 @@ describe("TransactionManager", () => {
       });
     });
 
+    it("should wait up to 60 seconds for add-order indexing", async () => {
+      const mockTransaction = { execute: vi.fn() };
+      vi.mocked(TransactionStore).mockImplementation(
+        () => mockTransaction as unknown as TransactionStore,
+      );
+
+      await manager.createAddOrderTransaction(addOrderMockArgs);
+
+      const callArgs = vi.mocked(TransactionStore).mock.calls[0][0];
+      const mockContext: IndexingContext = {
+        updateState: vi.fn(),
+        onSuccess: vi.fn(),
+        onError: vi.fn(),
+        links: [],
+      };
+
+      vi.mocked(
+        mockRaindexClient.getAddOrdersForTransaction,
+      ).mockResolvedValueOnce({
+        value: [{ orderHash: "0xneworderhash" }],
+      } as unknown as WasmEncodedResult<RaindexOrder[]>);
+
+      await callArgs.awaitIndexingFn!(mockContext);
+
+      expect(mockRaindexClient.getAddOrdersForTransaction).toHaveBeenCalledWith(
+        addOrderMockArgs.chainId,
+        addOrderMockArgs.raindex,
+        addOrderMockArgs.txHash,
+        12,
+        5000,
+      );
+    });
+
     it("should handle failed transaction", async () => {
       const mockTransaction = { execute: vi.fn() };
       let onError: () => void;

--- a/packages/ui-components/src/lib/providers/transactions/TransactionManager.ts
+++ b/packages/ui-components/src/lib/providers/transactions/TransactionManager.ts
@@ -33,10 +33,12 @@ import {
  */
 export type AddToastFunction = (toast: Omit<ToastProps, "id">) => void;
 
+const ADD_ORDER_INDEXING_MAX_ATTEMPTS = 12;
+const ADD_ORDER_INDEXING_INTERVAL_MS = 5_000;
+
 /**
  * Creates an indexing function that wraps SDK-based polling logic.
- * The SDK handles local-DB-first polling followed by subgraph fallback internally,
- * so we only need to call it once.
+ * The SDK handles the retry loop internally, so we only need to call it once.
  *
  * @param options Configuration for SDK-based indexing
  * @param options.call Function that calls the SDK method (e.g. getAddOrdersForTransaction)
@@ -496,11 +498,16 @@ export class TransactionManager {
       },
     ];
 
-    // SDK-based indexing - the SDK's getAddOrdersForTransaction handles
-    // local-DB-first polling followed by subgraph fallback internally
+    // SDK-based indexing - getAddOrdersForTransaction handles the retry loop.
     const awaitIndexingFn = createSdkIndexingFn({
       call: () =>
-        raindexClient.getAddOrdersForTransaction(chainId, raindex, txHash),
+        raindexClient.getAddOrdersForTransaction(
+          chainId,
+          raindex,
+          txHash,
+          ADD_ORDER_INDEXING_MAX_ATTEMPTS,
+          ADD_ORDER_INDEXING_INTERVAL_MS,
+        ),
       isSuccess: (orders) => Array.isArray(orders) && orders.length > 0,
       buildLinks: (orders) => {
         if (!Array.isArray(orders) || orders.length === 0) return [];


### PR DESCRIPTION
## Motivation
Deploy-order confirmation can show a subgraph timeout toast even when the transaction has likely landed, because the UI was relying on the SDK's default add-order indexing budget of roughly 10 seconds.

## Solution
- Pass explicit add-order indexing polling options from the transaction manager: 12 attempts at 5 seconds each.
- Keep the change scoped to add-order deployment confirmation.
- Update the nearby SDK retry-loop comment and add a unit test that locks the 60-second budget.

## Checks
- npm run test:unit -- TransactionManager.test.ts --run
- bunx prettier --check packages/ui-components/src/lib/providers/transactions/TransactionManager.ts packages/ui-components/src/__tests__/TransactionManager.test.ts

Closes RAI-1025

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced add-order transaction indexing reliability with configurable polling behavior (max attempts and interval).
  * Updated the underlying add-order indexing workflow to use the improved polling configuration.
* **Tests**
  * Added coverage for the add-order indexing “await” path, including verification of the SDK polling parameters used during retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->