### PR TITLE
test: mutation-harden SgVaultBalanceChangeType accessor coverage

### DIFF
--- a/crates/subgraph/src/types/common.rs
+++ b/crates/subgraph/src/types/common.rs
@@ -933,3 +933,166 @@ mod impls {
     impl_wasm_traits!(SgTradeEventTypename);
     impl_wasm_traits!(SgTradeRef);
 }
+
+#[cfg(test)]
+mod sg_vault_balance_change_type_tests {
+    use super::*;
+
+    fn vault_ref() -> SgVaultBalanceChangeVault {
+        SgVaultBalanceChangeVault {
+            id: SgBytes("0xvault".to_string()),
+            vault_id: SgBytes("vault-id".to_string()),
+            token: SgErc20 {
+                id: SgBytes("0xtoken".to_string()),
+                address: SgBytes("0xtoken".to_string()),
+                name: Some("Token".to_string()),
+                symbol: Some("TKN".to_string()),
+                decimals: Some(SgBigInt("18".to_string())),
+            },
+        }
+    }
+
+    fn raindex_ref() -> SgRaindex {
+        SgRaindex {
+            id: SgBytes("0xraindex".to_string()),
+        }
+    }
+
+    // Each variant is built so that, within a variant, every accessor-exposed
+    // field carries a DISTINCT value (so an arm that returns the wrong field is
+    // caught), and so that the same accessor returns a DIFFERENT value across
+    // variants (so an arm that delegates to the wrong variant's struct is
+    // caught). The prefix encodes the variant; the suffix encodes the field.
+    fn transaction_for(prefix: &str) -> SgTransaction {
+        SgTransaction {
+            id: SgBytes(format!("{prefix}-tx-id")),
+            from: SgBytes(format!("{prefix}-tx-from")),
+            block_number: SgBigInt(format!("{prefix}-tx-block")),
+            timestamp: SgBigInt(format!("{prefix}-tx-ts")),
+        }
+    }
+
+    fn withdrawal() -> SgVaultBalanceChangeType {
+        SgVaultBalanceChangeType::Withdrawal(SgWithdrawal {
+            id: SgBytes("withdrawal-id".to_string()),
+            __typename: "Withdrawal".to_string(),
+            amount: SgBytes("withdrawal-amount".to_string()),
+            new_vault_balance: SgBytes("withdrawal-newbal".to_string()),
+            old_vault_balance: SgBytes("withdrawal-oldbal".to_string()),
+            vault: vault_ref(),
+            timestamp: SgBigInt("withdrawal-ts".to_string()),
+            transaction: transaction_for("withdrawal"),
+            raindex: raindex_ref(),
+        })
+    }
+
+    fn trade_change() -> SgVaultBalanceChangeType {
+        SgVaultBalanceChangeType::TradeVaultBalanceChange(SgTradeVaultBalanceChange {
+            id: SgBytes("trade-id".to_string()),
+            __typename: "TradeVaultBalanceChange".to_string(),
+            amount: SgBytes("trade-amount".to_string()),
+            new_vault_balance: SgBytes("trade-newbal".to_string()),
+            old_vault_balance: SgBytes("trade-oldbal".to_string()),
+            vault: vault_ref(),
+            timestamp: SgBigInt("trade-ts".to_string()),
+            transaction: transaction_for("trade"),
+            raindex: raindex_ref(),
+            trade: SgTradeRef {
+                trade_event: SgTradeEventTypename {
+                    __typename: "TradeEvent".to_string(),
+                },
+            },
+        })
+    }
+
+    fn deposit() -> SgVaultBalanceChangeType {
+        SgVaultBalanceChangeType::Deposit(SgDeposit {
+            id: SgBytes("deposit-id".to_string()),
+            __typename: "Deposit".to_string(),
+            amount: SgBytes("deposit-amount".to_string()),
+            new_vault_balance: SgBytes("deposit-newbal".to_string()),
+            old_vault_balance: SgBytes("deposit-oldbal".to_string()),
+            vault: vault_ref(),
+            timestamp: SgBigInt("deposit-ts".to_string()),
+            transaction: transaction_for("deposit"),
+            raindex: raindex_ref(),
+        })
+    }
+
+    fn clear_bounty() -> SgVaultBalanceChangeType {
+        SgVaultBalanceChangeType::ClearBounty(SgClearBounty {
+            id: SgBytes("clearbounty-id".to_string()),
+            __typename: "ClearBounty".to_string(),
+            amount: SgBytes("clearbounty-amount".to_string()),
+            new_vault_balance: SgBytes("clearbounty-newbal".to_string()),
+            old_vault_balance: SgBytes("clearbounty-oldbal".to_string()),
+            vault: vault_ref(),
+            timestamp: SgBigInt("clearbounty-ts".to_string()),
+            transaction: transaction_for("clearbounty"),
+            raindex: raindex_ref(),
+            sender: SgBytes("clearbounty-sender".to_string()),
+        })
+    }
+
+    #[test]
+    fn test_typename_all_variants() {
+        // The __typename field is populated independently of the variant name,
+        // so this also pins each arm to its own variant's stored field.
+        assert_eq!(withdrawal().typename(), "Withdrawal");
+        assert_eq!(trade_change().typename(), "TradeVaultBalanceChange");
+        assert_eq!(deposit().typename(), "Deposit");
+        assert_eq!(clear_bounty().typename(), "ClearBounty");
+        // Unknown is a unit variant: the string is a literal, not a field.
+        assert_eq!(SgVaultBalanceChangeType::Unknown.typename(), "Unknown");
+    }
+
+    #[test]
+    fn test_timestamp_all_variants() {
+        assert_eq!(withdrawal().timestamp().unwrap().0, "withdrawal-ts");
+        assert_eq!(trade_change().timestamp().unwrap().0, "trade-ts");
+        assert_eq!(deposit().timestamp().unwrap().0, "deposit-ts");
+        assert_eq!(clear_bounty().timestamp().unwrap().0, "clearbounty-ts");
+        assert!(SgVaultBalanceChangeType::Unknown.timestamp().is_none());
+    }
+
+    #[test]
+    fn test_amount_all_variants() {
+        assert_eq!(withdrawal().amount().unwrap().0, "withdrawal-amount");
+        assert_eq!(trade_change().amount().unwrap().0, "trade-amount");
+        assert_eq!(deposit().amount().unwrap().0, "deposit-amount");
+        assert_eq!(clear_bounty().amount().unwrap().0, "clearbounty-amount");
+        assert!(SgVaultBalanceChangeType::Unknown.amount().is_none());
+    }
+
+    #[test]
+    fn test_new_vault_balance_all_variants() {
+        assert_eq!(
+            withdrawal().new_vault_balance().unwrap().0,
+            "withdrawal-newbal"
+        );
+        assert_eq!(
+            trade_change().new_vault_balance().unwrap().0,
+            "trade-newbal"
+        );
+        assert_eq!(deposit().new_vault_balance().unwrap().0, "deposit-newbal");
+        assert_eq!(
+            clear_bounty().new_vault_balance().unwrap().0,
+            "clearbounty-newbal"
+        );
+        assert!(SgVaultBalanceChangeType::Unknown
+            .new_vault_balance()
+            .is_none());
+    }
+
+    #[test]
+    fn test_transaction_all_variants() {
+        assert_eq!(withdrawal().transaction().unwrap().id.0, "withdrawal-tx-id");
+        assert_eq!(trade_change().transaction().unwrap().id.0, "trade-tx-id");
+        assert_eq!(deposit().transaction().unwrap().id.0, "deposit-tx-id");
+        assert_eq!(
+            clear_bounty().transaction().unwrap().id.0,
+            "clearbounty-tx-id"
+        );
+        assert!(SgVaultBalanceChangeType::Unknown.transaction().is_none());
+    }
+}


### PR DESCRIPTION
## Module

`crates/subgraph/src/types/common.rs` — the `SgVaultBalanceChangeType` accessor methods (`typename`, `timestamp`, `amount`, `new_vault_balance`, `transaction`). These are pure response→domain mapping: each method `match`es the enum's five variants (`Withdrawal`, `TradeVaultBalanceChange`, `Deposit`, `ClearBounty`, `Unknown`) and returns the corresponding field of the inner struct.

This is the weakest high-value pure-logic module in the subgraph client: `types/common.rs` had **no test module at all**, and these accessors were only exercised indirectly and partially:
- `typename()` — only via the `Deposit` variant (in `raindex_client/vault.rs` type-filter tests).
- `timestamp()` — only via `Deposit`/`Withdrawal` in the `vault_balance_changes_query.rs` sort test.
- `amount()`, `new_vault_balance()`, `transaction()` — **never asserted anywhere** in the crate.

By contrast, the query/filter-construction modules I surveyed (`raindex_client/order.rs::orders_list`, `raindex_client/vault.rs::vaults_list`, `pagination.rs`, `utils/slice_list.rs`) are already mutation-saturated with `body_contains` where-clause assertions, so this enum-mapping logic was the genuine gap.

## Mutation matrix

For each accessor arm I mutated the exact return expression (swap a variant's field to a sibling field, or `Some↔None`), ran the crate test suite, and recorded survival. On the unmutated suite **every** mutant below SURVIVED before this PR. After adding the discriminating tests, all are KILLED:

| Accessor | Withdrawal | TradeVaultBalanceChange | Deposit | ClearBounty | Unknown |
|---|---|---|---|---|---|
| `typename` | KILLED | KILLED | KILLED | KILLED | KILLED (literal) |
| `timestamp` | KILLED | KILLED | KILLED | KILLED | covered (`is_none`) |
| `amount` | KILLED | KILLED | KILLED | KILLED | covered (`is_none`) |
| `new_vault_balance` | KILLED | KILLED | KILLED | KILLED | covered (`is_none`) |
| `transaction` | KILLED | KILLED | KILLED | KILLED | covered (`is_none`) |

21 arm mutations covered, **0 survivors**. Each test builds one instance of every variant with field-distinct values (so an arm returning the wrong field is caught) and variant-distinct values (so an arm delegating to the wrong variant's struct is caught); the `Unknown` arm is pinned with `is_none()` / literal assertions.

## Gaps / notes

- One mutation in my harness (`timestamp` `Unknown → Some(&temp)`) is a build error (borrow of a temporary), not a coverage gap — the `Unknown` arm is already pinned by the `is_none()` assertion.
- No production code changed; diff is a single additive `#[cfg(test)] mod` (+163 lines). `cargo fmt` and `cargo clippy --tests` are clean; crate `cargo test` is green locally (185 passed, was 180).

## Inherited-red note

`main` is currently RED on unrelated 4-fix-set causes (rs-static rustfmt, sol-static, sol-test, wasm; tracked by #2749–#2752). A Rust coverage PR branched off `main` inherits those reds until they merge — they are **not** introduced by this change. The subgraph crate's own `cargo test` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)