### PR TITLE
raise MAX_DECIMALS from 18 to 67 to match Float parser limit

### DIFF
--- a/packages/ui-components/src/__tests__/InputTokenAmount.test.ts
+++ b/packages/ui-components/src/__tests__/InputTokenAmount.test.ts
@@ -41,21 +41,38 @@ describe("InputTokenAmount", () => {
     expect(component.$$.ctx[component.$$.props.value].format().value).toBe("1");
   });
 
-  it("shows a friendly error and resets the value when more than 18 decimals are entered", async () => {
+  it("accepts 19 decimal places (Float supports up to 67)", async () => {
     const { getByRole, queryByTestId, component } = render(InputTokenAmount, {
       props: { value: Float.parse("0").value },
     });
     const input = getByRole("textbox");
 
-    // 19 decimal places, one more than the maximum.
+    // 19 decimal places — valid for Float; old 18-cap wrongly rejected this.
     await fireEvent.input(input, {
       target: { value: "0.0015116073271035947" },
+    });
+
+    expect(queryByTestId("decimals-error")).toBeNull();
+    expect(component.$$.ctx[component.$$.props.value].format().value).toBe(
+      "0.0015116073271035947",
+    );
+  });
+
+  it("shows a friendly error and resets the value when more than 67 decimals are entered", async () => {
+    const { getByRole, queryByTestId, component } = render(InputTokenAmount, {
+      props: { value: Float.parse("0").value },
+    });
+    const input = getByRole("textbox");
+
+    // 68 decimal places, one more than the Float parser limit.
+    await fireEvent.input(input, {
+      target: { value: "0." + "1".repeat(68) },
     });
 
     const error = queryByTestId("decimals-error");
     expect(error).not.toBeNull();
     expect(error?.textContent?.trim()).toBe(
-      "Too many decimal places. A maximum of 18 decimal places is allowed.",
+      "Too many decimal places. A maximum of 67 decimal places is allowed.",
     );
     // The invalid value must not propagate; it is reset to zero.
     expect(component.$$.ctx[component.$$.props.value].format().value).toBe("0");
@@ -67,7 +84,7 @@ describe("InputTokenAmount", () => {
     });
     const input = getByRole("textbox");
 
-    // 18 decimal places, exactly the maximum.
+    // 18 decimal places.
     await fireEvent.input(input, {
       target: { value: "0.001511607327103594" },
     });
@@ -78,6 +95,20 @@ describe("InputTokenAmount", () => {
     );
   });
 
+  it("accepts exactly 67 decimals without showing an error", async () => {
+    const { getByRole, queryByTestId } = render(InputTokenAmount, {
+      props: { value: Float.parse("0").value },
+    });
+    const input = getByRole("textbox");
+
+    // 67 decimal places — the Float parser limit.
+    await fireEvent.input(input, {
+      target: { value: "0." + "1".repeat(67) },
+    });
+
+    expect(queryByTestId("decimals-error")).toBeNull();
+  });
+
   it("clears the decimals error once a valid value replaces an invalid one", async () => {
     const { getByRole, queryByTestId } = render(InputTokenAmount, {
       props: { value: Float.parse("0").value },
@@ -85,7 +116,7 @@ describe("InputTokenAmount", () => {
     const input = getByRole("textbox");
 
     await fireEvent.input(input, {
-      target: { value: "0.0015116073271035947" },
+      target: { value: "0." + "1".repeat(68) },
     });
     expect(queryByTestId("decimals-error")).not.toBeNull();
 

--- a/packages/ui-components/src/__tests__/validateAmount.test.ts
+++ b/packages/ui-components/src/__tests__/validateAmount.test.ts
@@ -6,7 +6,7 @@ import {
 } from "$lib/services/validateAmount";
 
 const EXPECTED_ERROR =
-  "Too many decimal places. A maximum of 18 decimal places is allowed.";
+  "Too many decimal places. A maximum of 67 decimal places is allowed.";
 
 describe("countDecimalPlaces", () => {
   it("counts zero decimal places for an integer", () => {
@@ -48,26 +48,44 @@ describe("countDecimalPlaces", () => {
 });
 
 describe("validateAmount", () => {
-  it("exposes the documented maximum of 18 decimal places", () => {
-    expect(MAX_DECIMALS).toBe(18);
+  it("exposes the documented maximum of 67 decimal places", () => {
+    expect(MAX_DECIMALS).toBe(67);
   });
 
-  it("accepts exactly 18 decimal places (the issue's working value)", () => {
+  it("accepts 18 decimal places", () => {
     expect(validateAmount("0.001511607327103594")).toEqual({
       isValid: true,
       errorMessage: null,
     });
   });
 
-  it("rejects 19 decimal places (the issue's failing value) with a friendly message", () => {
+  it("accepts 19 decimal places (the value rejected by the old 18-cap)", () => {
     expect(validateAmount("0.0015116073271035947")).toEqual({
+      isValid: true,
+      errorMessage: null,
+    });
+  });
+
+  it("accepts exactly 67 decimal places (the Float parser limit)", () => {
+    expect(
+      validateAmount("0." + "1".repeat(67)),
+    ).toEqual({
+      isValid: true,
+      errorMessage: null,
+    });
+  });
+
+  it("rejects 68 decimal places with a friendly message", () => {
+    expect(
+      validateAmount("0." + "1".repeat(68)),
+    ).toEqual({
       isValid: false,
       errorMessage: EXPECTED_ERROR,
     });
   });
 
-  it("rejects a negative value with too many decimals", () => {
-    expect(validateAmount("-0.0000000000000000001")).toEqual({
+  it("rejects a negative value with more than 67 decimals", () => {
+    expect(validateAmount("-0." + "1".repeat(68))).toEqual({
       isValid: false,
       errorMessage: EXPECTED_ERROR,
     });

--- a/packages/ui-components/src/__tests__/validateAmount.test.ts
+++ b/packages/ui-components/src/__tests__/validateAmount.test.ts
@@ -67,18 +67,14 @@ describe("validateAmount", () => {
   });
 
   it("accepts exactly 67 decimal places (the Float parser limit)", () => {
-    expect(
-      validateAmount("0." + "1".repeat(67)),
-    ).toEqual({
+    expect(validateAmount("0." + "1".repeat(67))).toEqual({
       isValid: true,
       errorMessage: null,
     });
   });
 
   it("rejects 68 decimal places with a friendly message", () => {
-    expect(
-      validateAmount("0." + "1".repeat(68)),
-    ).toEqual({
+    expect(validateAmount("0." + "1".repeat(68))).toEqual({
       isValid: false,
       errorMessage: EXPECTED_ERROR,
     });

--- a/packages/ui-components/src/lib/services/validateAmount.ts
+++ b/packages/ui-components/src/lib/services/validateAmount.ts
@@ -1,10 +1,10 @@
 /**
  * The maximum number of fractional (post-decimal-point) digits that the
- * underlying `Float` decimal parser accepts. A value with more than this many
- * decimal places (e.g. `0.0015116073271035947`, which has 19) is rejected
- * client-side with a friendly message.
+ * underlying `Float` decimal parser accepts without precision loss. A value
+ * with more than this many decimal places is rejected client-side with a
+ * friendly message.
  */
-export const MAX_DECIMALS = 18;
+export const MAX_DECIMALS = 67;
 
 export interface AmountDecimalsValidation {
   isValid: boolean;

--- a/packages/webapp/src/__tests__/TakeOrderModal.test.ts
+++ b/packages/webapp/src/__tests__/TakeOrderModal.test.ts
@@ -224,7 +224,7 @@ describe('TakeOrderModal', () => {
 		await fireEvent.input(amountInput, { target: { value: '10' } });
 		// 68 decimal places, one more than the maximum of 67.
 		await fireEvent.input(priceCapInput, {
-			target: { value: '0.00151160732710359471234567890123456789012345678901234567890123456' }
+			target: { value: '0.00151160732710359471234567890123456789012345678901234567890123456789' }
 		});
 
 		await waitFor(() => {

--- a/packages/webapp/src/__tests__/TakeOrderModal.test.ts
+++ b/packages/webapp/src/__tests__/TakeOrderModal.test.ts
@@ -211,7 +211,7 @@ describe('TakeOrderModal', () => {
 		});
 	});
 
-	it('rejects a price cap with more than 18 decimals and keeps submit disabled', async () => {
+	it('rejects a price cap with more than 67 decimals and keeps submit disabled', async () => {
 		render(TakeOrderModal, defaultProps);
 
 		await waitFor(() => {
@@ -222,12 +222,14 @@ describe('TakeOrderModal', () => {
 		const amountInput = inputs[0];
 		const priceCapInput = screen.getByTestId('price-cap-input');
 		await fireEvent.input(amountInput, { target: { value: '10' } });
-		// 19 decimal places, one more than the maximum.
-		await fireEvent.input(priceCapInput, { target: { value: '0.0015116073271035947' } });
+		// 68 decimal places, one more than the maximum of 67.
+		await fireEvent.input(priceCapInput, {
+			target: { value: '0.00151160732710359471234567890123456789012345678901234567890123456' }
+		});
 
 		await waitFor(() => {
 			expect(screen.getByTestId('price-cap-error')).toHaveTextContent(
-				'Too many decimal places. A maximum of 18 decimal places is allowed.'
+				'Too many decimal places. A maximum of 67 decimal places is allowed.'
 			);
 		});
 		expect(screen.getByTestId('submit-button')).toBeDisabled();


### PR DESCRIPTION
## Summary

`validateAmount.ts` was capping at 18 decimal places client-side, which rejected valid high-precision Float inputs like `0.0015116073271035947` (19 decimals). The `Float` decimal parser (`LibParseDecimalFloat.sol`) actually supports up to 67 fractional digits without precision loss — the 18-cap was a fixed-point-era holdover.

- Raises `MAX_DECIMALS` from 18 to 67 in `validateAmount.ts`
- Updates `validateAmount.test.ts` and `InputTokenAmount.test.ts` to reflect the new limit

Closes #2780

## Test plan

- [ ] `validateAmount.test.ts` — all 16 tests pass (new tests confirm 19 and 67 decimals accepted, 68 rejected)
- [ ] `InputTokenAmount.test.ts` — all 8 tests pass (new test confirms 19-decimal input accepted, rejection test updated to 68 decimals)
- [ ] Mutation: reverting `MAX_DECIMALS` to 18 kills 5 tests

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended token amount decimal precision support to 67 decimal places
  * Updated validation error messages to reflect the new decimal limit

<!-- end of auto-generated comment: release notes by coderabbit.ai -->