### PR TITLE
Fix NPM release workflow

### DIFF
--- a/.github/workflows/npm-package-release.yml
+++ b/.github/workflows/npm-package-release.yml
@@ -189,8 +189,10 @@ jobs:
           # the initial release instead of bumping it.
           if npm view @rainlanguage/raindex@latest version &>/dev/null; then
             npm version prerelease --preid alpha --no-git-tag-version  -w @rainlanguage/raindex
+            echo "FIRST_PUBLISH=false" >> $GITHUB_ENV
           else
             echo "@rainlanguage/raindex not yet on npm; publishing committed version as initial release"
+            echo "FIRST_PUBLISH=true" >> $GITHUB_ENV
           fi
           RAINDEX_NEW_VERSION=$(jq -r '.version' ./packages/raindex/package.json)
           echo "RAINDEX_NEW_VERSION=$RAINDEX_NEW_VERSION" >> $GITHUB_ENV

--- a/.github/workflows/npm-package-release.yml
+++ b/.github/workflows/npm-package-release.yml
@@ -211,9 +211,19 @@ jobs:
       - name: Rename raindex NPM Package Tarball
         if: ${{ env.OLD_HASH != env.NEW_HASH }}
         run: mv ${{ env.RAINDEX_NPM_PACKAGE }} raindex_npm_package_${{ env.RAINDEX_NEW_VERSION }}.tgz
+      # first publish raindex pkg to npm (uses NPM_TOKEN)
+      - name: First Publish raindex pkg To NPM
+        if: ${{ env.OLD_HASH != env.NEW_HASH && env.FIRST_PUBLISH == 'true' }}
+        run: |
+          npm publish raindex_npm_package_${{ env.RAINDEX_NEW_VERSION }}.tgz \
+            --access public \
+            --tag latest \
+            --verbose
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       # publish raindex pkg to npm
       - name: Publish raindex pkg To NPM
-        if: ${{ env.OLD_HASH != env.NEW_HASH }}
+        if: ${{ env.OLD_HASH != env.NEW_HASH && && env.FIRST_PUBLISH == 'false'}}
         run: |
           npm publish raindex_npm_package_${{ env.RAINDEX_NEW_VERSION }}.tgz \
             --access public \
@@ -226,9 +236,19 @@ jobs:
       - name: Rename ui-components NPM Package Tarball
         if: ${{ env.OLD_HASH != env.NEW_HASH }}
         run: mv ${{ env.UC_NPM_PACKAGE }} ui_components_npm_package_${{ env.UC_NEW_VERSION }}.tgz
+      # first publish ui-components to npm (uses NPM_TOKEN)
+      - name: First Publish ui-components To NPM
+        if: ${{ env.OLD_HASH != env.NEW_HASH && && env.FIRST_PUBLISH == 'true'}}
+        run: |
+          npm publish ui_components_npm_package_${{ env.UC_NEW_VERSION }}.tgz \
+            --access public \
+            --tag latest \
+            --verbose
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       # publish ui-components to npm
       - name: Publish ui-components To NPM
-        if: ${{ env.OLD_HASH != env.NEW_HASH }}
+        if: ${{ env.OLD_HASH != env.NEW_HASH && && env.FIRST_PUBLISH == 'false'}}
         run: |
           npm publish ui_components_npm_package_${{ env.UC_NEW_VERSION }}.tgz \
             --access public \

--- a/.github/workflows/npm-package-release.yml
+++ b/.github/workflows/npm-package-release.yml
@@ -238,19 +238,9 @@ jobs:
       - name: Rename ui-components NPM Package Tarball
         if: ${{ env.OLD_HASH != env.NEW_HASH }}
         run: mv ${{ env.UC_NPM_PACKAGE }} ui_components_npm_package_${{ env.UC_NEW_VERSION }}.tgz
-      # first publish ui-components to npm (uses NPM_TOKEN)
-      - name: First Publish ui-components To NPM
-        if: ${{ env.OLD_HASH != env.NEW_HASH && && env.FIRST_PUBLISH == 'true'}}
-        run: |
-          npm publish ui_components_npm_package_${{ env.UC_NEW_VERSION }}.tgz \
-            --access public \
-            --tag latest \
-            --verbose
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       # publish ui-components to npm
       - name: Publish ui-components To NPM
-        if: ${{ env.OLD_HASH != env.NEW_HASH && && env.FIRST_PUBLISH == 'false'}}
+        if: ${{ env.OLD_HASH != env.NEW_HASH }}
         run: |
           npm publish ui_components_npm_package_${{ env.UC_NEW_VERSION }}.tgz \
             --access public \


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation
Fixes the NPM Release workflow
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Using OIDC for releasing npm pkgs requires for the pkg to already exist on npm registry, raindex doesn't (since recently renamed form orderbook to raindex). First ever publish need to be with old `NPM_TOKEN`, after that OIDC can be used for publishing.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [ ] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed conditional syntax error in npm release automation workflow

* **Chores**
  * Enhanced package release workflow with automatic detection of first-time publishes
  * Improved release process by separating publish steps based on deployment context for more reliable releases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->