### PR TITLE
Improve local DB sync startup

### DIFF
--- a/crates/common/src/local_db/executor.rs
+++ b/crates/common/src/local_db/executor.rs
@@ -258,11 +258,19 @@ impl LocalDbQueryExecutor for RusqliteExecutor {
 
     async fn wipe_and_recreate(&self) -> Result<(), LocalDbQueryError> {
         let db_path = self.db_path.clone();
+        let pool = Arc::clone(&self.pool);
         spawn_blocking(move || {
-            if db_path.exists() {
-                std::fs::remove_file(&db_path).map_err(|e| {
-                    LocalDbQueryError::database(format!("Failed to delete database file: {e}"))
-                })?;
+            pool.lock().unwrap_or_else(|e| e.into_inner()).clear();
+
+            for path in sqlite_file_paths(&db_path) {
+                if path.exists() {
+                    std::fs::remove_file(&path).map_err(|e| {
+                        LocalDbQueryError::database(format!(
+                            "Failed to delete database file {}: {e}",
+                            path.display()
+                        ))
+                    })?;
+                }
             }
             let conn = open_connection(&db_path)?;
             drop(conn);
@@ -271,6 +279,17 @@ impl LocalDbQueryExecutor for RusqliteExecutor {
         .await
         .map_err(join_err)?
     }
+}
+
+fn sqlite_file_paths(db_path: &Path) -> Vec<PathBuf> {
+    ["", "-wal", "-shm"]
+        .into_iter()
+        .map(|suffix| {
+            let mut path = db_path.as_os_str().to_os_string();
+            path.push(suffix);
+            PathBuf::from(path)
+        })
+        .collect()
 }
 
 #[cfg(test)]

--- a/crates/common/src/local_db/pipeline/mod.rs
+++ b/crates/common/src/local_db/pipeline/mod.rs
@@ -82,6 +82,9 @@ pub struct SyncOutcome {
 #[cfg_attr(target_family = "wasm", derive(Tsify))]
 #[serde(rename_all = "snake_case")]
 pub enum SyncPhase {
+    PreparingLocalDatabase,
+    FetchingSyncManifest,
+    DownloadingInitialDump,
     FetchingLatestBlock,
     RunningBootstrap,
     ComputingSyncWindow,
@@ -101,6 +104,9 @@ impl_wasm_traits!(SyncPhase);
 impl SyncPhase {
     pub fn to_message(&self) -> &'static str {
         match self {
+            Self::PreparingLocalDatabase => "Preparing local database",
+            Self::FetchingSyncManifest => "Fetching sync manifest",
+            Self::DownloadingInitialDump => "Downloading initial dump",
             Self::FetchingLatestBlock => "Fetching latest block",
             Self::RunningBootstrap => "Running bootstrap",
             Self::ComputingSyncWindow => "Computing sync window",

--- a/crates/common/src/local_db/pipeline/runner/utils.rs
+++ b/crates/common/src/local_db/pipeline/runner/utils.rs
@@ -343,7 +343,13 @@ raindexes:
         );
         assert_eq!(target_a.inputs.cfg.deployment_block, 111);
         assert_eq!(target_a.inputs.cfg.fetch.chunk_size(), 10);
+        assert_eq!(target_a.inputs.cfg.fetch.max_concurrent_requests(), 5);
+        assert_eq!(target_a.inputs.cfg.fetch.max_concurrent_blocks(), 5);
+        assert_eq!(target_a.inputs.cfg.fetch.max_retry_attempts(), 3);
+        assert_eq!(target_a.inputs.cfg.fetch.retry_delay_ms(), 100);
+        assert_eq!(target_a.inputs.cfg.fetch.rate_limit_delay_ms(), 50);
         assert_eq!(target_a.inputs.cfg.finality.depth, 12);
+        assert_eq!(target_a.inputs.block_number_threshold, 10000);
         assert!(target_a.inputs.cfg.window_overrides.start_block.is_none());
         assert_eq!(
             target_a.inputs.metadata_rpcs,

--- a/crates/common/src/raindex_client/local_db/pipeline/runner/mod.rs
+++ b/crates/common/src/raindex_client/local_db/pipeline/runner/mod.rs
@@ -19,9 +19,12 @@ use crate::local_db::{
             },
             RunOutcome, RunReport, TargetFailure, TargetSuccess,
         },
-        EventsPipeline, StatusBus, TokensPipeline, WindowPipeline,
+        EventsPipeline, StatusBus, SyncPhase, TokensPipeline, WindowPipeline,
     },
-    query::LocalDbQueryExecutor,
+    query::{
+        fetch_target_watermark::{fetch_target_watermark_stmt, TargetWatermarkRow},
+        LocalDbQueryExecutor,
+    },
     LocalDbError, RaindexIdentifier,
 };
 use crate::raindex_client::local_db::pipeline::bootstrap::ClientBootstrapAdapter;
@@ -110,9 +113,32 @@ where
         self.chain_id
     }
 
+    pub fn raindex_ids(&self) -> Vec<RaindexIdentifier> {
+        self.base_targets
+            .iter()
+            .map(|target| target.inputs.raindex_id.clone())
+            .collect()
+    }
+
+    pub fn needs_initial_provisioning(&self) -> bool {
+        !self.manifests_loaded || !self.has_provisioned_dumps
+    }
+
     pub async fn run<DB>(&mut self, db: &DB) -> Result<RunOutcome, LocalDbError>
     where
         DB: LocalDbQueryExecutor + ?Sized,
+    {
+        self.run_with_phase_callback(db, |_| {}).await
+    }
+
+    pub async fn run_with_phase_callback<DB, F>(
+        &mut self,
+        db: &DB,
+        on_phase: F,
+    ) -> Result<RunOutcome, LocalDbError>
+    where
+        DB: LocalDbQueryExecutor + ?Sized,
+        F: Fn(SyncPhase),
     {
         if self.leadership_guard.is_none() {
             match self.leadership.acquire().await? {
@@ -122,6 +148,7 @@ where
         }
 
         if !self.manifests_loaded {
+            on_phase(SyncPhase::FetchingSyncManifest);
             self.manifest_map = match self
                 .environment
                 .fetch_manifests(&self.settings.raindexes)
@@ -161,7 +188,8 @@ where
         let needs_provisioning = !self.has_provisioned_dumps;
 
         if needs_provisioning {
-            let (provisioned, mut provisioning_failures) = self.provision_dumps(targets).await;
+            let (provisioned, mut provisioning_failures) =
+                self.provision_dumps(db, targets, &on_phase).await;
             let had_provisioning_failures = !provisioning_failures.is_empty();
             targets = provisioned;
 
@@ -186,21 +214,45 @@ where
         Ok(RunOutcome::Report(report))
     }
 
-    async fn provision_dumps(
+    async fn provision_dumps<DB, F>(
         &self,
+        db: &DB,
         targets: Vec<RunnerTarget>,
-    ) -> (Vec<RunnerTarget>, Vec<TargetFailure>) {
+        on_phase: &F,
+    ) -> (Vec<RunnerTarget>, Vec<TargetFailure>)
+    where
+        DB: LocalDbQueryExecutor + ?Sized,
+        F: Fn(SyncPhase),
+    {
         let manifest_map = &self.manifest_map;
         let environment = self.environment.clone();
         let futures = targets.into_iter().map(move |mut target| {
             let environment = environment.clone();
             async move {
                 if let Some(entry) = lookup_manifest_entry(manifest_map, &target) {
+                    let should_download_dump =
+                        match self.should_download_dump(db, &target, &entry).await {
+                            Ok(should_download_dump) => should_download_dump,
+                            Err(error) => {
+                                return Err(TargetFailure {
+                                    raindex_id: target.inputs.raindex_id.clone(),
+                                    raindex_key: Some(target.raindex_key.clone()),
+                                    stage: TargetStage::DumpDownload,
+                                    error,
+                                })
+                            }
+                        };
+                    target.inputs.manifest_end_block = entry.end_block;
+
+                    if !should_download_dump {
+                        return Ok(target);
+                    }
+
+                    on_phase(SyncPhase::DownloadingInitialDump);
                     let dump_sql = environment.download_dump(&entry.dump_url).await;
                     return match dump_sql {
                         Ok(sql) => {
                             target.inputs.dump_str = Some(sql);
-                            target.inputs.manifest_end_block = entry.end_block;
                             Ok(target)
                         }
                         Err(error) => Err(TargetFailure {
@@ -226,6 +278,25 @@ where
         }
 
         (provisioned, failures)
+    }
+
+    async fn should_download_dump<DB>(
+        &self,
+        db: &DB,
+        target: &RunnerTarget,
+        entry: &raindex_app_settings::local_db_manifest::ManifestRaindex,
+    ) -> Result<bool, LocalDbError>
+    where
+        DB: LocalDbQueryExecutor + ?Sized,
+    {
+        let rows: Vec<TargetWatermarkRow> = db
+            .query_json(&fetch_target_watermark_stmt(&target.inputs.raindex_id))
+            .await?;
+
+        Ok(rows.first().is_none_or(|row| {
+            entry.end_block.saturating_sub(row.last_block)
+                > u64::from(target.inputs.block_number_threshold)
+        }))
     }
 
     async fn execute_targets<DB>(
@@ -1127,6 +1198,16 @@ raindexes:
         }
     }
 
+    fn target_watermark_row(target: &RunnerTarget, last_block: u64) -> TargetWatermarkRow {
+        TargetWatermarkRow {
+            chain_id: target.inputs.raindex_id.chain_id,
+            raindex_address: target.inputs.raindex_id.raindex_address,
+            last_block,
+            last_hash: Bytes::copy_from_slice(B256::ZERO.as_slice()),
+            updated_at: 1,
+        }
+    }
+
     fn engine_builder_for_behaviors(
         telemetry: Telemetry,
         behaviors: HashMap<String, EngineBehavior>,
@@ -1460,6 +1541,44 @@ raindexes:
             .expect("record for raindex-b");
         assert!(record_b.dump_sql.is_none());
         assert_eq!(record_b.latest_block, 0);
+    }
+
+    #[tokio::test]
+    async fn fresh_runner_skips_dump_when_existing_watermark_is_within_threshold() {
+        let telemetry = Telemetry::default();
+        let environment =
+            build_environment(manifest_for_a(), HashMap::new(), 1, 0, telemetry.clone());
+        let settings = single_raindex_settings_yaml();
+        let mut runner =
+            ClientRunner::with_environment(settings, environment, AlwaysLeadership).unwrap();
+
+        let db = RecordingDb::default();
+        prepare_db_baseline(&db);
+        let target = runner.base_targets[0].clone();
+        db.set_json_value(
+            &fetch_target_watermark_stmt(&target.inputs.raindex_id),
+            [target_watermark_row(&target, 100)],
+        );
+        db.set_json_raw(
+            &fetch_store_addresses_stmt(&target.inputs.raindex_id),
+            json!([]),
+        );
+
+        let outcome = runner.run(&db).await.expect("run succeeds");
+        let report = unwrap_report(outcome);
+
+        assert_eq!(report.successes.len(), 1);
+        assert!(report.failures.is_empty());
+        assert!(runner.has_provisioned_dumps);
+        assert_eq!(telemetry.manifest_fetch_count(), 1);
+        assert!(
+            telemetry.dump_requests().is_empty(),
+            "existing local DB inside threshold must not re-download bootstrap dump"
+        );
+        let records = telemetry.bootstrap_records();
+        assert_eq!(records.len(), 1);
+        assert!(records[0].dump_sql.is_none());
+        assert_eq!(records[0].latest_block, 111);
     }
 
     #[tokio::test]

--- a/crates/common/src/raindex_client/local_db/pipeline/runner/scheduler/wasm.rs
+++ b/crates/common/src/raindex_client/local_db/pipeline/runner/scheduler/wasm.rs
@@ -9,7 +9,9 @@ use crate::local_db::pipeline::adapters::{
 };
 use crate::local_db::pipeline::runner::utils::ParsedRunnerSettings;
 use crate::local_db::pipeline::runner::RunOutcome;
+use crate::local_db::pipeline::SyncPhase;
 use crate::local_db::LocalDbError;
+use crate::local_db::RaindexIdentifier;
 use crate::raindex_client::local_db::pipeline::bootstrap::ClientBootstrapAdapter;
 use crate::raindex_client::local_db::pipeline::status::{
     set_scheduler_state, set_status_callback, ClientStatusBus,
@@ -23,7 +25,7 @@ use js_sys::Function;
 use raindex_app_settings::local_db_manifest::DB_SCHEMA_VERSION;
 use raindex_app_settings::network::NetworkCfg;
 use std::cell::Cell;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::future::Future;
 use std::pin::Pin;
 use std::rc::Rc;
@@ -44,21 +46,32 @@ trait SchedulerRunner {
     fn run_once<'a>(
         &'a mut self,
         db_executor: &'a LocalDb,
+        on_phase: Rc<dyn Fn(SyncPhase) + 'a>,
     ) -> Pin<Box<dyn Future<Output = Result<RunOutcome, LocalDbError>> + 'a>>;
 
     fn chain_id(&self) -> Option<u32>;
+
+    fn raindex_ids(&self) -> Vec<RaindexIdentifier>;
 }
 
 impl SchedulerRunner for DefaultClientRunner {
     fn run_once<'a>(
         &'a mut self,
         db_executor: &'a LocalDb,
+        on_phase: Rc<dyn Fn(SyncPhase) + 'a>,
     ) -> Pin<Box<dyn Future<Output = Result<RunOutcome, LocalDbError>> + 'a>> {
-        Box::pin(async move { self.run(db_executor).await })
+        Box::pin(async move {
+            self.run_with_phase_callback(db_executor, |phase| on_phase(phase))
+                .await
+        })
     }
 
     fn chain_id(&self) -> Option<u32> {
         self.chain_id()
+    }
+
+    fn raindex_ids(&self) -> Vec<RaindexIdentifier> {
+        self.raindex_ids()
     }
 }
 
@@ -88,6 +101,7 @@ pub(crate) fn start(
     status_callback: Option<Function>,
     sync_readiness: SyncReadiness,
     status_store: LocalDbSyncStatusStore,
+    schema_initialized: bool,
 ) -> Result<SchedulerHandle, LocalDbError> {
     let mut networks_map: HashMap<String, NetworkCfg> = HashMap::new();
     for raindex_cfg in settings.raindexes.values() {
@@ -119,21 +133,24 @@ pub(crate) fn start(
             return;
         }
 
-        if let Err(err) = bootstrap
-            .runner_run(&db_clone, Some(DB_SCHEMA_VERSION))
-            .await
-        {
-            for network in &networks_for_spawn {
-                emit_network_status(
-                    &status_store,
-                    callback.as_deref(),
-                    NetworkSyncStatus::failure(network.chain_id, err.to_readable_msg()),
-                );
-            }
-            return;
-        }
-
         set_status_callback(callback.clone());
+        emit_initial_sync_statuses(&settings_clone, &status_store, callback.as_deref());
+
+        if !schema_initialized {
+            if let Err(err) = bootstrap
+                .runner_run(&db_clone, Some(DB_SCHEMA_VERSION))
+                .await
+            {
+                for network in &networks_for_spawn {
+                    emit_network_status(
+                        &status_store,
+                        callback.as_deref(),
+                        NetworkSyncStatus::failure(network.chain_id, err.to_readable_msg()),
+                    );
+                }
+                return;
+            }
+        }
 
         for network in &networks_for_spawn {
             let config =
@@ -237,12 +254,20 @@ async fn run_network_loop<R>(
     R: SchedulerRunner + 'static,
 {
     let chain_id = runner.chain_id().unwrap_or(0);
+    let raindex_ids = runner.raindex_ids();
     let mut was_leader_last_cycle = false;
 
     emit_network_status(
         &status_store,
         callback.as_deref(),
         NetworkSyncStatus::syncing(chain_id),
+    );
+
+    emit_raindex_sync_statuses(
+        &status_store,
+        callback.as_deref(),
+        &raindex_ids,
+        SyncPhase::PreparingLocalDatabase,
     );
 
     loop {
@@ -258,7 +283,19 @@ async fn run_network_loop<R>(
             );
         }
 
-        match runner.run_once(&db).await {
+        let phase_status_store = status_store.clone();
+        let phase_callback = callback.clone();
+        let phase_raindex_ids = raindex_ids.clone();
+        let on_phase = Rc::new(move |phase| {
+            emit_raindex_sync_statuses(
+                &phase_status_store,
+                phase_callback.as_deref(),
+                &phase_raindex_ids,
+                phase,
+            );
+        });
+
+        match runner.run_once(&db, on_phase).await {
             Ok(outcome) => match outcome {
                 RunOutcome::Report(report) => {
                     was_leader_last_cycle = true;
@@ -267,6 +304,12 @@ async fn run_network_loop<R>(
                     if report.failures.is_empty() {
                         sync_readiness.mark_ready(chain_id);
                         status_store.record_chain_ready(chain_id);
+                        emit_raindex_active_statuses(
+                            &status_store,
+                            callback.as_deref(),
+                            &raindex_ids,
+                            SchedulerState::Leader,
+                        );
                         emit_network_status(
                             &status_store,
                             callback.as_deref(),
@@ -280,10 +323,11 @@ async fn run_network_loop<R>(
                             first.stage,
                             first.error.to_readable_msg()
                         );
-                        status_store.record_raindex_status(RaindexSyncStatus::failure(
-                            first.raindex_id.clone(),
-                            msg.clone(),
-                        ));
+                        emit_raindex_status(
+                            &status_store,
+                            callback.as_deref(),
+                            RaindexSyncStatus::failure(first.raindex_id.clone(), msg.clone()),
+                        );
                         emit_network_status(
                             &status_store,
                             callback.as_deref(),
@@ -296,6 +340,12 @@ async fn run_network_loop<R>(
                     set_scheduler_state(SchedulerState::NotLeader);
                     sync_readiness.mark_ready(chain_id);
                     status_store.record_chain_ready(chain_id);
+                    emit_raindex_active_statuses(
+                        &status_store,
+                        callback.as_deref(),
+                        &raindex_ids,
+                        SchedulerState::NotLeader,
+                    );
                     emit_network_status(
                         &status_store,
                         callback.as_deref(),
@@ -318,6 +368,74 @@ async fn run_network_loop<R>(
         }
 
         TimeoutFuture::new(interval_ms).await;
+    }
+}
+
+fn emit_initial_sync_statuses(
+    settings: &ParsedRunnerSettings,
+    status_store: &LocalDbSyncStatusStore,
+    callback: Option<&Function>,
+) {
+    let mut emitted_networks = HashSet::new();
+    for raindex in settings.raindexes.values() {
+        let chain_id = raindex.network.chain_id;
+        if !settings.syncs.contains_key(&raindex.network.key) {
+            continue;
+        }
+        if emitted_networks.insert(chain_id) {
+            emit_network_status(status_store, callback, NetworkSyncStatus::syncing(chain_id));
+        }
+        emit_raindex_status(
+            status_store,
+            callback,
+            RaindexSyncStatus::syncing(
+                RaindexIdentifier::new(chain_id, raindex.address),
+                SyncPhase::PreparingLocalDatabase,
+            ),
+        );
+    }
+}
+
+fn emit_raindex_sync_statuses(
+    status_store: &LocalDbSyncStatusStore,
+    callback: Option<&Function>,
+    raindex_ids: &[RaindexIdentifier],
+    phase: SyncPhase,
+) {
+    for raindex_id in raindex_ids {
+        emit_raindex_status(
+            status_store,
+            callback,
+            RaindexSyncStatus::syncing(raindex_id.clone(), phase),
+        );
+    }
+}
+
+fn emit_raindex_active_statuses(
+    status_store: &LocalDbSyncStatusStore,
+    callback: Option<&Function>,
+    raindex_ids: &[RaindexIdentifier],
+    scheduler_state: SchedulerState,
+) {
+    for raindex_id in raindex_ids {
+        emit_raindex_status(
+            status_store,
+            callback,
+            RaindexSyncStatus::active(raindex_id.clone(), scheduler_state),
+        );
+    }
+}
+
+fn emit_raindex_status(
+    status_store: &LocalDbSyncStatusStore,
+    callback: Option<&Function>,
+    status: RaindexSyncStatus,
+) {
+    status_store.record_raindex_status(status.clone());
+    if let Some(callback) = callback {
+        if let Ok(value) = serde_wasm_bindgen::to_value(&status) {
+            let _ = callback.call1(&JsValue::NULL, &value);
+        }
     }
 }
 
@@ -392,6 +510,7 @@ mod wasm_tests {
         fn run_once<'a>(
             &'a mut self,
             _db_executor: &'a LocalDb,
+            _on_phase: Rc<dyn Fn(SyncPhase) + 'a>,
         ) -> Pin<Box<dyn Future<Output = Result<RunOutcome, LocalDbError>> + 'a>> {
             let calls = Rc::clone(&self.calls);
             let failures = Rc::clone(&self.failures);
@@ -428,6 +547,10 @@ mod wasm_tests {
 
         fn chain_id(&self) -> Option<u32> {
             Some(self.chain_id)
+        }
+
+        fn raindex_ids(&self) -> Vec<RaindexIdentifier> {
+            Vec::new()
         }
     }
 
@@ -704,6 +827,7 @@ mod wasm_tests {
         fn run_once<'a>(
             &'a mut self,
             _db_executor: &'a LocalDb,
+            _on_phase: Rc<dyn Fn(SyncPhase) + 'a>,
         ) -> Pin<Box<dyn Future<Output = Result<RunOutcome, LocalDbError>> + 'a>> {
             let calls = Rc::clone(&self.calls);
             let delay_ms = self.delay_ms;
@@ -723,6 +847,10 @@ mod wasm_tests {
         fn chain_id(&self) -> Option<u32> {
             Some(self.chain_id)
         }
+
+        fn raindex_ids(&self) -> Vec<RaindexIdentifier> {
+            Vec::new()
+        }
     }
 
     #[wasm_bindgen_test]
@@ -737,6 +865,7 @@ mod wasm_tests {
             None,
             SyncReadiness::new(),
             LocalDbSyncStatusStore::new(),
+            false,
         )
         .expect("should start with valid yaml");
 

--- a/crates/common/src/raindex_client/local_db/pipeline/status/mod.rs
+++ b/crates/common/src/raindex_client/local_db/pipeline/status/mod.rs
@@ -22,6 +22,18 @@ mod tests {
     #[test]
     fn sync_phase_to_message_returns_correct_strings() {
         assert_eq!(
+            SyncPhase::PreparingLocalDatabase.to_message(),
+            "Preparing local database"
+        );
+        assert_eq!(
+            SyncPhase::FetchingSyncManifest.to_message(),
+            "Fetching sync manifest"
+        );
+        assert_eq!(
+            SyncPhase::DownloadingInitialDump.to_message(),
+            "Downloading initial dump"
+        );
+        assert_eq!(
             SyncPhase::FetchingLatestBlock.to_message(),
             "Fetching latest block"
         );

--- a/crates/common/src/raindex_client/mod.rs
+++ b/crates/common/src/raindex_client/mod.rs
@@ -1,3 +1,8 @@
+#[cfg(target_family = "wasm")]
+use crate::local_db::{
+    pipeline::adapters::bootstrap::BootstrapPipeline,
+    query::fetch_target_watermark::{fetch_target_watermark_stmt, TargetWatermarkRow},
+};
 use crate::local_db::{
     query::{
         fetch_last_synced_block::{fetch_last_synced_block_stmt, SyncStatusResponse},
@@ -36,6 +41,8 @@ use raindex_subgraph_client::{
     RaindexSubgraphClientError,
 };
 use serde::{Deserialize, Serialize};
+#[cfg(target_family = "wasm")]
+use std::collections::HashMap;
 #[cfg(not(target_family = "wasm"))]
 use std::sync::Arc;
 #[cfg(target_family = "wasm")]
@@ -183,20 +190,32 @@ impl RaindexClient {
             None
         };
 
-        let scheduler = if has_syncs {
-            let db = local_db
-                .clone()
-                .expect("local_db should be set when has_syncs");
-            let settings =
+        let settings = if has_syncs {
+            Some(
                 crate::local_db::pipeline::runner::utils::parse_runner_settings_from_yaml(
                     &raindex_yaml,
-                )?;
+                )?,
+            )
+        } else {
+            None
+        };
+
+        if let (Some(db), Some(settings)) = (local_db.as_ref(), settings.as_ref()) {
+            initialize_local_db_readiness(db, settings, &sync_readiness, &sync_status_store)
+                .await?;
+        }
+
+        let scheduler = if has_syncs {
+            let (db, settings) = local_db.clone().zip(settings.clone()).ok_or_else(|| {
+                RaindexError::LocalDbSetupMissing("local_db settings".to_string())
+            })?;
             let handle = crate::raindex_client::local_db::pipeline::runner::scheduler::start(
                 settings,
                 db,
                 status_callback,
                 sync_readiness.clone(),
                 sync_status_store.clone(),
+                true,
             )?;
             Rc::new(RefCell::new(Some(handle)))
         } else {
@@ -552,6 +571,63 @@ impl From<serde_wasm_bindgen::Error> for RaindexError {
     fn from(err: serde_wasm_bindgen::Error) -> Self {
         RaindexError::SerdeError(err.into())
     }
+}
+
+#[cfg(target_family = "wasm")]
+async fn initialize_local_db_readiness(
+    db: &LocalDb,
+    settings: &crate::local_db::pipeline::runner::utils::ParsedRunnerSettings,
+    sync_readiness: &SyncReadiness,
+    sync_status_store: &LocalDbSyncStatusStore,
+) -> Result<(), RaindexError> {
+    crate::raindex_client::local_db::pipeline::bootstrap::ClientBootstrapAdapter::new()
+        .runner_run(
+            db,
+            Some(raindex_app_settings::local_db_manifest::DB_SCHEMA_VERSION),
+        )
+        .await?;
+
+    sync_status_store.seed(settings);
+
+    let mut chain_raindexes = settings
+        .raindexes
+        .values()
+        .filter(|raindex| settings.syncs.contains_key(&raindex.network.key))
+        .fold(
+            HashMap::<u32, Vec<crate::local_db::RaindexIdentifier>>::new(),
+            |mut chain_raindexes, raindex| {
+                chain_raindexes
+                    .entry(raindex.network.chain_id)
+                    .or_default()
+                    .push(crate::local_db::RaindexIdentifier::new(
+                        raindex.network.chain_id,
+                        raindex.address,
+                    ));
+                chain_raindexes
+            },
+        );
+
+    for (chain_id, raindex_ids) in chain_raindexes.drain() {
+        let mut chain_ready = true;
+
+        for raindex_id in raindex_ids {
+            let rows: Vec<TargetWatermarkRow> = db
+                .query_json(&fetch_target_watermark_stmt(&raindex_id))
+                .await?;
+
+            if rows.is_empty() {
+                chain_ready = false;
+                break;
+            }
+        }
+
+        if chain_ready {
+            sync_readiness.mark_ready(chain_id);
+            sync_status_store.record_chain_ready(chain_id);
+        }
+    }
+
+    Ok(())
 }
 
 impl RaindexError {

--- a/crates/common/src/raindex_client/orders.rs
+++ b/crates/common/src/raindex_client/orders.rs
@@ -1205,43 +1205,20 @@ impl RaindexClient {
                 );
             }
 
-            let dotrain_started_at = Timing::now();
-            let orders = fetch_orders_dotrain_sources(all_orders)
-                .instrument(info_span!("orders.fetching_dotrain_sources"))
-                .await
-                .map_err(|err| {
-                    error!(
-                        local_rows,
-                        subgraph_rows,
-                        duration_ms = dotrain_started_at.elapsed_ms(),
-                        error = %err,
-                        "failed fetching order dotrain sources"
-                    );
-                    err
-                })?;
-            info!(
-                local_rows,
-                subgraph_rows,
-                returned_order_count = orders.len(),
-                total_count,
-                duration_ms = dotrain_started_at.elapsed_ms(),
-                "fetched order dotrain sources"
-            );
-
             info!(
                 query_source,
                 local_chain_ids_count,
                 subgraph_chain_ids_count,
                 local_rows,
                 subgraph_rows,
-                returned_order_count = orders.len(),
+                returned_order_count = all_orders.len(),
                 total_count,
                 duration_ms = started_at.elapsed_ms(),
                 "completed get_orders"
             );
 
             Ok(RaindexOrdersListResult {
-                orders,
+                orders: all_orders,
                 total_count,
             })
         }
@@ -2973,6 +2950,7 @@ mod tests {
             assert_eq!(result.orders().len(), 2);
             assert_eq!(result.total_count(), 2);
             assert!(logs_contain("completed get_orders"));
+            assert!(!logs_contain("fetched order dotrain sources"));
 
             let expected_order1 = RaindexOrder::try_from_sg_order(
                 Arc::new(raindex_client.clone()),
@@ -3037,6 +3015,7 @@ mod tests {
 
             assert_eq!(order1.raindex(), expected_order1.raindex());
             assert_eq!(order1.timestamp_added(), expected_order1.timestamp_added());
+            assert!(order1.dotrain_source().is_none());
 
             let order2 = result.orders()[1].clone();
             assert_eq!(order2.chain_id, 137);

--- a/packages/webapp/src/lib/constants.ts
+++ b/packages/webapp/src/lib/constants.ts
@@ -1,2 +1,2 @@
 export const REGISTRY_URL =
-  "https://raw.githubusercontent.com/rainlanguage/rain.strategies/85c5d10a507f9759b936ae6327e06c2d759cee55/registry";
+  "https://raw.githubusercontent.com/rainlanguage/rain.strategies/2f170669a23407411d2ea403a0d0a397bf880980/registry";

--- a/packages/webapp/vite.config.ts
+++ b/packages/webapp/vite.config.ts
@@ -15,6 +15,9 @@ export default defineConfig(({ mode }) => ({
 	build: {
 		target: 'es2023'
 	},
+	ssr: {
+		noExternal: ['@tanstack/svelte-query', 'lodash', 'svelte-codemirror-editor']
+	},
 	optimizeDeps: {
 		exclude: ['@rainlanguage/sqlite-web']
 	},


### PR DESCRIPTION
## Dependent PR

- https://github.com/rainlanguage/rain.strategies/pull/120

## Summary
- Seed local DB readiness during `RaindexClient` initialization when every configured raindex already has a target watermark, so warm refreshes can query the browser DB immediately.
- Return order list results without fetching dotrain sources; detail lookups still hydrate the source when the detail page needs it.
- Emit earlier and more precise per-raindex sync statuses for preparing the DB, fetching the manifest, downloading an initial dump, active state, and failures.
- Skip initial dump downloads when an existing target watermark is within the YAML-configured bootstrap threshold. Sync tuning remains sourced from YAML; there are no hardcoded Base limits in the SDK.
- Make local DB wipe/recreate close pooled SQLite connections and remove WAL/SHM sidecars before recreating the file.
- Pin the webapp default registry to the new `rain.strategies` registry commit and keep the Vite dev SSR dependency fix for Svelte packages.

## Validation
- `cargo fmt --all --check`
- `cargo check -p raindex_common`
- `cargo check -p raindex_common --target wasm32-unknown-unknown`
- `cargo test -p raindex_common test_get_orders`
- `cargo test -p raindex_common test_get_order_by_hash`
- `cargo test -p raindex_common` (1117 passed)
- `nix develop .#wasm-shell -c rainix-rs-static`
- `nix develop .#wasm-shell -c npm run build -w @rainlanguage/raindex`
- `nix develop .#wasm-shell -c npm run build -w @rainlanguage/ui-components`
- `nix develop .#wasm-shell -c npm run build -w @rainlanguage/webapp`

## Review
- Manual review caught and removed duplicate WASM scheduler bootstrapping after readiness initialization.
- Full `raindex_common` testing exposed a pooled SQLite connection bug in `wipe_and_recreate`; the fix is included here.
- The order list path now has a regression assertion that it does not run dotrain source hydration; `get_order_by_hash` remains covered for the detail path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced sync progress tracking with new preparation and manifest phases for local database initialization.
  * Improved local database provisioning logic with better watermark checks.

* **Bug Fixes**
  * Simplified order retrieval by removing unnecessary enrichment steps.

* **Chores**
  * Updated registry URL reference.
  * Optimized server-side rendering bundling configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->