### PR TITLE
test: mutation-harden webapp deploy <+layout> coverage

### DIFF
--- a/packages/webapp/src/routes/deploy/layout.test.ts
+++ b/packages/webapp/src/routes/deploy/layout.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { load } from './+layout';
+
+describe('deploy /+layout load function', () => {
+	const mockGetAllOrderDetails = vi.fn();
+	const mockOrdersGet = vi.fn();
+
+	const makeRegistry = () => ({
+		getAllOrderDetails: mockGetAllOrderDetails,
+		orders: { get: mockOrdersGet }
+	});
+
+	const mockParent = vi.fn();
+
+	beforeEach(() => {
+		vi.resetAllMocks();
+	});
+
+	const callLoad = () =>
+		load({
+			parent: mockParent
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		} as any);
+
+	it('returns "Registry not loaded" when parent registry is null', async () => {
+		mockParent.mockResolvedValue({ registry: null });
+
+		const result = await callLoad();
+
+		expect(result).toEqual({
+			validOrders: [],
+			invalidOrders: [],
+			registry: null,
+			error: 'Registry not loaded'
+		});
+		// getAllOrderDetails must not be reached when registry is missing
+		expect(mockGetAllOrderDetails).not.toHaveBeenCalled();
+	});
+
+	it('returns "Registry not loaded" when parent does not provide a registry', async () => {
+		// registry is undefined -> `?? null` coalescing path
+		mockParent.mockResolvedValue({});
+
+		const result = await callLoad();
+
+		expect(result.registry).toBeNull();
+		expect(result.error).toBe('Registry not loaded');
+	});
+
+	it('returns the registry error readableMsg when getAllOrderDetails errors', async () => {
+		const registry = makeRegistry();
+		mockGetAllOrderDetails.mockReturnValue({
+			error: { readableMsg: 'Human readable failure', msg: 'raw failure' }
+		});
+		mockParent.mockResolvedValue({ registry });
+
+		const result = await callLoad();
+
+		expect(result).toEqual({
+			validOrders: [],
+			invalidOrders: [],
+			registry,
+			error: 'Human readable failure'
+		});
+	});
+
+	it('falls back to error.msg when readableMsg is absent on the registry error', async () => {
+		const registry = makeRegistry();
+		mockGetAllOrderDetails.mockReturnValue({
+			error: { msg: 'raw failure only' }
+		});
+		mockParent.mockResolvedValue({ registry });
+
+		const result = await callLoad();
+
+		expect(result.error).toBe('raw failure only');
+		expect(result.validOrders).toEqual([]);
+		expect(result.invalidOrders).toEqual([]);
+	});
+
+	it('does not treat a falsy-but-present error field as an error', async () => {
+		// `if (orderDetails.error)` must be falsy here so we proceed to mapping,
+		// not return early with `undefined` as the error message.
+		const registry = makeRegistry();
+		mockGetAllOrderDetails.mockReturnValue({
+			error: null,
+			value: { valid: new Map(), invalid: new Map() }
+		});
+		mockParent.mockResolvedValue({ registry });
+
+		const result = await callLoad();
+
+		expect(result.error).toBeNull();
+		expect(result.validOrders).toEqual([]);
+		expect(result.invalidOrders).toEqual([]);
+	});
+
+	it('maps valid orders with name, details and dotrain from registry.orders', async () => {
+		const registry = makeRegistry();
+		const detailsA = { name: 'Order A', description: 'desc A' };
+		const detailsB = { name: 'Order B', description: 'desc B' };
+		mockGetAllOrderDetails.mockReturnValue({
+			value: {
+				valid: new Map([
+					['order-a', detailsA],
+					['order-b', detailsB]
+				]),
+				invalid: new Map()
+			}
+		});
+		mockOrdersGet.mockImplementation((name: string) =>
+			name === 'order-a' ? 'dotrain-a-source' : 'dotrain-b-source'
+		);
+		mockParent.mockResolvedValue({ registry });
+
+		const result = await callLoad();
+
+		expect(result.error).toBeNull();
+		expect(result.validOrders).toEqual([
+			{ name: 'order-a', dotrain: 'dotrain-a-source', details: detailsA },
+			{ name: 'order-b', dotrain: 'dotrain-b-source', details: detailsB }
+		]);
+		// dotrain must come from the looked-up order keyed by its name
+		expect(mockOrdersGet).toHaveBeenCalledWith('order-a');
+		expect(mockOrdersGet).toHaveBeenCalledWith('order-b');
+	});
+
+	it('falls back to empty-string dotrain when registry.orders has no entry', async () => {
+		const registry = makeRegistry();
+		const details = { name: 'Order A', description: 'desc A' };
+		mockGetAllOrderDetails.mockReturnValue({
+			value: {
+				valid: new Map([['order-a', details]]),
+				invalid: new Map()
+			}
+		});
+		// registry.orders.get returns undefined -> `?? ''`
+		mockOrdersGet.mockReturnValue(undefined);
+		mockParent.mockResolvedValue({ registry });
+
+		const result = await callLoad();
+
+		expect(result.validOrders).toEqual([{ name: 'order-a', dotrain: '', details }]);
+	});
+
+	it('maps invalid orders using error.readableMsg', async () => {
+		const registry = makeRegistry();
+		mockGetAllOrderDetails.mockReturnValue({
+			value: {
+				valid: new Map(),
+				invalid: new Map([['broken-order', { readableMsg: 'nice message', msg: 'raw' }]])
+			}
+		});
+		mockParent.mockResolvedValue({ registry });
+
+		const result = await callLoad();
+
+		expect(result.invalidOrders).toEqual([{ name: 'broken-order', error: 'nice message' }]);
+		expect(result.error).toBeNull();
+	});
+
+	it('falls back to error.msg for invalid orders when readableMsg is absent', async () => {
+		const registry = makeRegistry();
+		mockGetAllOrderDetails.mockReturnValue({
+			value: {
+				valid: new Map(),
+				invalid: new Map([['broken-order', { msg: 'raw message only' }]])
+			}
+		});
+		mockParent.mockResolvedValue({ registry });
+
+		const result = await callLoad();
+
+		expect(result.invalidOrders).toEqual([{ name: 'broken-order', error: 'raw message only' }]);
+	});
+
+	it('returns both valid and invalid orders with error null on success', async () => {
+		const registry = makeRegistry();
+		const validDetails = { name: 'Good', description: 'good desc' };
+		mockGetAllOrderDetails.mockReturnValue({
+			value: {
+				valid: new Map([['good-order', validDetails]]),
+				invalid: new Map([['bad-order', { readableMsg: 'bad reason', msg: 'raw' }]])
+			}
+		});
+		mockOrdersGet.mockReturnValue('good-dotrain');
+		mockParent.mockResolvedValue({ registry });
+
+		const result = await callLoad();
+
+		expect(result).toEqual({
+			validOrders: [{ name: 'good-order', dotrain: 'good-dotrain', details: validDetails }],
+			invalidOrders: [{ name: 'bad-order', error: 'bad reason' }],
+			registry,
+			error: null
+		});
+	});
+
+	it('catches a thrown Error and returns its message', async () => {
+		const registry = makeRegistry();
+		mockGetAllOrderDetails.mockImplementation(() => {
+			throw new Error('boom from registry');
+		});
+		mockParent.mockResolvedValue({ registry });
+
+		const result = await callLoad();
+
+		expect(result).toEqual({
+			validOrders: [],
+			invalidOrders: [],
+			registry,
+			error: 'boom from registry'
+		});
+	});
+
+	it('catches a non-Error throw and returns the generic message', async () => {
+		const registry = makeRegistry();
+		// throw a non-Error value -> `error instanceof Error` is false
+		mockGetAllOrderDetails.mockImplementation(() => {
+			throw 'a plain string, not an Error';
+		});
+		mockParent.mockResolvedValue({ registry });
+
+		const result = await callLoad();
+
+		expect(result.error).toBe('Unknown error occurred');
+		expect(result.validOrders).toEqual([]);
+		expect(result.invalidOrders).toEqual([]);
+		expect(result.registry).toBe(registry);
+	});
+});


### PR DESCRIPTION
## Module

`packages/webapp/src/routes/deploy/+layout.ts` — the **deploy route's root `+layout.ts` `load` function**. It was entirely untested: no inline `import.meta.vitest` block and no sibling test file, unlike its `[orderName]` and `[deploymentKey]` child layouts which each ship a `layout.test.ts`. This was the weakest high-value untested webapp pure-logic module (route load logic with several `??` fallbacks and a catch ternary). Adds `packages/webapp/src/routes/deploy/layout.test.ts` (12 tests).

This is a standalone, **test-only** coverage PR. `git diff` touches no `src/` production code — only the new test file.

## Mutation matrix

Every behavior was validated by mutating the exact source line and running a fresh `npx vitest run src/routes/deploy/layout.test.ts` in isolation (no watch/cache reuse). All 13 mutants were **killed**, then the source was restored:

| # | Mutation | Behavior pinned | Result |
|---|---|---|---|
| M1 | drop `?? null` on `parentData.registry ?? null` | registry null-coalesce | KILLED |
| M2 | `if (!registry)` → `if (registry)` | registry-not-loaded guard | KILLED (12/12) |
| M3 | corrupt `'Registry not loaded'` string | guard error message | KILLED |
| M4 | `if (orderDetails.error)` → `if (!...)` | error early-return guard | KILLED |
| M5 | drop `readableMsg` in `readableMsg ?? msg` (registry error) | preferred message | KILLED |
| M6 | drop `?? msg` fallback (registry error) | fallback message | KILLED |
| M7 | drop `?? ''` on `registry.orders.get(name) ?? ''` | dotrain empty fallback | KILLED |
| M7b | wrong dotrain fallback value | dotrain empty fallback value | KILLED |
| M8 | drop `readableMsg` in invalid-order `readableMsg ?? msg` | preferred message | KILLED |
| M8b | drop `?? msg` fallback (invalid order) | fallback message | KILLED |
| M9 | success `error: null` → non-null | success return shape | KILLED (4 fail) |
| M10 | catch ternary → always `'Unknown error occurred'` | Error branch | KILLED |
| M10b | catch ternary → always `error.message` | non-Error branch | KILLED |

The 12 tests pass on the unmutated baseline (`12 passed`), pass within the full `npm run test -w @rainlanguage/webapp` suite, and eslint is clean on the new file.

## Gaps / saturation

None outstanding. The module was previously 0%-covered and is now branch-complete for `load()`. No real bug surfaced — the code is correct, just untested.

## Build / test recipe

Per `.github/workflows/test-webapp.yaml`, run inside `nix develop .#wasm-shell`: `npm install --no-check` → `npm run build -w @rainlanguage/raindex` (wasm) → `npm run build -w @rainlanguage/ui-components` → then vitest. Without the wasm + ui-components builds, vitest reds with "Failed to resolve entry".

## Inherited-red note

This branch is cut off `main`, which is currently RED on the 4-fix-set causes (rs-static, sol-static, sol-test, wasm) pending #2749–#2752. A coverage PR off main **inherits those reds** — they are pre-existing and **not** caused by this test-only change (it adds a single `*.test.ts` and edits no source). The relevant signal here is the webapp `test` job.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for the deploy layout functionality, validating error handling, order processing, and data structure integrity across various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->