### PR TITLE
Surface vaultless read models

### DIFF
--- a/crates/common/src/raindex_client/orders.rs
+++ b/crates/common/src/raindex_client/orders.rs
@@ -3070,6 +3070,8 @@ mod tests {
                 Address::from_str("0x0000000000000000000000000000000000000000").unwrap()
             );
             assert_eq!(order2_outputs.vault_id(), U256::from(0));
+            assert!(order2_outputs.vaultless());
+            assert!(order2_outputs.is_vaultless());
             assert_eq!(
                 order2_outputs.token().id(),
                 "0x0000000000000000000000000000000000000000".to_string()
@@ -3097,6 +3099,8 @@ mod tests {
                 Address::from_str("0x0000000000000000000000000000000000000000").unwrap()
             );
             assert_eq!(order2_inputs.vault_id(), U256::from(0));
+            assert!(order2_inputs.vaultless());
+            assert!(order2_inputs.is_vaultless());
             assert_eq!(
                 order2_inputs.token().id(),
                 "0x0000000000000000000000000000000000000000".to_string()

--- a/crates/common/src/raindex_client/vaults.rs
+++ b/crates/common/src/raindex_client/vaults.rs
@@ -132,6 +132,10 @@ impl RaindexVault {
     pub(crate) fn token_address(&self) -> Address {
         self.token.address
     }
+
+    pub fn is_vaultless(&self) -> bool {
+        self.vault_id == U256::ZERO
+    }
 }
 
 #[cfg(target_family = "wasm")]
@@ -164,6 +168,14 @@ impl RaindexVault {
     #[wasm_bindgen(getter = vaultId)]
     pub fn vault_id(&self) -> Result<BigInt, RaindexError> {
         Self::u256_to_bigint(self.vault_id)
+    }
+    #[wasm_bindgen(getter)]
+    pub fn vaultless(&self) -> bool {
+        self.is_vaultless()
+    }
+    #[wasm_bindgen(getter = isVaultless)]
+    pub fn is_vaultless_getter(&self) -> bool {
+        self.is_vaultless()
     }
     #[wasm_bindgen(getter)]
     pub fn balance(&self) -> Float {
@@ -207,6 +219,9 @@ impl RaindexVault {
     }
     pub fn vault_id(&self) -> U256 {
         self.vault_id
+    }
+    pub fn vaultless(&self) -> bool {
+        self.is_vaultless()
     }
     pub fn balance(&self) -> Float {
         self.balance

--- a/packages/raindex/test/js_api/raindexClient.test.ts
+++ b/packages/raindex/test/js_api/raindexClient.test.ts
@@ -658,6 +658,15 @@ describe("Rain Raindex JS API Package Bindgen Tests - Raindex Client", async fun
       assert.equal(result.orders.length, 2);
       assert.equal(result.orders[0].id, order1.id);
       assert.equal(result.orders[1].id, order2.id);
+      assert.equal(result.orders[0].vaultsList.items[0].isVaultless, false);
+      assert.equal(result.orders[0].vaultsList.items[0].vaultless, false);
+      assert.equal(result.orders[1].vaultsList.items[0].isVaultless, true);
+      assert.equal(result.orders[1].vaultsList.items[0].vaultless, true);
+      assert.equal(
+        result.orders[1].inputsOutputsList.items[0].isVaultless,
+        true,
+      );
+      assert.equal(result.orders[1].inputsOutputsList.items[0].vaultless, true);
       assert.equal(result.totalCount, 2);
 
       result = extractWasmEncodedData(await raindexClient.getOrders([1]));


### PR DESCRIPTION
## Summary
- Surface derived `vaultless` and `isVaultless` on `RaindexVault` when `vaultId == 0`.
- Make the flag available to JS/WASM consumers on order/vault read models without changing stored schemas.
- Keep existing zero-vault filtering for normal withdrawable/depositable vault flows intact.

## Validation
- `cargo test -p raindex_common raindex_client::orders`
- `cargo check -p raindex_common`
- `npm run build && npm test -- test/js_api/raindexClient.test.ts` in `packages/raindex`
- Final stack: `rainix-rs-static`
- Final stack: wasm target cargo test for `raindex_quote`, `raindex_bindings`, `raindex_js_api`, `raindex_common`
- Final stack: `npm run build && npm test` in `packages/raindex`

## Review
- Staged local review completed with no actionable findings.

Refs RAI-1063.